### PR TITLE
fix(engine): microcompact respects per-tool cacheable flag — never dedupe wallet-state reads

### DIFF
--- a/packages/engine/src/__tests__/microcompact.test.ts
+++ b/packages/engine/src/__tests__/microcompact.test.ts
@@ -1,9 +1,28 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import { microcompact } from '../compact/microcompact.js';
-import type { Message } from '../types.js';
+import { buildTool } from '../tool.js';
+import type { Message, Tool } from '../types.js';
 
 function msg(role: 'user' | 'assistant', content: Message['content']): Message {
   return { role, content };
+}
+
+/**
+ * [v1.5.1] Helper to spin up a minimal Tool for the cacheable-flag tests.
+ * The `call` is never invoked — microcompact only inspects metadata.
+ */
+function fakeTool(name: string, cacheable?: boolean): Tool {
+  return buildTool({
+    name,
+    description: `${name} (test)`,
+    inputSchema: z.object({}).passthrough(),
+    jsonSchema: { type: 'object', properties: {}, required: [] },
+    cacheable,
+    async call() {
+      throw new Error('not invoked');
+    },
+  });
 }
 
 describe('microcompact', () => {
@@ -158,5 +177,168 @@ describe('microcompact', () => {
 
   it('returns empty array for empty input', () => {
     expect(microcompact([])).toEqual([]);
+  });
+
+  describe('[v1.5.1] cacheable flag', () => {
+    /**
+     * The exact failure mode the user reported: three identical-input
+     * `balance_check` calls (session prefetch + two post-write refreshes)
+     * collapsing to a single back-reference, leaving the LLM with no
+     * fresh state and forcing it to do snapshot-arithmetic.
+     */
+    it('never dedupes calls to a tool marked cacheable: false', () => {
+      const tools = [fakeTool('balance_check', false)];
+      const messages: Message[] = [
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu1', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu1', content: '{"wallet":93}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu2', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu2', content: '{"wallet":83}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu3', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu3', content: '{"wallet":103}' },
+        ]),
+      ];
+
+      const result = microcompact(messages, tools);
+
+      const r1 = result[1].content[0];
+      const r2 = result[3].content[0];
+      const r3 = result[5].content[0];
+      if (r1.type === 'tool_result') expect(r1.content).toBe('{"wallet":93}');
+      if (r2.type === 'tool_result') expect(r2.content).toBe('{"wallet":83}');
+      if (r3.type === 'tool_result') expect(r3.content).toBe('{"wallet":103}');
+      expect(result.dedupedToolUseIds.size).toBe(0);
+    });
+
+    it('still dedupes other tools when only some are non-cacheable', () => {
+      // balance_check non-cacheable, defillama_token_prices cacheable.
+      const tools = [
+        fakeTool('balance_check', false),
+        fakeTool('defillama_token_prices'),
+      ];
+      const messages: Message[] = [
+        msg('assistant', [
+          { type: 'tool_use', id: 'b1', name: 'balance_check', input: {} },
+          { type: 'tool_use', id: 'p1', name: 'defillama_token_prices', input: { tokens: ['SUI'] } },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'b1', content: '{"wallet":100}' },
+          { type: 'tool_result', toolUseId: 'p1', content: '{"SUI":1.0}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'b2', name: 'balance_check', input: {} },
+          { type: 'tool_use', id: 'p2', name: 'defillama_token_prices', input: { tokens: ['SUI'] } },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'b2', content: '{"wallet":50}' },
+          { type: 'tool_result', toolUseId: 'p2', content: '{"SUI":1.0}' },
+        ]),
+      ];
+
+      const result = microcompact(messages, tools);
+      const blocks = result[3].content;
+      const balanceResult = blocks.find(
+        (b): b is Extract<typeof b, { type: 'tool_result' }> =>
+          b.type === 'tool_result' && b.toolUseId === 'b2',
+      );
+      const priceResult = blocks.find(
+        (b): b is Extract<typeof b, { type: 'tool_result' }> =>
+          b.type === 'tool_result' && b.toolUseId === 'p2',
+      );
+
+      expect(balanceResult?.content).toBe('{"wallet":50}');
+      expect(priceResult?.content).toContain('Same result as call #');
+      expect(result.dedupedToolUseIds.has('b2')).toBe(false);
+      expect(result.dedupedToolUseIds.has('p2')).toBe(true);
+    });
+
+    /**
+     * Subtle correctness check: a non-cacheable call must not pollute
+     * the `seen` map. Otherwise a later cacheable call with the same
+     * key would dedupe against it and lose freshness.
+     */
+    it('non-cacheable calls do not register in the seen map', () => {
+      // This scenario is hypothetical — same tool name appearing both
+      // cacheable and not is unusual in practice — but it exercises the
+      // contract that microcompact treats non-cacheable rows as
+      // pass-through, never as dedupe anchors.
+      const tools = [fakeTool('balance_check', false)];
+      const messages: Message[] = [
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu1', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu1', content: '{"wallet":100}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu2', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu2', content: '{"wallet":80}' },
+        ]),
+      ];
+
+      const result = microcompact(messages, tools);
+      expect(result.dedupedToolUseIds.size).toBe(0);
+    });
+
+    it('falls back to dedupe-everything behavior when no tools array is passed (back-compat)', () => {
+      // No tools registry — every tool is treated as cacheable, so the
+      // pre-v1.5.1 dedupe behavior is preserved for legacy hosts.
+      const messages: Message[] = [
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu1', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu1', content: '{"wallet":100}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu2', name: 'balance_check', input: {} },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu2', content: '{"wallet":80}' },
+        ]),
+      ];
+
+      const result = microcompact(messages);
+      const r2 = result[3].content[0];
+      if (r2.type === 'tool_result') {
+        expect(r2.content).toContain('Same result as call #');
+      }
+    });
+
+    it('cacheable: true (explicit) behaves like default — dedupes', () => {
+      const tools = [fakeTool('defillama_yield_pools', true)];
+      const messages: Message[] = [
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu1', name: 'defillama_yield_pools', input: { chain: 'sui' } },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu1', content: '{"pools":[]}' },
+        ]),
+        msg('assistant', [
+          { type: 'tool_use', id: 'tu2', name: 'defillama_yield_pools', input: { chain: 'sui' } },
+        ]),
+        msg('user', [
+          { type: 'tool_result', toolUseId: 'tu2', content: '{"pools":[]}' },
+        ]),
+      ];
+
+      const result = microcompact(messages, tools);
+      const r2 = result[3].content[0];
+      if (r2.type === 'tool_result') {
+        expect(r2.content).toContain('Same result as call #1');
+      }
+    });
   });
 });

