### PR TITLE
Implement Audric Harness Correctness Spec v1.4 (engine + sdk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ marketing/
 audric-raise-strategy.canvas.tsx
 audric-litepaper.html
 AUDRIC_LITEPAPER.md
+AUDRIC_HARNESS_CORRECTNESS_SPEC_v1.3.md
 
 # MCP registry tokens
 .mcpregistry_*

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -922,14 +922,21 @@ Three-layer validation prevents impossible transactions:
 Write tools with `permissionLevel: 'confirm'` yield a `pending_action` event:
 
 ```
-Engine yields pending_action(toolName, toolUseId, input, description, assistantContent)
-    → Client displays confirmation UI
+Engine yields pending_action(toolName, toolUseId, input, description,
+                             assistantContent, turnIndex, modifiableFields?)
+    → Client displays confirmation UI (PermissionCard)
+    → User may edit any field declared in `modifiableFields`
     → Client executes the transaction on-chain
-    → Client calls POST /api/engine/resume with the execution result
-    → Engine reconstructs the full turn and continues the conversation
+    → Client calls POST /api/engine/resume with the execution result and any
+      `modifications` overlay
+    → Engine reconstructs the full turn from the post-modification input
+    → Server updates `TurnMetrics(sessionId, turnIndex)` with the resolved
+      `pendingActionOutcome` ('approved' | 'declined' | 'modified')
 ```
 
 This stateless flow is serverless-friendly — no long-lived SSE connections needed for write operations.
+
+`turnIndex` (engine 0.41.0) is derived from the assistant message count when the action is yielded, giving hosts a stable join key from `pending_action` events back to the originating `TurnMetrics` row written at turn close. `modifiableFields` is the engine-side declaration of which `input` keys the user is allowed to edit before approval — sourced from the `TOOL_MODIFIABLE_FIELDS` registry — and the resume route applies the resulting `modifications` to `action.input` so the conversation history reflects what was actually approved on-chain.
 
 ### MCP Integration
 

--- a/PRODUCT_FACTS.md
+++ b/PRODUCT_FACTS.md
@@ -30,8 +30,8 @@ See `audric-roadmap.md` for the full taxonomy + naming rules and `CLAUDE.md` for
 
 | Package | Version |
 |---------|---------|
-| `@t2000/sdk` | `0.40.4` |
-| `@t2000/engine` | `0.40.4` |
+| `@t2000/sdk` | `0.40.5` |
+| `@t2000/engine` | `0.41.0` |
 | `@t2000/cli` | `0.40.4` |
 | `@suimpp/mpp` | `0.3.1` |
 | `@t2000/mcp` | `0.40.4` |
@@ -650,7 +650,7 @@ MPP uses peer-to-peer verification via mppx; no facilitator URL or verify/settle
 | Fact | Value |
 |------|-------|
 | Package | `@t2000/engine` |
-| Version | `0.40.2` |
+| Version | `0.41.0` |
 | Description | Agent engine for conversational finance — implements Audric Intelligence (the moat) |
 | Entry point | `@t2000/engine` (ESM only) |
 | Build | tsup → ESM bundle |
@@ -745,7 +745,9 @@ Extended thinking is **always on** for Sonnet/Opus (adaptive mode). `ENABLE_THIN
 
 ### Engine Event Types
 
-`text_delta`, `thinking_delta`, `thinking_done`, `tool_start`, `tool_result`, `pending_action`, `canvas`, `turn_complete`, `usage`, `error`
+`text_delta`, `thinking_delta`, `thinking_done`, `tool_start`, `tool_result`, `pending_action`, `canvas`, `compaction`, `turn_complete`, `usage`, `error`
+
+> v0.41.0 additions: `compaction` event (emitted after the context budget triggers a compaction so hosts can record `TurnMetrics.compactionFired`), plus per-event flags `tool_result.wasEarlyDispatched` and `tool_result.resultDeduped` so hosts can attribute zero-cost tool results back to the early dispatcher / microcompact.
 
 ### Engine Permission Levels
 
@@ -754,6 +756,15 @@ Extended thinking is **always on** for Sonnet/Opus (adaptive mode). `ENABLE_THIN
 | `auto` | Executes without user approval |
 | `confirm` | Yields `pending_action`, client executes and resumes via `resumeWithToolResult` |
 | `explicit` | Manual-only — not dispatched by LLM |
+
+### Pending Action (engine 0.41.0)
+
+`pending_action` events now stamp two extra fields on the action payload so hosts can wire the modification protocol and per-turn analytics:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `turnIndex` | `number` | Index of the originating assistant turn (derived from `messages.filter(m => m.role === 'assistant').length`). Hosts use this to update the matching `TurnMetrics` row when the user resolves the action. |
+| `modifiableFields` | `PendingActionModifiableField[]` | Editable input fields registered for the tool (e.g. `{ name: 'amount', kind: 'amount', asset: 'USDC' }`). Sourced from `TOOL_MODIFIABLE_FIELDS` in `packages/engine/src/tools/tool-modifiable-fields.ts`. Empty / absent for non-write tools. |
 
 ---
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -88,7 +88,7 @@ const THREE_PRODUCTS = [
   {
     tag: "Consumer",
     name: "Audric",
-    desc: "The consumer app. Conversational finance. Passport, Intelligence, Finance, and Pay on Sui. Store coming soon.",
+    desc: "The consumer app. Banking by conversation. Five products: Audric Passport (sign in with Google, non-custodial wallet), Audric Intelligence (40-tool agent harness, the moat), Audric Finance (save, credit, swap, charts via NAVI + Cetus), Audric Pay (send USDC, payment links, invoices, QR). Audric Store coming soon.",
     cta: { label: "Try Audric", href: AUDRIC_URL, primary: true },
   },
   {

--- a/packages/engine/src/__tests__/aci-constraints.test.ts
+++ b/packages/engine/src/__tests__/aci-constraints.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { defillamaYieldPoolsTool } from '../tools/defillama.js';
+import { transactionHistoryTool } from '../tools/history.js';
+import { mppServicesTool } from '../tools/mpp-services.js';
+
+const baseCtx = {
+  walletAddress: '0xtest',
+  suiRpcUrl: 'https://stub',
+} as Parameters<typeof defillamaYieldPoolsTool.call>[1];
+
+describe('[v1.4 ACI] defillama_yield_pools — refinement when no chain/project', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            { pool: 'a', chain: 'Sui', project: 'navi', symbol: 'USDC', tvlUsd: 5e6, apy: 8 },
+            { pool: 'b', chain: 'Sui', project: 'cetus', symbol: 'SUI/USDC', tvlUsd: 2e6, apy: 12 },
+            { pool: 'c', chain: 'Ethereum', project: 'aave', symbol: 'USDC', tvlUsd: 1e8, apy: 5 },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as typeof fetch;
+  });
+
+  it('returns _refine + chain summary when called with no filters', async () => {
+    const res = await defillamaYieldPoolsTool.call({}, baseCtx);
+    const data = res.data as {
+      _refine: { reason: string; availableChains: { chain: string }[] };
+    };
+    expect(data._refine).toBeDefined();
+    expect(data._refine.reason).toMatch(/chain/i);
+    expect(data._refine.availableChains.map((c) => c.chain)).toContain('Sui');
+  });
+
+  it('returns actual pools when chain is supplied', async () => {
+    const res = await defillamaYieldPoolsTool.call({ chain: 'Sui', minTvl: 0 }, baseCtx);
+    expect(Array.isArray(res.data)).toBe(true);
+    const arr = res.data as Array<{ chain: string }>;
+    expect(arr.length).toBeGreaterThan(0);
+    for (const p of arr) expect(p.chain).toBe('Sui');
+  });
+});
+
+describe('[v1.4 ACI] transaction_history — action filter + 30-day default', () => {
+  beforeEach(() => {
+    const now = Date.now();
+    const recent = (offsetDays: number, action: string) => ({
+      digest: `0x${action}${offsetDays}`,
+      timestampMs: String(now - offsetDays * 86_400_000),
+      effects: { gasUsed: { computationCost: '0', storageCost: '0', storageRebate: '0' } },
+      transaction: {
+        data: {
+          transaction: {
+            commands:
+              action === 'send'
+                ? [{ TransferObjects: {} }]
+                : [{ MoveCall: { package: 'p', module: 'navi', function: 'borrow' } }],
+          },
+        },
+      },
+      balanceChanges: [],
+    });
+
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          result: {
+            data: [
+              recent(1, 'send'),
+              recent(5, 'send'),
+              recent(10, 'lending'),
+              recent(45, 'send'),    // outside 30-day window
+            ],
+            nextCursor: null,
+            hasNextPage: false,
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as typeof fetch;
+  });
+
+  it('drops transactions older than 30 days when no date is supplied', async () => {
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: Array<{ digest: string }>; lookbackDays: number };
+    expect(data.lookbackDays).toBe(30);
+    expect(data.transactions.find((t) => t.digest.endsWith('45'))).toBeUndefined();
+  });
+
+  it('filters by action when supplied', async () => {
+    const res = await transactionHistoryTool.call({ limit: 10, action: 'lending' }, baseCtx);
+    const data = res.data as { transactions: Array<{ action: string }>; action: string };
+    expect(data.action).toBe('lending');
+    for (const t of data.transactions) expect(t.action).toBe('lending');
+  });
+});
+
+describe('[v1.4 ACI] mpp_services — category summary + filter', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify([
+          {
+            id: 'wx', name: 'Weather', serviceUrl: 'x', description: '', categories: ['weather'],
+            endpoints: [{ method: 'GET', path: '/now', description: '', price: '0.01' }],
+          },
+          {
+            id: 'tr', name: 'Translate', serviceUrl: 'x', description: '', categories: ['language'],
+            endpoints: [{ method: 'POST', path: '/translate', description: '', price: '0.02' }],
+          },
+          {
+            id: 'wx2', name: 'Weather Pro', serviceUrl: 'x', description: '', categories: ['weather'],
+            endpoints: [{ method: 'GET', path: '/forecast', description: '', price: '0.03' }],
+          },
+        ]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    ) as typeof fetch;
+  });
+
+  it('returns category summary when no filters supplied', async () => {
+    const res = await mppServicesTool.call({}, baseCtx);
+    const data = res.data as {
+      _refine: { reason: string };
+      categories: { category: string; services: number }[];
+      totalServices: number;
+    };
+    expect(data._refine).toBeDefined();
+    const weather = data.categories.find((c) => c.category === 'weather');
+    expect(weather?.services).toBe(2);
+    expect(data.totalServices).toBe(3);
+  });
+
+  it('filters by category when supplied', async () => {
+    const res = await mppServicesTool.call({ category: 'weather' }, baseCtx);
+    const data = res.data as { services: { id: string }[]; total: number };
+    expect(data.total).toBe(2);
+    expect(data.services.map((s) => s.id).sort()).toEqual(['wx', 'wx2']);
+  });
+});

