### PR TITLE
feat(engine): post-write refresh — eliminate post-write balance hallucinations

### DIFF
--- a/PRODUCT_FACTS.md
+++ b/PRODUCT_FACTS.md
@@ -30,8 +30,8 @@ See `audric-roadmap.md` for the full taxonomy + naming rules and `CLAUDE.md` for
 
 | Package | Version |
 |---------|---------|
-| `@t2000/sdk` | `0.40.5` |
-| `@t2000/engine` | `0.41.0` |
+| `@t2000/sdk` | `0.42.0` |
+| `@t2000/engine` | `0.42.0` |
 | `@t2000/cli` | `0.40.4` |
 | `@suimpp/mpp` | `0.3.1` |
 | `@t2000/mcp` | `0.40.4` |

--- a/packages/engine/src/__tests__/post-write-refresh.test.ts
+++ b/packages/engine/src/__tests__/post-write-refresh.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { QueryEngine } from '../engine.js';
+import { buildTool } from '../tool.js';
+import type {
+  LLMProvider,
+  ChatParams,
+  ProviderEvent,
+  EngineEvent,
+  PendingAction,
+  Tool,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Minimal scripted provider — same shape as confirmation.test.ts so each
+// QueryEngine.chat() call returns the next scripted "turn".
+// ---------------------------------------------------------------------------
+
+type ScriptedTurn =
+  | { type: 'text'; text: string }
+  | { type: 'tool_call'; id: string; name: string; input: unknown };
+
+function createMockProvider(turns: ScriptedTurn[][]): LLMProvider {
+  let callIndex = 0;
+  return {
+    async *chat(_params: ChatParams): AsyncGenerator<ProviderEvent> {
+      const turn = turns[callIndex] ?? [];
+      callIndex++;
+      yield { type: 'message_start', messageId: `msg-${callIndex}`, model: 'mock' };
+      yield { type: 'usage', inputTokens: 10, outputTokens: 5 };
+      const hasToolCalls = turn.some((t) => t.type === 'tool_call');
+      for (const item of turn) {
+        if (item.type === 'text') {
+          yield { type: 'text_delta', text: item.text };
+        } else {
+          yield { type: 'tool_use_start', id: item.id, name: item.name };
+          yield { type: 'tool_use_done', id: item.id, name: item.name, input: item.input };
+        }
+      }
+      yield { type: 'stop', reason: hasToolCalls ? 'tool_use' : 'end_turn' };
+    },
+  };
+}
+
+async function collect(gen: AsyncGenerator<EngineEvent>): Promise<EngineEvent[]> {
+  const out: EngineEvent[] = [];
+  for await (const e of gen) out.push(e);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Test tools — call counters let us assert refresh tools fired exactly once
+// each per resume, and never on the deny / failed-write paths.
+// ---------------------------------------------------------------------------
+
+let balanceCalls = 0;
+let savingsCalls = 0;
+let healthCalls = 0;
+
+const balanceTool: Tool = buildTool({
+  name: 'balance_check',
+  description: 'wallet balance',
+  inputSchema: z.object({}),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: true,
+  async call() {
+    balanceCalls++;
+    return { data: { wallet: 112.43, holdings: [{ symbol: 'USDC', balance: 93.37 }] } };
+  },
+});
+
+const savingsTool: Tool = buildTool({
+  name: 'savings_info',
+  description: 'savings positions',
+  inputSchema: z.object({}),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: true,
+  async call() {
+    savingsCalls++;
+    return { data: { totalSavings: 10, savingsRate: 3.96 } };
+  },
+});
+
+const healthTool: Tool = buildTool({
+  name: 'health_check',
+  description: 'borrow health',
+  inputSchema: z.object({}),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: true,
+  async call() {
+    healthCalls++;
+    return { data: { healthFactor: 2.1 } };
+  },
+});
+
+// Save deposit — write tool requiring confirmation.
+const saveDeposit: Tool = buildTool({
+  name: 'save_deposit',
+  description: 'deposit USDC into NAVI',
+  inputSchema: z.object({ amount: z.number() }),
+  jsonSchema: {
+    type: 'object',
+    properties: { amount: { type: 'number' } },
+    required: ['amount'],
+  },
+  isReadOnly: false,
+  permissionLevel: 'confirm',
+  async call(input) {
+    return { data: { success: true, amount: input.amount } };
+  },
+});
+
+// Failing write — used to assert refresh is skipped on { success: false }.
+const failingWrite: Tool = buildTool({
+  name: 'borrow',
+  description: 'borrow against savings',
+  inputSchema: z.object({ amount: z.number() }),
+  jsonSchema: {
+    type: 'object',
+    properties: { amount: { type: 'number' } },
+    required: ['amount'],
+  },
+  isReadOnly: false,
+  permissionLevel: 'confirm',
+  async call(input) {
+    return { data: { success: true, amount: input.amount } };
+  },
+});
+
+describe('Post-write refresh ([v1.5] EngineConfig.postWriteRefresh)', () => {
+  function reset(): void {
+    balanceCalls = 0;
+    savingsCalls = 0;
+    healthCalls = 0;
+  }
+
+  // Helper: drive a write through pending_action → resume.
+  async function runWriteAndResume(opts: {
+    refreshMap?: Record<string, string[]>;
+    write: Tool;
+    writeName: string;
+    writeInput: unknown;
+    approved: boolean;
+    executionResult?: unknown;
+    extraTools?: Tool[];
+  }): Promise<EngineEvent[]> {
+    const provider = createMockProvider([
+      [{ type: 'tool_call', id: 'tc-write', name: opts.writeName, input: opts.writeInput }],
+      [{ type: 'text', text: 'Done.' }],
+    ]);
+    const engine = new QueryEngine({
+      provider,
+      tools: [
+        opts.write,
+        balanceTool,
+        savingsTool,
+        healthTool,
+        ...(opts.extraTools ?? []),
+      ],
+      systemPrompt: 'test',
+      postWriteRefresh: opts.refreshMap,
+    });
+
+    let pa: PendingAction | null = null;
+    for await (const e of engine.submitMessage('go')) {
+      if (e.type === 'pending_action') pa = e.action;
+    }
+    expect(pa).not.toBeNull();
+
+    return collect(
+      engine.resumeWithToolResult(pa!, {
+        approved: opts.approved,
+        executionResult: opts.executionResult,
+      }),
+    );
+  }
+
+  it('runs configured refresh tools after a successful write and flags them', async () => {
+    reset();
+    const events = await runWriteAndResume({
+      refreshMap: { save_deposit: ['balance_check', 'savings_info'] },
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: true,
+      executionResult: { success: true, digest: '0xabc' },
+    });
+
+    expect(balanceCalls).toBe(1);
+    expect(savingsCalls).toBe(1);
+    expect(healthCalls).toBe(0);
+
+    const toolResults = events.filter((e) => e.type === 'tool_result');
+    // 1 for the write itself + 2 for refresh
+    expect(toolResults.length).toBeGreaterThanOrEqual(3);
+    const refreshes = toolResults.filter(
+      (e) => e.type === 'tool_result' && e.wasPostWriteRefresh,
+    );
+    expect(refreshes).toHaveLength(2);
+    const names = refreshes.map((e) => (e.type === 'tool_result' ? e.toolName : ''));
+    expect(names).toEqual(['balance_check', 'savings_info']);
+  });
+
+  it('orders refresh events between the write tool_result and the LLM narration', async () => {
+    reset();
+    const events = await runWriteAndResume({
+      refreshMap: { save_deposit: ['balance_check'] },
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: true,
+      executionResult: { success: true },
+    });
+
+    const eventTypes = events.map((e) =>
+      e.type === 'tool_result'
+        ? `tool_result:${e.toolName}${e.wasPostWriteRefresh ? '*' : ''}`
+        : e.type,
+    );
+    const writeIdx = eventTypes.indexOf('tool_result:save_deposit');
+    const refreshIdx = eventTypes.indexOf('tool_result:balance_check*');
+    const firstTextIdx = eventTypes.indexOf('text_delta');
+
+    expect(writeIdx).toBeGreaterThanOrEqual(0);
+    expect(refreshIdx).toBeGreaterThan(writeIdx);
+    // Refresh must land before the LLM's narration so the model can cite it.
+    expect(firstTextIdx === -1 || firstTextIdx > refreshIdx).toBe(true);
+  });
+
+  it('skips refresh entirely when the write was declined', async () => {
+    reset();
+    await runWriteAndResume({
+      refreshMap: { save_deposit: ['balance_check', 'savings_info'] },
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: false,
+    });
+    expect(balanceCalls).toBe(0);
+    expect(savingsCalls).toBe(0);
+  });
+
+  it('skips refresh when executionResult signals { success: false }', async () => {
+    reset();
+    await runWriteAndResume({
+      refreshMap: { borrow: ['balance_check', 'savings_info', 'health_check'] },
+      write: failingWrite,
+      writeName: 'borrow',
+      writeInput: { amount: 50 },
+      approved: true,
+      executionResult: { success: false, error: 'insufficient collateral' },
+    });
+    expect(balanceCalls).toBe(0);
+    expect(savingsCalls).toBe(0);
+    expect(healthCalls).toBe(0);
+  });
+
+  it('is a no-op when no refresh map is configured (back-compat)', async () => {
+    reset();
+    const events = await runWriteAndResume({
+      refreshMap: undefined,
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: true,
+      executionResult: { success: true },
+    });
+    expect(balanceCalls).toBe(0);
+    const refreshes = events.filter(
+      (e) => e.type === 'tool_result' && e.wasPostWriteRefresh,
+    );
+    expect(refreshes).toHaveLength(0);
+  });
+
+  it('silently ignores unknown / non-readonly refresh tool names', async () => {
+    reset();
+    const events = await runWriteAndResume({
+      refreshMap: {
+        save_deposit: ['balance_check', 'does_not_exist', 'save_deposit'],
+      },
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: true,
+      executionResult: { success: true },
+    });
+    expect(balanceCalls).toBe(1);
+    const refreshes = events.filter(
+      (e) => e.type === 'tool_result' && e.wasPostWriteRefresh,
+    );
+    expect(refreshes).toHaveLength(1);
+  });
+
+  it('still continues to the LLM narration when a refresh tool throws', async () => {
+    reset();
+    const flakyTool: Tool = buildTool({
+      name: 'health_check_flaky',
+      description: 'simulates RPC failure',
+      inputSchema: z.object({}),
+      jsonSchema: { type: 'object', properties: {} },
+      isReadOnly: true,
+      async call() {
+        throw new Error('rpc 503');
+      },
+    });
+    const events = await runWriteAndResume({
+      refreshMap: { save_deposit: ['health_check_flaky', 'balance_check'] },
+      write: saveDeposit,
+      writeName: 'save_deposit',
+      writeInput: { amount: 10 },
+      approved: true,
+      executionResult: { success: true },
+      extraTools: [flakyTool],
+    });
+    expect(balanceCalls).toBe(1);
+    const errored = events.filter(
+      (e) =>
+        e.type === 'tool_result' &&
+        e.wasPostWriteRefresh &&
+        e.isError,
+    );
+    expect(errored).toHaveLength(1);
+    // Narration still happens
+    expect(events.some((e) => e.type === 'text_delta')).toBe(true);
+    expect(events.some((e) => e.type === 'turn_complete')).toBe(true);
+  });
+});

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -76,6 +76,9 @@ export class QueryEngine {
   private readonly sessionSpendUsd: number | undefined;
   private readonly onAutoExecuted: EngineConfig['onAutoExecuted'];
   private readonly onGuardFired: EngineConfig['onGuardFired'];
+  // [v1.5] See `EngineConfig.postWriteRefresh` — drives the post-write
+  // synthetic read injection in `resumeWithToolResult`.
+  private readonly postWriteRefresh: EngineConfig['postWriteRefresh'];
   private matchedRecipe: Recipe | null = null;
 
   private messages: Message[] = [];
@@ -110,6 +113,7 @@ export class QueryEngine {
     this.sessionSpendUsd = config.sessionSpendUsd;
     this.onAutoExecuted = config.onAutoExecuted;
     this.onGuardFired = config.onGuardFired;
+    this.postWriteRefresh = config.postWriteRefresh;
 
     this.tools = config.tools ?? (config.agent ? getDefaultTools() : []);
   }
@@ -203,7 +207,138 @@ export class QueryEngine {
       return;
     }
 
+    // [v1.5] Post-write refresh — eliminate the "LLM invents a wallet
+    // total in the post-write narration" hallucination class by
+    // physically injecting authoritative ground truth into the
+    // conversation BEFORE the LLM gets to narrate. Tools are configured
+    // per write via `EngineConfig.postWriteRefresh`. Errors are
+    // non-fatal: we still advance to agentLoop so the user gets *some*
+    // narration even if RPC blips.
+    yield* this.runPostWriteRefresh(action, response, signal);
+
     yield* this.agentLoop(null, signal, false);
+  }
+
+  /**
+   * [v1.5] Auto-run configured read tools after a successful write,
+   * push their results into the conversation, and yield `tool_result`
+   * events so hosts/UI render them in the timeline. See
+   * `EngineConfig.postWriteRefresh`.
+   *
+   * Pure injection — no LLM call here. The next `agentLoop` turn sees
+   * the fresh tool results and narrates from them.
+   */
+  private async *runPostWriteRefresh(
+    action: PendingAction,
+    response: PermissionResponse,
+    signal: AbortSignal,
+  ): AsyncGenerator<EngineEvent> {
+    const refreshList = this.postWriteRefresh?.[action.toolName];
+    if (!refreshList || refreshList.length === 0) return;
+
+    // Refresh only on confirmed success. Failed writes leave on-chain
+    // state untouched; refreshing would just surface the pre-write
+    // snapshot a second time — wasted RPC + zero new info.
+    const exec = response.executionResult;
+    const writeFailed =
+      exec != null &&
+      typeof exec === 'object' &&
+      'success' in exec &&
+      (exec as { success?: unknown }).success === false;
+    if (writeFailed) return;
+
+    // Resolve & filter — silently drop unknown / non-readonly entries
+    // so config drift between host & engine never breaks resume.
+    const refreshTools = refreshList
+      .map((name) => findTool(this.tools, name))
+      .filter((t): t is Tool =>
+        t !== undefined && t.isReadOnly && t.isConcurrencySafe,
+      );
+    if (refreshTools.length === 0) return;
+
+    const context: ToolContext = {
+      agent: this.agent,
+      mcpManager: this.mcpManager,
+      walletAddress: this.walletAddress,
+      suiRpcUrl: this.suiRpcUrl,
+      serverPositions: this.serverPositions,
+      positionFetcher: this.positionFetcher,
+      env: this.env,
+      signal,
+      priceCache: this.priceCache,
+      permissionConfig: this.permissionConfig,
+      sessionSpendUsd: this.sessionSpendUsd,
+    };
+
+    // Run all refreshes in parallel — they're read-only and target
+    // different RPC endpoints (wallet, NAVI positions, health). The
+    // common case (1-3 tools) finishes well under 1s.
+    const idStem = `pwr_${action.toolUseId.slice(-6)}`;
+    const refreshes = await Promise.all(
+      refreshTools.map(async (tool, idx) => {
+        const id = `${idStem}_${idx}_${tool.name}`;
+        try {
+          const parsed = tool.inputSchema.safeParse({});
+          if (!parsed.success) {
+            return {
+              tool,
+              id,
+              isError: true as const,
+              data: {
+                error: `Post-write refresh: invalid input for ${tool.name}`,
+              },
+            };
+          }
+          const result = await tool.call(parsed.data, context);
+          return { tool, id, isError: false as const, data: result.data };
+        } catch (err) {
+          return {
+            tool,
+            id,
+            isError: true as const,
+            data: {
+              error:
+                err instanceof Error
+                  ? err.message
+                  : 'Post-write refresh failed',
+            },
+          };
+        }
+      }),
+    );
+
+    // Push synthetic conversation pair so the LLM sees:
+    //   assistant(refresh tool_uses) → user(refresh tool_results)
+    // Anthropic accepts back-to-back assistant/user blocks; this is the
+    // same shape `buildSyntheticPrefetch` uses at session start.
+    const refreshUses: ContentBlock[] = refreshes.map((r) => ({
+      type: 'tool_use',
+      id: r.id,
+      name: r.tool.name,
+      input: {},
+    }));
+    this.messages.push({ role: 'assistant', content: refreshUses });
+
+    const refreshResults: ContentBlock[] = refreshes.map((r) => ({
+      type: 'tool_result',
+      toolUseId: r.id,
+      content: typeof r.data === 'string' ? r.data : JSON.stringify(r.data),
+      isError: r.isError,
+    }));
+    this.messages.push({ role: 'user', content: refreshResults });
+
+    // Yield events so hosts log them in `TurnMetrics.toolsCalled[]` and
+    // the UI renders the refreshed cards in-line.
+    for (const r of refreshes) {
+      yield {
+        type: 'tool_result',
+        toolName: r.tool.name,
+        toolUseId: r.id,
+        result: r.data,
+        isError: r.isError,
+        wasPostWriteRefresh: true,
+      };
+    }
   }
 
   interrupt(): void {

--- a/packages/engine/src/streaming.ts
+++ b/packages/engine/src/streaming.ts
@@ -9,7 +9,19 @@ export type SSEEvent =
   | { type: 'thinking_done'; signature?: string }
   | { type: 'text_delta'; text: string }
   | { type: 'tool_start'; toolName: string; toolUseId: string; input: unknown }
-  | { type: 'tool_result'; toolName: string; toolUseId: string; result: unknown; isError: boolean }
+  | {
+      type: 'tool_result';
+      toolName: string;
+      toolUseId: string;
+      result: unknown;
+      isError: boolean;
+      // [v1.4] flags carried through unchanged from EngineEvent.tool_result
+      wasEarlyDispatched?: boolean;
+      resultDeduped?: boolean;
+      // [v1.5] true when injected by the engine's post-write refresh
+      // (see EngineConfig.postWriteRefresh)
+      wasPostWriteRefresh?: boolean;
+    }
   | { type: 'pending_action'; action: PendingAction }
   | { type: 'turn_complete'; stopReason: StopReason }
   | { type: 'usage'; inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheWriteTokens?: number }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -48,6 +48,16 @@ export type EngineEvent =
        * actually re-running the tool.
        */
       resultDeduped?: boolean;
+      /**
+       * [v1.5] True when this result was produced by the engine's
+       * post-write refresh mechanism (see `EngineConfig.postWriteRefresh`).
+       * The engine auto-runs configured read tools immediately after a
+       * successful write so the LLM narrates from fresh on-chain state
+       * instead of inferring from a stale snapshot. Hosts should render
+       * these like any other tool result; the flag is for analytics and
+       * UI affordances (e.g. a subtle "auto-refreshed" badge).
+       */
+      wasPostWriteRefresh?: boolean;
     }
   | {
       type: 'pending_action';
@@ -308,6 +318,43 @@ export interface EngineConfig {
    * verdict→action mapping. Errors thrown by the host are caught.
    */
   onGuardFired?: (guard: import('./guards.js').GuardMetric) => void;
+  /**
+   * [v1.5] Map of write tool name → list of read tool names whose state
+   * the write invalidates. After a successful write resumes via
+   * `resumeWithToolResult`, the engine auto-runs each configured read
+   * tool with empty input, pushes synthetic `tool_use` + `tool_result`
+   * messages into the conversation, and yields `tool_result` events
+   * with `wasPostWriteRefresh: true` BEFORE handing control back to the
+   * LLM for narration.
+   *
+   * Why: writes change on-chain state. Without a fresh read, the LLM
+   * narrates from the pre-write snapshot and frequently invents balance
+   * totals. Auto-injecting fresh reads makes the hallucination class
+   * physically impossible — the model has authoritative ground truth in
+   * its context before generating the post-write sentence.
+   *
+   * Constraints:
+   *  - Refresh tools MUST be `isReadOnly` and `isConcurrencySafe`.
+   *  - Refresh runs only when the write succeeded (executionResult is
+   *    not `{ success: false }`); failed writes leave state unchanged
+   *    and refreshing would be misleading.
+   *  - Tools are invoked with empty input; refresh tools should accept
+   *    an empty object schema (e.g. `balance_check`, `savings_info`).
+   *  - Errors during refresh are non-fatal — a tool_result with
+   *    `isError: true` is still pushed so the LLM knows refresh failed.
+   *
+   * Example:
+   * ```
+   * {
+   *   save_deposit: ['balance_check', 'savings_info'],
+   *   send_transfer: ['balance_check'],
+   *   borrow: ['balance_check', 'savings_info', 'health_check'],
+   * }
+   * ```
+   *
+   * Omit (undefined / empty map) to disable post-write refresh entirely.
+   */
+  postWriteRefresh?: Record<string, string[]>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

After every write (save, swap, send, borrow, withdraw, etc.) Sonnet 4.6 frequently invents balance totals in the post-write narration sentence — e.g. "you now have ~\$154 USDC in total" when the real number is \$103. Root cause: the LLM has only the session-start snapshot in context and does pre-write + delta math to estimate post-write state. The system prompt explicitly forbids this but the model ignores it ~10-20% of the time.

## Fix

Make the hallucination class physically impossible by injecting authoritative ground truth into the conversation **before** the LLM gets to narrate.

New `EngineConfig.postWriteRefresh` — a map of write tool → list of read tools whose state the write invalidates:

\`\`\`ts
{
  save_deposit: ['balance_check', 'savings_info'],
  send_transfer: ['balance_check'],
  borrow:       ['balance_check', 'savings_info', 'health_check'],
  swap_execute: ['balance_check'],
  // ... etc
}
\`\`\`

After a successful write resumes via \`resumeWithToolResult\`, the engine:

1. Resolves the refresh list for the just-executed write.
2. Runs each read tool with empty input (in parallel).
3. Pushes synthetic \`tool_use\` + \`tool_result\` messages into the conversation (same shape as \`buildSyntheticPrefetch\` at session start).
4. Yields \`tool_result\` events with \`wasPostWriteRefresh: true\` so hosts log them in \`TurnMetrics.toolsCalled[]\` and the UI renders the refreshed cards.
5. Hands control to \`agentLoop\` — the LLM now has fresh ground truth and the next text turn cites real numbers.

## Guards

- Refresh runs **only** on \`approved && !{ success: false }\` writes — failed/declined writes don't change state, so re-reading would just re-surface the snapshot.
- Refresh tools must be \`isReadOnly && isConcurrencySafe\`. Unknown tool names are silently filtered.
- Errors during refresh push \`isError: true\` results — narration still proceeds (graceful degradation on RPC blips).
- Back-compat: omit \`postWriteRefresh\` and the engine behaves identically to v0.41.0.

## Test plan

7 new vitest cases in \`__tests__/post-write-refresh.test.ts\`:

- Refresh tools fire after success, with correct ordering & flags
- Events appear between write tool_result and the LLM's first text_delta
- Skip when declined
- Skip when \`executionResult.success === false\`
- No-op when no config (back-compat)
- Unknown / non-readonly tool names are filtered silently
- Refresh-tool throws → still narrates with isError result

All 289 engine tests pass. Typecheck + lint clean.

## Follow-ups (separate PRs)

- audric: wire \`postWriteRefresh\` map in \`engine-factory.ts\` and invert the now-stale "do NOT call balance_check after writes" rule in \`engine-context.ts\`.

Made with [Cursor](https://cursor.com)