--- a/packages/engine/src/compact/microcompact.ts
+++ b/packages/engine/src/compact/microcompact.ts
@@ -1,4 +1,4 @@
-import type { Message, ContentBlock } from '../types.js';
+import type { Message, ContentBlock, Tool } from '../types.js';
 
 /**
  * [v1.4 Item 4] Side-channel return from `microcompact` so callers can
@@ -22,21 +22,50 @@ export interface MicrocompactResult extends Array<Message> {
  * the full prior result with a compact back-reference. Runs before any
  * LLM-based compaction and costs nothing.
  *
+ * [v1.5.1] Tools may opt out of dedupe by setting `cacheable: false` on
+ * their `Tool` definition. Non-cacheable tools (e.g. `balance_check`,
+ * `savings_info`, `health_check`, `transaction_history`) are excluded
+ * from the `seen` map entirely, so neither the current call nor any
+ * later call with identical inputs gets replaced — necessary because
+ * their results depend on mutable on-chain state that writes invalidate.
+ *
  * Returns a new array — does not mutate the input. The returned array
  * carries a `dedupedToolUseIds` property listing every tool-use ID whose
  * tool_result block was replaced with a back-reference this pass.
+ *
+ * @param messages — conversation ledger to compact.
+ * @param tools    — optional tool registry consulted to resolve the
+ *                   per-tool `cacheable` flag. Omit to dedupe every
+ *                   tool (legacy behavior — back-compat).
  */