--- a/packages/engine/src/__tests__/permission-rules-spend.test.ts
+++ b/packages/engine/src/__tests__/permission-rules-spend.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolvePermissionTier,
+  DEFAULT_PERMISSION_CONFIG,
+} from '../permission-rules.js';
+
+/**
+ * [v1.4] Day 2 — sessionSpendUsd parameter on resolvePermissionTier.
+ *
+ * The default config has autonomousDailyLimit=200 and a `save` rule with
+ * autoBelow=50, so a $40 save is normally `auto`. When session spend is
+ * close to the daily limit, the resolver downgrades `auto` to `confirm`.
+ */
+describe('resolvePermissionTier — sessionSpendUsd cumulative cap', () => {
+  it('returns auto when sessionSpendUsd is undefined (current behavior preserved)', () => {
+    expect(resolvePermissionTier('save', 40, DEFAULT_PERMISSION_CONFIG)).toBe('auto');
+    expect(resolvePermissionTier('save', 40, DEFAULT_PERMISSION_CONFIG, undefined)).toBe('auto');
+  });
+
+  it('returns auto when cumulative spend stays under the daily limit', () => {
+    // 100 + 40 = 140, well under 200 daily limit
+    expect(resolvePermissionTier('save', 40, DEFAULT_PERMISSION_CONFIG, 100)).toBe('auto');
+  });
+
+  it('downgrades auto to confirm when cumulative spend would breach the daily limit', () => {
+    // 180 already spent + 40 incoming = 220 > 200 daily limit → must confirm
+    expect(resolvePermissionTier('save', 40, DEFAULT_PERMISSION_CONFIG, 180)).toBe('confirm');
+  });
+
+  it('does not weaken tiers — confirm/explicit pass through unchanged regardless of spend', () => {
+    // 100 USD save is in the confirm tier (50–1000); spend should not move it.
+    expect(resolvePermissionTier('save', 100, DEFAULT_PERMISSION_CONFIG, 0)).toBe('confirm');
+    expect(resolvePermissionTier('save', 100, DEFAULT_PERMISSION_CONFIG, 1000)).toBe('confirm');
+    // 1500 USD save is explicit; spend never elevates that to auto.
+    expect(resolvePermissionTier('save', 1500, DEFAULT_PERMISSION_CONFIG, 0)).toBe('explicit');
+    expect(resolvePermissionTier('save', 1500, DEFAULT_PERMISSION_CONFIG, 5000)).toBe('explicit');
+  });
+
+  it('treats spend exactly equal to the daily limit as still autonomous', () => {
+    // sessionSpend (160) + amount (40) = 200, equal to limit, NOT greater → still auto
+    expect(resolvePermissionTier('save', 40, DEFAULT_PERMISSION_CONFIG, 160)).toBe('auto');
+  });
+});

--- a/packages/engine/src/__tests__/streaming.test.ts
+++ b/packages/engine/src/__tests__/streaming.test.ts
@@ -21,6 +21,7 @@ describe('serializeSSE', () => {
         input: { to: '0xabc', amount: 50 },
         description: 'Send $50 to 0xabc',
         assistantContent: [{ type: 'tool_use', id: 'tc-1', name: 'send_transfer', input: { to: '0xabc', amount: 50 } }],
+        turnIndex: 0,
       },
     });
     expect(sse).toContain('event: pending_action');
@@ -85,6 +86,7 @@ describe('engineToSSE', () => {
           input: { to: '0x1', amount: 10 },
           description: 'Send $10',
           assistantContent: [{ type: 'tool_use', id: 'tc-1', name: 'send_transfer', input: { to: '0x1', amount: 10 } }],
+          turnIndex: 0,
         },
       };
     }

--- a/packages/engine/src/compact/microcompact.ts
+++ b/packages/engine/src/compact/microcompact.ts
@@ -1,18 +1,37 @@
 import type { Message, ContentBlock } from '../types.js';
 
 /**
+ * [v1.4 Item 4] Side-channel return from `microcompact` so callers can
+ * count or surface dedup hits without re-walking the message ledger.
+ * Backwards-compatible: `microcompact(messages)` still returns the
+ * processed `Message[]` (now enriched), and the dedup set lives on the
+ * returned array via a non-enumerable `dedupedToolUseIds` accessor that
+ * the engine reads in its agent loop.
+ */
+export interface MicrocompactResult extends Array<Message> {
+  /**
+   * Tool-use IDs whose prior results were replaced with a compact
+   * back-reference during this pass. Empty when nothing matched.
+   */
+  dedupedToolUseIds: Set<string>;
+}
+
+/**
  * Zero-cost deduplication pass: if the same tool was called with identical
  * inputs earlier in the conversation and the result hasn't changed, replace
  * the full prior result with a compact back-reference. Runs before any
  * LLM-based compaction and costs nothing.
  *
- * Returns a new array — does not mutate the input.
+ * Returns a new array — does not mutate the input. The returned array
+ * carries a `dedupedToolUseIds` property listing every tool-use ID whose
+ * tool_result block was replaced with a back-reference this pass.
  */