-export function microcompact(messages: readonly Message[]): MicrocompactResult {
+export function microcompact(
+  messages: readonly Message[],
+  tools?: readonly Tool[],
+): MicrocompactResult {
   const seen = new Map<string, { turnIndex: number }>();
   let toolUseIndex = 0;
 
   const toolUseInputs = new Map<string, string>();
+  // Map tool name → cacheable flag. Default behavior (no entry, or
+  // `cacheable === undefined`) is `true` — back-compat with hosts that
+  // don't pass a tools array.
+  const cacheableByName = new Map<string, boolean>();
+  if (tools) {
+    for (const t of tools) {
+      cacheableByName.set(t.name, t.cacheable ?? true);
+    }
+  }
   const dedupedToolUseIds = new Set<string>();
+
+  // Resolve tool name from a tool_use_id — cached lookup so each result
+  // pass stays linear.
+  const toolNameById = new Map<string, string>();
 
   for (const msg of messages) {
     for (const block of msg.content) {
       if (block.type === 'tool_use') {
         toolUseInputs.set(block.id, `${block.name}:${stableStringify(block.input)}`);
+        toolNameById.set(block.id, block.name);
       }
     }
   }
@@ -52,6 +81,16 @@ export function microcompact(messages: readonly Message[]): MicrocompactResult {
 
       const key = toolUseInputs.get(block.toolUseId);
       if (!key) return block;
+
+      // [v1.5.1] Skip dedupe entirely for tools whose results depend on
+      // mutable state. Don't write to `seen` either — otherwise a later
+      // *cacheable* call with the same key would erroneously dedupe
+      // against this fresh result.
+      const toolName = toolNameById.get(block.toolUseId);
+      if (toolName && cacheableByName.get(toolName) === false) {
+        toolUseIndex++;
+        return block;
+      }
 
       toolUseIndex++;
       const prior = seen.get(key);

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -437,7 +437,12 @@ export class QueryEngine {
         // deduped prior call so hosts can flip `resultDeduped` on the
         // matching `TurnMetrics.toolsCalled[]` row. Marker shape is
         // explicit so collectors don't double-count emissions.
-        const microcompacted = microcompact(this.messages);
+        // [v1.5.1] Pass the tool registry so microcompact honors per-tool
+        // `cacheable` flags. Mutable-state reads (balance_check etc.)
+        // never dedupe, so post-write refreshes always surface fresh
+        // data instead of a "[Same result as call #N]" marker that the
+        // LLM previously misread as "stale snapshot, fall back to math".
+        const microcompacted = microcompact(this.messages, this.tools);
         this.messages = microcompacted;
         for (const dedupedId of microcompacted.dedupedToolUseIds) {
           yield {

--- a/packages/engine/src/tool.ts
+++ b/packages/engine/src/tool.ts
@@ -25,6 +25,11 @@ export interface BuildToolOptions<TInput, TOutput> {
   preflight?: (input: TInput) => PreflightResult;
   maxResultSizeChars?: number;
   summarizeOnTruncate?: (result: string, maxChars: number) => string;
+  /**
+   * [v1.5.1] See `Tool.cacheable`. Default `true`. Set `false` for
+   * tools whose results depend on mutable on-chain state.
+   */
+  cacheable?: boolean;
 }
 
 type AnyPreflight = (input: unknown) => PreflightResult;
@@ -46,6 +51,7 @@ export function buildTool<TInput, TOutput>(
     preflight: opts.preflight as AnyPreflight | undefined,
     maxResultSizeChars: opts.maxResultSizeChars,
     summarizeOnTruncate: opts.summarizeOnTruncate,
+    cacheable: opts.cacheable,
   };
 }
 

--- a/packages/engine/src/tools/balance.ts
+++ b/packages/engine/src/tools/balance.ts
@@ -37,6 +37,10 @@ export const balanceCheckTool = buildTool({
   inputSchema: z.object({}),
   jsonSchema: { type: 'object', properties: {}, required: [] },
   isReadOnly: true,
+  // [v1.5.1] Wallet contents change after every send/swap/save/etc.
+  // Microcompact must NEVER dedupe these calls — each one reflects a
+  // different on-chain state.
+  cacheable: false,
 
   async call(_input, context) {
     if (hasNaviMcp(context)) {

--- a/packages/engine/src/tools/health.ts
+++ b/packages/engine/src/tools/health.ts
@@ -17,6 +17,9 @@ export const healthCheckTool = buildTool({
   inputSchema: z.object({}),
   jsonSchema: { type: 'object', properties: {}, required: [] },
   isReadOnly: true,
+  // [v1.5.1] Health factor changes on every borrow / repay / collateral
+  // movement and even passively as oracle prices update. Never dedupe.
+  cacheable: false,
 
   async call(_input, context) {
     if (context.positionFetcher && context.walletAddress) {

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -232,6 +232,10 @@ export const transactionHistoryTool = buildTool({
   },
   isReadOnly: true,
   maxResultSizeChars: 8_000,
+  // [v1.5.1] New transactions land continuously. Even with an explicit
+  // `date` filter the dedupe is wrong post-write because the just-
+  // executed write may now be in history. Never dedupe.
+  cacheable: false,
 
   async call(
     input,

--- a/packages/engine/src/tools/savings.ts
+++ b/packages/engine/src/tools/savings.ts
@@ -85,6 +85,9 @@ export const savingsInfoTool = buildTool({
   inputSchema: z.object({}),
   jsonSchema: { type: 'object', properties: {}, required: [] },
   isReadOnly: true,
+  // [v1.5.1] NAVI deposits change on save_deposit / withdraw / claim.
+  // Each call reflects a fresh on-chain snapshot — never dedupe.
+  cacheable: false,
 
   async call(_input, context) {
     if (context.positionFetcher && context.walletAddress) {

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -231,6 +231,18 @@ export interface Tool<TInput = unknown, TOutput = unknown> {
   maxResultSizeChars?: number;
   /** Custom truncation strategy. Falls back to generic slice + hint when omitted. */
   summarizeOnTruncate?: (result: string, maxChars: number) => string;
+  /**
+   * [v1.5.1] Whether `microcompact` may dedupe this tool's results across
+   * multiple calls with identical input. Default `true` — most tools are
+   * effectively pure within a session (price lookups, protocol info,
+   * yield pools). Set to `false` for tools whose result depends on
+   * mutable on-chain state and therefore changes after writes
+   * (`balance_check`, `savings_info`, `health_check`,
+   * `transaction_history`). Non-cacheable tools are excluded from the
+   * `seen` map entirely, so neither this call nor any later call with
+   * the same input gets replaced with a "[Same result …]" back-reference.
+   */
+  cacheable?: boolean;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`microcompact` keys dedupe on `tool_name + input_hash`. For `balance_check`, `savings_info`, `health_check` (all `input = {}`), every call collapses to the first one — including v1.5's post-write refresh injections. The LLM then reads `[Same result as call #N]` as "stale snapshot" and falls back to snapshot arithmetic, exactly the failure mode v1.5 was meant to fix.

## Fix

- Add optional `Tool.cacheable` (default `true`).
- `microcompact` now accepts an optional `tools` array and skips dedupe when `cacheable === false` — and crucially does **not** register the call in `seen`, so later cacheable calls don't anchor against a non-cacheable row.
- Mark the four mutable-state reads as `cacheable: false`: `balance_check`, `savings_info`, `health_check`, `transaction_history`.
- Engine threads `this.tools` into the microcompact call site.

## Evidence (user-reported session)

> "the balance_check after withdrawal returned '[Same result as call #2]' which means it's stale. Let me think… Before the \$10 deposit: USDC = 103.37, After \$10 deposit (fresh): 83.37, After withdrawal: should be ~103.37"

The model is doing snapshot math because the post-withdrawal refresh got deduped. With this fix, every refresh surfaces fresh state.

## Tests

- 5 new cases in `microcompact.test.ts` covering the cacheable contract:
  - never dedupes a non-cacheable tool across 3 identical-input calls
  - mixes cacheable + non-cacheable in one assistant turn correctly
  - non-cacheable calls don't pollute the `seen` map
  - back-compat: legacy `microcompact(messages)` still dedupes everything
  - explicit `cacheable: true` behaves identically to default
- All 294 engine tests pass.

## Test plan

- [x] `pnpm --filter @t2000/engine typecheck`
- [x] `pnpm --filter @t2000/engine test`
- [ ] After merge: trigger Release workflow with `bump: minor` (adds public `Tool.cacheable` field) → publishes `0.43.0`
- [ ] Bump Audric to `@t2000/engine@0.43.0`, deploy, re-run Tier 2 spec — verify post-write narration cites fresh refresh data and no `[Same result as call #N]` markers appear in the model's "How I evaluated this".

Made with [Cursor](https://cursor.com)