-export function microcompact(messages: readonly Message[]): Message[] {
+export function microcompact(messages: readonly Message[]): MicrocompactResult {
   const seen = new Map<string, { turnIndex: number }>();
   let toolUseIndex = 0;
 
   const toolUseInputs = new Map<string, string>();
+  const dedupedToolUseIds = new Set<string>();
 
   for (const msg of messages) {
     for (const block of msg.content) {
@@ -22,7 +41,7 @@ export function microcompact(messages: readonly Message[]): Message[] {
     }
   }
 
-  return messages.map((msg) => {
+  const out = messages.map((msg) => {
     if (msg.role !== 'user') return { role: msg.role, content: [...msg.content] };
 
     const hasToolResults = msg.content.some((b) => b.type === 'tool_result');
@@ -38,6 +57,7 @@ export function microcompact(messages: readonly Message[]): Message[] {
       const prior = seen.get(key);
 
       if (prior && !block.isError) {
+        dedupedToolUseIds.add(block.toolUseId);
         return {
           ...block,
           content: `[Same result as call #${prior.turnIndex} — ${key.split(':')[0]} with identical inputs. Result unchanged.]`,
@@ -52,6 +72,18 @@ export function microcompact(messages: readonly Message[]): Message[] {
 
     return { role: msg.role, content: newContent };
   });
+
+  // Attach the side-channel without breaking `Message[]` consumers — the
+  // result is structurally compatible with `Message[]`, the extra property
+  // is invisible to anything that only reads array semantics or runs deep
+  // equality against a plain `Message[]` (vitest, JSON.stringify, …).
+  Object.defineProperty(out, 'dedupedToolUseIds', {
+    value: dedupedToolUseIds,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  return out as MicrocompactResult;
 }
 
 function stableStringify(value: unknown): string {

--- a/packages/engine/src/early-dispatcher.ts
+++ b/packages/engine/src/early-dispatcher.ts
@@ -75,6 +75,7 @@ export class EarlyToolDispatcher {
           toolUseId: entry.call.id,
           result: budgeted,
           isError: result.isError,
+          wasEarlyDispatched: true,
         };
       } catch (err) {
         yield {
@@ -83,6 +84,7 @@ export class EarlyToolDispatcher {
           toolUseId: entry.call.id,
           result: { error: err instanceof Error ? err.message : 'Tool execution failed' },
           isError: true,
+          wasEarlyDispatched: true,
         };
       }
     }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -14,6 +14,7 @@ import type {
 import { toolsToDefinitions, findTool } from './tool.js';
 import { TxMutex, runTools, type PendingToolCall } from './orchestration.js';
 import { getDefaultTools } from './tools/index.js';
+import { getModifiableFields } from './tools/tool-modifiable-fields.js';
 import { DEFAULT_SYSTEM_PROMPT } from './prompt.js';
 import { CostTracker, type CostSnapshot } from './cost.js';
 import { estimatePayApiCost } from './tools/pay.js';
@@ -71,6 +72,10 @@ export class QueryEngine {
   private readonly contextSummarizer: EngineConfig['contextSummarizer'];
   private readonly priceCache: Map<string, number> | undefined;
   private readonly permissionConfig: import('./permission-rules.js').UserPermissionConfig | undefined;
+  // [v1.4] Session-scoped autonomous spend tracking.
+  private readonly sessionSpendUsd: number | undefined;
+  private readonly onAutoExecuted: EngineConfig['onAutoExecuted'];
+  private readonly onGuardFired: EngineConfig['onGuardFired'];
   private matchedRecipe: Recipe | null = null;
 
   private messages: Message[] = [];
@@ -102,6 +107,9 @@ export class QueryEngine {
     this.contextSummarizer = config.contextSummarizer;
     this.priceCache = config.priceCache;
     this.permissionConfig = config.permissionConfig;
+    this.sessionSpendUsd = config.sessionSpendUsd;
+    this.onAutoExecuted = config.onAutoExecuted;
+    this.onGuardFired = config.onGuardFired;
 
     this.tools = config.tools ?? (config.agent ? getDefaultTools() : []);
   }
@@ -264,6 +272,7 @@ export class QueryEngine {
       signal,
       priceCache: this.priceCache,
       permissionConfig: this.permissionConfig,
+      sessionSpendUsd: this.sessionSpendUsd,
     };
 
     let turns = 0;
@@ -288,8 +297,23 @@ export class QueryEngine {
       const dispatcher = new EarlyToolDispatcher(this.tools, context);
 
       try {
-        // B.3: Zero-cost dedup of identical tool calls every turn
-        this.messages = microcompact(this.messages);
+        // B.3: Zero-cost dedup of identical tool calls every turn.
+        // [v1.4 Item 4] Emit a synthetic tool_result event for each
+        // deduped prior call so hosts can flip `resultDeduped` on the
+        // matching `TurnMetrics.toolsCalled[]` row. Marker shape is
+        // explicit so collectors don't double-count emissions.
+        const microcompacted = microcompact(this.messages);
+        this.messages = microcompacted;
+        for (const dedupedId of microcompacted.dedupedToolUseIds) {
+          yield {
+            type: 'tool_result',
+            toolName: '__deduped__',
+            toolUseId: dedupedId,
+            result: null,
+            isError: false,
+            resultDeduped: true,
+          };
+        }
 
         // RE-3.3: Compact context if budget is exceeded
         if (this.contextBudget.shouldCompact()) {
@@ -298,6 +322,10 @@ export class QueryEngine {
             keepRecentCount: 8,
             summarizer: this.contextSummarizer,
           });
+          // [v1.4 Item 4] Notify hosts that compaction fired this turn.
+          // `compactMessages` stays a pure function; the event keeps the
+          // signal observable without coupling.
+          yield { type: 'compaction' };
         }
 
         this.messages = validateHistory(this.messages);
@@ -484,7 +512,13 @@ export class QueryEngine {
             const operation = toolNameToOperation(call.name);
             if (operation) {
               const usdValue = resolveUsdValue(call.name, call.input as Record<string, unknown>, context.priceCache);
-              const tier = resolvePermissionTier(operation, usdValue, context.permissionConfig);
+              // [v1.4] sessionSpendUsd consulted to enforce daily cap
+              const tier = resolvePermissionTier(
+                operation,
+                usdValue,
+                context.permissionConfig,
+                context.sessionSpendUsd,
+              );
               return tier !== 'auto';
             }
           }
@@ -511,7 +545,14 @@ export class QueryEngine {
           const tool = findTool(this.tools, call.name);
           if (!tool) { guardedApproved.push(call); continue; }
 
-          const check = runGuards(tool, call, this.guardState, this.guardConfig, convCtx);
+          const check = runGuards(
+            tool,
+            call,
+            this.guardState,
+            this.guardConfig,
+            convCtx,
+            this.onGuardFired,
+          );
           this.guardEvents.push(...check.events);
 
           if (check.blocked) {
@@ -614,6 +655,32 @@ export class QueryEngine {
                 toolUseId: finalEvent.toolUseId,
               };
             }
+
+            // [v1.4] Fire onAutoExecuted for write tools that auto-executed
+            // (non-readonly tools that reach this loop have already passed the
+            // auto-tier check). Wrapped in try/catch so any host error never
+            // propagates back into the engine — the tool result already shipped.
+            if (
+              tool && !tool.isReadOnly && this.onAutoExecuted &&
+              this.permissionConfig && this.priceCache
+            ) {
+              const operation = toolNameToOperation(toolEvent.toolName);
+              if (operation && originalCall) {
+                const usdValue = resolveUsdValue(
+                  toolEvent.toolName,
+                  originalCall.input as Record<string, unknown>,
+                  this.priceCache,
+                );
+                Promise.resolve()
+                  .then(() => this.onAutoExecuted!({
+                    toolName: toolEvent.toolName,
+                    usdValue,
+                  }))
+                  .catch((err) => {
+                    console.warn('[engine] onAutoExecuted callback failed:', err);
+                  });
+              }
+            }
           }
 
           toolResultBlocks.push({
@@ -632,7 +699,12 @@ export class QueryEngine {
       if (pendingWrite && this.guardConfig) {
         const convCtx = extractConversationText(this.messages);
         const check = runGuards(
-          pendingWrite.tool, pendingWrite.call, this.guardState, this.guardConfig, convCtx,
+          pendingWrite.tool,
+          pendingWrite.call,
+          this.guardState,
+          this.guardConfig,
+          convCtx,
+          this.onGuardFired,
         );
         this.guardEvents.push(...check.events);
 
@@ -668,6 +740,13 @@ export class QueryEngine {
         const writeGuardInjections =
           (pendingWrite.call as PendingToolCall & { _guardInjections?: Array<{ _gate: string; _hint?: string; _warning?: string }> })._guardInjections;
 
+        // [v1.4 Item 6] Stamp the action with the registry's modifiable
+        // fields (UI uses this to render editable controls) and a turnIndex
+        // derived from the assistant message count so hosts can update the
+        // matching `TurnMetrics` row when the action resolves.
+        const modifiableFields = getModifiableFields(pendingWrite.call.name);
+        const turnIndex = this.messages.filter((m) => m.role === 'assistant').length;
+
         yield {
           type: 'pending_action',
           action: {
@@ -682,6 +761,8 @@ export class QueryEngine {
               isError: (b as { isError?: boolean }).isError ?? false,
             })),
             ...(writeGuardInjections?.length ? { guardInjections: writeGuardInjections } : {}),
+            ...(modifiableFields?.length ? { modifiableFields } : {}),
+            turnIndex,
           },
         };
         return;

--- a/packages/engine/src/guards.ts
+++ b/packages/engine/src/guards.ts
@@ -41,6 +41,31 @@ export interface GuardEvent {
   message?: string;
 }
 
+/**
+ * [v1.4 Item 4] Per-guard metric emitted via `EngineConfig.onGuardFired`.
+ * Hosts (e.g. audric `TurnMetricsCollector`) accumulate these for the
+ * `TurnMetrics.guardsFired` JSON column. Mirrors `GuardEvent` but with
+ * a coarser tri-state action (allow/warn/block) so the host doesn't
+ * need to know the engine's verdict vocabulary.
+ */
+export interface GuardMetric {
+  name: string;
+  tier: GuardTier;
+  action: 'allow' | 'warn' | 'block';
+  injectionAdded: boolean;
+}
+
+/**
+ * Engine-internal mapping from `GuardVerdict` to `GuardMetric.action`.
+ * `pass` and `hint` collapse to `allow` because hint is non-blocking —
+ * the model just sees a soft note.
+ */
+export function guardVerdictToAction(verdict: GuardVerdict): GuardMetric['action'] {
+  if (verdict === 'pass' || verdict === 'hint') return 'allow';
+  if (verdict === 'warn') return 'warn';
+  return 'block';
+}
+
 // ---------------------------------------------------------------------------
 // Guard configuration
 // ---------------------------------------------------------------------------
@@ -386,9 +411,29 @@ export function runGuards(
   state: GuardRunnerState,
   config: GuardConfig,
   conversationContext: { fullText: string; lastAssistantText: string },
+  /**
+   * [v1.4 Item 4] Optional per-guard observation hook. Fired exactly
+   * once per non-`pass` guard verdict (i.e. for every event that ends
+   * up in `events`/`injections`/`block`). Errors thrown by the host
+   * are caught so a misbehaving collector can't break tool execution.
+   */
+  onGuardFired?: (guard: GuardMetric) => void,
 ): GuardCheckResult {
   const results: GuardResult[] = [];
   const now = Date.now();
+  const fire = (verdict: GuardVerdict, tier: GuardTier, gate: string, hadInjection: boolean) => {
+    if (!onGuardFired) return;
+    try {
+      onGuardFired({
+        name: gate,
+        tier,
+        action: guardVerdictToAction(verdict),
+        injectionAdded: hadInjection,
+      });
+    } catch (err) {
+      console.warn('[guards] onGuardFired threw (ignored):', err);
+    }
+  };
 
   // Tier 0: Input validation (preflight) — runs first, invalid input = immediate block
   if (config.inputValidation !== false && tool.preflight) {
@@ -403,6 +448,7 @@ export function runGuards(
         tier: 'safety',
         message: check.error,
       };
+      fire('block', 'safety', 'input_validation', false);
       return {
         blocked: true,
         blockReason: check.error,
@@ -455,6 +501,13 @@ export function runGuards(
 
   const block = results.find((r) => r.verdict === 'block');
   if (block) {
+    // Fire once for the block winner; non-blocking warnings/hints from
+    // earlier in the chain are surfaced too so the host sees the full
+    // picture per turn.
+    for (const r of results) {
+      if (r.verdict === 'pass') continue;
+      fire(r.verdict, r.tier, r.gate, false);
+    }
     return {
       blocked: true,
       blockReason: block.message ?? `Blocked by ${block.gate}`,
@@ -470,6 +523,11 @@ export function runGuards(
       _gate: r.gate,
       ...(r.verdict === 'hint' ? { _hint: r.message } : { _warning: r.message }),
     }));
+
+  for (const r of results) {
+    if (r.verdict === 'pass') continue;
+    fire(r.verdict, r.tier, r.gate, r.verdict === 'hint' || r.verdict === 'warn');
+  }
 
   return { blocked: false, injections, events };
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -9,6 +9,7 @@ export type {
   EngineConfig,
   StopReason,
   PendingAction,
+  PendingActionModifiableField,
   Tool,
   ToolFlags,
   PreflightResult,
@@ -224,6 +225,7 @@ export {
 
 // All default tools
 export { getDefaultTools } from './tools/index.js';
+export { getModifiableFields, TOOL_MODIFIABLE_FIELDS } from './tools/tool-modifiable-fields.js';
 
 // Tool utilities
 export { requireAgent, hasNaviMcp, getMcpManager, getWalletAddress } from './tools/utils.js';

--- a/packages/engine/src/permission-rules.ts
+++ b/packages/engine/src/permission-rules.ts
@@ -75,18 +75,39 @@ export const PERMISSION_PRESETS = {
   },
 } satisfies Record<string, UserPermissionConfig>;
 
+/**
+ * Resolve the permission tier for a given operation + USD value.
+ *
+ * [v1.4] When `sessionSpendUsd` is supplied and adding the incoming
+ * `amountUsd` would push cumulative session spend over
+ * `config.autonomousDailyLimit`, an otherwise-`auto` tier is downgraded to
+ * `confirm`. This is the runtime guard for the daily autonomous spend cap.
+ * Tiers above `auto` are returned unchanged.
+ */
 export function resolvePermissionTier(
   operation: string,
   amountUsd: number,
   config: UserPermissionConfig,
+  sessionSpendUsd?: number,
 ): 'auto' | 'confirm' | 'explicit' {
   const rule = config.rules.find((r) => r.operation === operation);
   const autoBelow = rule?.autoBelow ?? config.globalAutoBelow;
   const confirmBetween = rule?.confirmBetween ?? 1000;
 
-  if (amountUsd < autoBelow) return 'auto';
-  if (amountUsd < confirmBetween) return 'confirm';
-  return 'explicit';
+  let tier: 'auto' | 'confirm' | 'explicit';
+  if (amountUsd < autoBelow) tier = 'auto';
+  else if (amountUsd < confirmBetween) tier = 'confirm';
+  else tier = 'explicit';
+
+  if (
+    tier === 'auto' &&
+    typeof sessionSpendUsd === 'number' &&
+    sessionSpendUsd + amountUsd > config.autonomousDailyLimit
+  ) {
+    return 'confirm';
+  }
+
+  return tier;
 }
 
 const TOOL_TO_OPERATION: Record<string, PermissionOperation> = {

--- a/packages/engine/src/tools/defillama.ts
+++ b/packages/engine/src/tools/defillama.ts
@@ -20,6 +20,16 @@ async function cachedFetch<T>(url: string): Promise<T> {
   return data as T;
 }
 
+/**
+ * [v1.4] Named, exported helper for fetching the raw DefiLlama yield pool
+ * dataset. Extracted from the inline `cachedFetch` call below so tests
+ * (and other tools) can stub it.
+ */
+export async function fetchDefillamaYieldPools(): Promise<YieldPool[]> {
+  const data = await cachedFetch<{ data: YieldPool[] }>(`${YIELDS_API}/pools`);
+  return data.data ?? [];
+}
+
 // ---------------------------------------------------------------------------
 // 1. defillama_yield_pools
 // ---------------------------------------------------------------------------
@@ -65,9 +75,36 @@ export const defillamaYieldPoolsTool = buildTool({
   isReadOnly: true,
   maxResultSizeChars: 6_000,
 
-  async call(input) {
-    const data = await cachedFetch<{ data: YieldPool[] }>(`${YIELDS_API}/pools`);
-    let pools = data.data ?? [];
+  async call(input): Promise<{ data: Record<string, unknown> | unknown[]; displayText: string }> {
+    // [v1.4 ACI] Refuse cross-chain queries — DefiLlama's pool list is
+    // unbounded across networks, and unfiltered results are wide enough to
+    // bias the LLM. Force the caller to commit to a chain (or pick one of
+    // the suggested popular chains) before pouring data in.
+    if (!input.chain && !input.project) {
+      const all = await fetchDefillamaYieldPools();
+      const chainCounts = new Map<string, number>();
+      for (const p of all) {
+        chainCounts.set(p.chain, (chainCounts.get(p.chain) ?? 0) + 1);
+      }
+      const topChains = [...chainCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([chain, count]) => ({ chain, pools: count }));
+      return {
+        data: {
+          _refine: {
+            reason: 'Cross-chain yield search is too broad; pick a chain.',
+            suggestedParams: { chain: 'Sui' },
+            availableChains: topChains,
+          },
+        },
+        displayText:
+          'Yield query needs a chain filter. Common chains: ' +
+          topChains.map((c) => c.chain).join(', '),
+      };
+    }
+
+    let pools = await fetchDefillamaYieldPools();
 
     if (input.chain) {
       const chain = input.chain.toLowerCase();

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -194,13 +194,23 @@ async function queryHistoryByDate(
   return results.slice(0, limit);
 }
 
+/**
+ * [v1.4 ACI] Allowed values for the `action` filter — kept in sync with
+ * `classifyAction` above (the labels it can return).
+ */
+const HISTORY_ACTIONS = ['send', 'lending', 'swap', 'transaction'] as const;
+type HistoryAction = (typeof HISTORY_ACTIONS)[number];
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+
 export const transactionHistoryTool = buildTool({
   name: 'transaction_history',
   description:
-    'Retrieve transaction history: past sends, saves, withdrawals, borrows, repayments, and rewards claims. Pass a date (YYYY-MM-DD) to find transactions from a specific day, or omit for the most recent.',
+    'Retrieve recent transaction history (last 30 days by default): sends, saves, withdrawals, borrows, repayments, and rewards claims. Pass `date` (YYYY-MM-DD) for a specific day, `action` to filter by category (send/lending/swap), or both.',
   inputSchema: z.object({
     limit: z.number().int().min(1).max(50).optional(),
     date: z.string().optional().describe('Specific date to search for transactions (YYYY-MM-DD format). Paginates back to find that day.'),
+    action: z.enum(HISTORY_ACTIONS).optional().describe('Filter by action: send, lending, swap, or transaction.'),
   }),
   jsonSchema: {
     type: 'object',
@@ -213,20 +223,41 @@ export const transactionHistoryTool = buildTool({
         type: 'string',
         description: 'Specific date to search for transactions (YYYY-MM-DD format). Paginates back to find that day.',
       },
+      action: {
+        type: 'string',
+        enum: [...HISTORY_ACTIONS],
+        description: 'Filter results by action category: send, lending, swap, or transaction.',
+      },
     },
   },
   isReadOnly: true,
   maxResultSizeChars: 8_000,
 
-  async call(input, context) {
+  async call(
+    input,
+    context,
+  ): Promise<{ data: Record<string, unknown>; displayText: string }> {
     const limit = input.limit ?? 10;
+    const action = input.action as HistoryAction | undefined;
+
+    /**
+     * [v1.4] After fetching, narrow by `action` (when supplied), and trim
+     * to a `DEFAULT_LOOKBACK_DAYS` window when no explicit date is given —
+     * keeps results recent and bounded so the LLM doesn't over-summarize.
+     */
+    const finalize = (records: TxRecord[]): TxRecord[] => {
+      let scoped = records;
+      if (action) scoped = scoped.filter((r) => r.action === action);
+      return scoped.slice(0, limit);
+    };
 
     if (context.agent) {
       const agent = requireAgent(context);
-      const records = await agent.history({ limit });
+      const records = await agent.history({ limit: input.date ? limit : Math.max(limit * 4, 50) });
+      const filtered = finalize(records);
       return {
-        data: { transactions: records, count: records.length, date: input.date ?? null },
-        displayText: `${records.length} recent transaction(s)`,
+        data: { transactions: filtered, count: filtered.length, date: input.date ?? null, action: action ?? null },
+        displayText: `${filtered.length} recent transaction(s)`,
       };
     }
 
@@ -235,20 +266,40 @@ export const transactionHistoryTool = buildTool({
     }
 
     if (input.date) {
-      const records = await queryHistoryByDate(context.suiRpcUrl, context.walletAddress, input.date, limit);
+      const records = await queryHistoryByDate(
+        context.suiRpcUrl,
+        context.walletAddress,
+        input.date,
+        Math.max(limit * 4, 50),
+      );
+      const filtered = finalize(records);
       const dateLabel = new Date(input.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
       return {
-        data: { transactions: records, count: records.length, date: input.date },
-        displayText: records.length > 0
-          ? `${records.length} transaction(s) on ${dateLabel}`
+        data: { transactions: filtered, count: filtered.length, date: input.date, action: action ?? null },
+        displayText: filtered.length > 0
+          ? `${filtered.length} transaction(s) on ${dateLabel}`
           : `No transactions found on ${dateLabel}`,
       };
     }
 
-    const records = await queryHistoryRpc(context.suiRpcUrl, context.walletAddress, limit);
+    // No date — last 30 days. Over-fetch then trim by lookback window.
+    const cutoffMs = Date.now() - DEFAULT_LOOKBACK_DAYS * 86_400_000;
+    const records = await queryHistoryRpc(
+      context.suiRpcUrl,
+      context.walletAddress,
+      Math.max(limit * 4, 50),
+    );
+    const recent = records.filter((r) => r.timestamp >= cutoffMs);
+    const filtered = finalize(recent);
     return {
-      data: { transactions: records, count: records.length, date: null },
-      displayText: `${records.length} recent transaction(s)`,
+      data: {
+        transactions: filtered,
+        count: filtered.length,
+        date: null,
+        action: action ?? null,
+        lookbackDays: DEFAULT_LOOKBACK_DAYS,
+      },
+      displayText: `${filtered.length} transaction(s) in the last ${DEFAULT_LOOKBACK_DAYS} days`,
     };
   },
 });

--- a/packages/engine/src/tools/mpp-services.ts
+++ b/packages/engine/src/tools/mpp-services.ts
@@ -48,19 +48,27 @@ function matchesQuery(service: GatewayService, q: string): boolean {
 export const mppServicesTool = buildTool({
   name: 'mpp_services',
   description:
-    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Use this BEFORE calling pay_api to find the correct URL and body format for any real-world API (weather, search, translation, image generation, email, maps, etc.).',
+    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Pass `query` for keyword search or `category` to filter by category. Calling with NO filters returns a category summary (not the full catalog) — narrow first, then fetch endpoints. Use this BEFORE calling pay_api.',
   inputSchema: z.object({
     query: z
       .string()
       .optional()
-      .describe('Filter by keyword (e.g. "postcard", "translate", "weather"). Omit to list all services.'),
+      .describe('Filter by keyword (e.g. "postcard", "translate", "weather").'),
+    category: z
+      .string()
+      .optional()
+      .describe('Filter by category exactly (e.g. "weather", "image"). See category summary returned when called without filters.'),
   }),
   jsonSchema: {
     type: 'object',
     properties: {
       query: {
         type: 'string',
-        description: 'Filter by keyword (e.g. "postcard", "translate", "weather"). Omit to list all.',
+        description: 'Filter by keyword (e.g. "postcard", "translate", "weather").',
+      },
+      category: {
+        type: 'string',
+        description: 'Filter by category exactly (e.g. "weather", "image").',
       },
     },
     required: [],
@@ -68,9 +76,44 @@ export const mppServicesTool = buildTool({
   isReadOnly: true,
   maxResultSizeChars: 5_000,
 
-  async call(input) {
+  async call(input): Promise<{ data: Record<string, unknown>; displayText: string }> {
     const catalog = await fetchCatalog();
-    const filtered = input.query ? catalog.filter((s) => matchesQuery(s, input.query!)) : catalog;
+
+    // [v1.4 ACI] If neither query nor category is supplied, return a
+    // category summary rather than the unbounded full catalog. The model
+    // then re-calls with a filter, which keeps the context window tight
+    // and makes the MPP discovery flow two-step (categorize → drill down).
+    if (!input.query && !input.category) {
+      const counts = new Map<string, number>();
+      for (const svc of catalog) {
+        for (const cat of svc.categories) {
+          counts.set(cat, (counts.get(cat) ?? 0) + 1);
+        }
+      }
+      const categories = [...counts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([category, services]) => ({ category, services }));
+      return {
+        data: {
+          _refine: {
+            reason: 'MPP catalog has many services — pick a category or supply a query first.',
+            suggestedParams: { category: categories[0]?.category ?? 'weather' },
+          },
+          categories,
+          totalServices: catalog.length,
+        },
+        displayText: `${catalog.length} services across ${categories.length} categories. Re-call with a category or query.`,
+      };
+    }
+
+    let filtered = catalog;
+    if (input.category) {
+      const cat = input.category.toLowerCase();
+      filtered = filtered.filter((s) => s.categories.some((c) => c.toLowerCase() === cat));
+    }
+    if (input.query) {
+      filtered = filtered.filter((s) => matchesQuery(s, input.query!));
+    }
 
     const services = filtered.map((s) => ({
       id: s.id,
@@ -85,9 +128,11 @@ export const mppServicesTool = buildTool({
       })),
     }));
 
-    const summary = input.query
-      ? `Found ${services.length} service(s) matching "${input.query}"`
-      : `${services.length} services available on MPP gateway`;
+    const filterDesc = [
+      input.query ? `query "${input.query}"` : null,
+      input.category ? `category "${input.category}"` : null,
+    ].filter(Boolean).join(' + ');
+    const summary = `Found ${services.length} service(s) matching ${filterDesc}`;
 
     return {
       data: { services, total: services.length },

--- a/packages/engine/src/tools/tool-modifiable-fields.ts
+++ b/packages/engine/src/tools/tool-modifiable-fields.ts
@@ -1,0 +1,59 @@
+/**
+ * tool-modifiable-fields.ts — Audric Harness Correctness Spec v1.4 / Item 6
+ *
+ * Per-tool registry of input fields the host UI may let the user modify
+ * before approving a `PendingAction`. The engine consults this registry
+ * when emitting a `pending_action` event so the client can render an
+ * editable control without hard-coding tool names in the UI layer.
+ *
+ * The plan reserves modification for amount-bearing write tools where the
+ * user might want to lower the amount before confirming (e.g. "save $50"
+ * → user edits to $30 → engine resumes with the modified input). Tools
+ * absent from this registry have no modifiable fields and the UI renders
+ * a static "approve / deny" pair.
+ */
+import type { PendingActionModifiableField } from '../types.js';
+
+/**
+ * Tool name → ordered list of modifiable input fields. Order matters for
+ * UI rendering — the first entry typically becomes the prominent control.
+ */
+export const TOOL_MODIFIABLE_FIELDS: Record<string, PendingActionModifiableField[]> = {
+  save_deposit: [
+    { name: 'amount', kind: 'amount', asset: 'USDC' },
+  ],
+  withdraw: [
+    { name: 'amount', kind: 'amount', asset: 'USDC' },
+  ],
+  send_transfer: [
+    // `amount` first so the UI surfaces it prominently; the recipient
+    // address field is also editable in case the user typed the wrong one.
+    { name: 'amount', kind: 'amount' },
+    { name: 'to', kind: 'address' },
+  ],
+  swap_execute: [
+    { name: 'amount', kind: 'amount' },
+  ],
+  borrow: [
+    { name: 'amount', kind: 'amount', asset: 'USDC' },
+  ],
+  repay_debt: [
+    { name: 'amount', kind: 'amount', asset: 'USDC' },
+  ],
+  volo_stake: [
+    { name: 'amount', kind: 'amount', asset: 'SUI' },
+  ],
+  volo_unstake: [
+    { name: 'amount', kind: 'amount', asset: 'vSUI' },
+  ],
+};
+
+/**
+ * Returns the modifiable fields for a tool name, or `undefined` if the tool
+ * has no modifiable inputs. Used by the engine when emitting `pending_action`.
+ */
+export function getModifiableFields(
+  toolName: string,
+): PendingActionModifiableField[] | undefined {
+  return TOOL_MODIFIABLE_FIELDS[toolName];
+}

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -36,6 +36,18 @@ export type EngineEvent =
       toolUseId: string;
       result: unknown;
       isError: boolean;
+      /**
+       * [v1.4 Item 4] True when the tool was executed by `EarlyToolDispatcher`
+       * (read tools dispatched concurrently before the LLM yields). Hosts
+       * record this in `TurnMetrics.toolsCalled[].wasEarlyDispatched`.
+       */
+      wasEarlyDispatched?: boolean;
+      /**
+       * [v1.4 Item 4] True when this result was synthesized from a previous
+       * identical tool call by `microcompact` deduplication, instead of
+       * actually re-running the tool.
+       */
+      resultDeduped?: boolean;
     }
   | {
       type: 'pending_action';
@@ -57,9 +69,36 @@ export type EngineEvent =
       data: unknown;
       title: string;
       toolUseId: string;
-    };
+    }
+  /**
+   * [v1.4 Item 4] Emitted exactly once per agent turn when context-window
+   * compaction fires. Hosts (e.g. audric `TurnMetricsCollector`) flip a
+   * boolean for the `TurnMetrics.compactionTriggered` column. Carries no
+   * payload — `compactMessages` stays a pure function.
+   */
+  | { type: 'compaction' };
 
 export type StopReason = 'end_turn' | 'tool_use' | 'max_tokens' | 'max_turns' | 'error';
+
+/**
+ * [v1.4 Item 6] Describes a single input field on a `PendingAction` that
+ * the host UI may let the user modify before approving. Carried on the
+ * `pending_action` event so clients can render editable controls without
+ * hard-coding per-tool field metadata. See
+ * `packages/engine/src/tools/tool-modifiable-fields.ts` for the registry.
+ */
+export interface PendingActionModifiableField {
+  /** Input key on the `PendingAction.input` object (e.g. "amount", "to"). */
+  name: string;
+  /**
+   * UI hint for which control to render.
+   *  - `amount` — numeric input; UI shows a "~Max" hint when balance is known.
+   *  - `address` — Sui address input with paste/scan affordance.
+   */
+  kind: 'amount' | 'address';
+  /** Optional asset symbol (e.g. "USDC", "SUI", "vSUI") for amount fields. */
+  asset?: string;
+}
 
 /**
  * Serializable description of a write tool that needs user approval.
@@ -76,6 +115,19 @@ export interface PendingAction {
   completedResults?: Array<{ toolUseId: string; content: string; isError: boolean }>;
   /** Guard injections (hints/warnings) from pre-execution checks. */
   guardInjections?: Array<{ _gate: string; _hint?: string; _warning?: string }>;
+  /**
+   * [v1.4 Item 6] Fields the host UI may let the user modify before
+   * approving. Sourced from `tool-modifiable-fields.ts`. Absent (or
+   * empty) means the action is approve-or-deny only.
+   */
+  modifiableFields?: PendingActionModifiableField[];
+  /**
+   * [v1.4 Item 6] Monotonic turn index (assistant message count) at the
+   * point this pending action was emitted. Hosts use it to update the
+   * matching `TurnMetrics` row when the action resolves — see
+   * `apps/web/app/api/engine/resume/route.ts` `updateMany` clause.
+   */
+  turnIndex: number;
 }
 
 /**
@@ -114,6 +166,13 @@ export interface ToolContext {
   priceCache?: Map<string, number>;
   /** Per-user permission config for USD-threshold write tool gating (B.4). */
   permissionConfig?: import('./permission-rules.js').UserPermissionConfig;
+  /**
+   * [v1.4] Cumulative USD already auto-executed in the current session.
+   * Used by `resolvePermissionTier` to enforce `autonomousDailyLimit` —
+   * downgrades `auto` to `confirm` when adding the incoming tool's USD
+   * value would exceed the limit. Optional; omitted = unbounded.
+   */
+  sessionSpendUsd?: number;
 }
 
 export interface ServerPositionData {
@@ -229,6 +288,26 @@ export interface EngineConfig {
   priceCache?: Map<string, number>;
   /** Per-user permission config for USD-threshold write tool gating (B.4). */
   permissionConfig?: import('./permission-rules.js').UserPermissionConfig;
+  /**
+   * [v1.4] Cumulative USD already auto-executed in the current session.
+   * Forwarded to `ToolContext` and consulted by `resolvePermissionTier` to
+   * enforce `autonomousDailyLimit`.
+   */
+  sessionSpendUsd?: number;
+  /**
+   * [v1.4] Fired after a write tool successfully auto-executes (no
+   * confirmation required). Hosts use this to persist cumulative spend in
+   * Redis. Errors are caught — the tool result is never blocked by a failure
+   * here.
+   */
+  onAutoExecuted?: (info: { toolName: string; usdValue: number }) => void | Promise<void>;
+  /**
+   * [v1.4 Item 4] Per-guard observation hook. Forwarded to `runGuards`
+   * and fired once per non-`pass` verdict so hosts can record guard
+   * behaviour in `TurnMetrics.guardsFired` without re-implementing the
+   * verdict→action mapping. Errors thrown by the host are caught.
+   */
+  onGuardFired?: (guard: import('./guards.js').GuardMetric) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,6 +44,8 @@ export {
   SUI_DECIMALS,
   USDC_DECIMALS,
   BPS_DENOMINATOR,
+  SAVE_FEE_BPS,
+  BORROW_FEE_BPS,
   SUPPORTED_ASSETS,
   CLOCK_ID,
   DEFAULT_NETWORK,
@@ -97,6 +99,7 @@ export { getSwapQuote } from './swap-quote.js';
 export {
   findSwapRoute,
   buildSwapTx,
+  OVERLAY_FEE_RATE,
 } from './protocols/cetus-swap.js';
 export type { SwapRouteResult } from './protocols/cetus-swap.js';
 export {

--- a/packages/sdk/src/protocols/cetus-swap.ts
+++ b/packages/sdk/src/protocols/cetus-swap.ts
@@ -14,7 +14,14 @@ export interface SwapRouteResult {
   insufficientLiquidity: boolean;
 }
 
-const OVERLAY_FEE_RATE = 0.001; // 0.1% swap fee
+/**
+ * [v1.4 Item 5] T2000 swap overlay fee — 0.1% taken on top of Cetus's
+ * own fee. Exported so consumers (web app, spec-consistency assertions)
+ * can compare against a single source of truth instead of hard-coding
+ * the value. Changing this rate requires a coordinated SDK + audric
+ * release.
+ */
+export const OVERLAY_FEE_RATE = 0.001;
 const OVERLAY_FEE_RECEIVER = process.env.T2000_TREASURY_ADDRESS
   ?? '0x3bb501b8300125dca59019247941a42af6b292a150ce3cfcce9449456be2ec91';
 


### PR DESCRIPTION
## Summary
Implements the engine + SDK side of the [Audric Harness Correctness Spec v1.4](../audric/blob/harness-correctness-v1.4/) execution plan. Bumps both packages to **0.41.0** when the next release runs (lockstep via `.github/workflows/release.yml`). The matching audric host PR is open separately.

### Engine (`@t2000/engine` 0.40.4 → 0.41.0)
- **Session-spend permission tier (Item 2):** `resolvePermissionTier` now takes `sessionSpendUsd` and downgrades `auto` → `confirm` when cumulative spend would breach `autonomousDailyLimit`.
- **ACI tool refinements (Item 3):** `defillama_yield_pools`, `transaction_history`, `mpp_services` return `_refine` payloads instead of dumping the full result set when invoked without enough filters.
- **TurnMetrics surface (Item 4):** new `compaction` `EngineEvent`, new `tool_result.wasEarlyDispatched` / `tool_result.resultDeduped` flags, new `EngineConfig.onGuardFired`, plus `GuardMetric` / `guardVerdictToAction` helpers in `guards.ts`. `microcompact` now returns `dedupedToolUseIds` (non-enumerable so existing equality checks stay green).
- **Pending-action modification protocol (Item 6):** `PendingAction` gains `turnIndex` and `modifiableFields` (sourced from the new `TOOL_MODIFIABLE_FIELDS` registry covering `save_deposit`, `withdraw`, `send_transfer`, `swap_execute`, `borrow`, `repay_debt`, `volo_stake`, `volo_unstake`).
- **Early dispatcher:** tags its `tool_result` events with `wasEarlyDispatched: true` so hosts can attribute zero-cost results.

### SDK (`@t2000/sdk` 0.40.4 → 0.41.0)
- Exports `OVERLAY_FEE_RATE`, plus re-exports `SAVE_FEE_BPS` and `BORROW_FEE_BPS` so the audric spec-consistency check (Item 5) can assert against canonical values.

### Tests
- New: `permission-rules-spend.test.ts` (5 cases), `aci-constraints.test.ts` (per-tool refinement coverage).
- Updated: `streaming.test.ts` for the new `pending_action.turnIndex`.
- Full suite: 282/282 engine, 350/350 sdk.

### Docs
- `ARCHITECTURE.md`: documents the v1.4 modification protocol end-to-end (`turnIndex` join key, `modifiableFields` overlay, resume-route reconciliation).
- `PRODUCT_FACTS.md`: bumps the version table and lists the new event types / pending-action fields.

### Drive-by
- `apps/web/app/page.tsx`: short marketing tweak (separate commit) that expands the Audric "five products" copy on the t2000 homepage.

## Test plan
- [x] `pnpm --filter @t2000/engine typecheck && pnpm --filter @t2000/engine test` — 282/282
- [x] `pnpm --filter @t2000/sdk typecheck && pnpm --filter @t2000/sdk test` — 350/350
- [ ] Trigger `Release` workflow with `bump: minor` after merge so all packages step to `0.41.0` in lockstep
- [ ] In audric, pin `@t2000/engine@0.41.0` + `@t2000/sdk@0.41.0` once published, then drop the temporary `as unknown` casts catalogued in the audric PR


Made with [Cursor](https://cursor.com)