### PR TITLE
fix(engine): never break tool result shape on truncation — fixes missing rich cards

### DIFF
--- a/packages/engine/src/__tests__/early-dispatcher.test.ts
+++ b/packages/engine/src/__tests__/early-dispatcher.test.ts
@@ -116,8 +116,13 @@ describe('EarlyToolDispatcher', () => {
     const events = await collectAll(dispatcher.collectResults());
     expect(events).toHaveLength(1);
     if (events[0].type === 'tool_result') {
-      const r = String(events[0].result);
-      expect(r).toContain('Truncated');
+      // [v1.5.2] Object payloads are wrapped in a `_truncated` envelope so
+      // downstream consumers (frontend cards, replay logic) can still
+      // destructure the result. See `budgetToolResult` in orchestration.ts.
+      const r = events[0].result as { _truncated: boolean; _note: string };
+      expect(typeof r).toBe('object');
+      expect(r._truncated).toBe(true);
+      expect(r._note).toContain('Truncated');
     }
   });
 

--- a/packages/engine/src/__tests__/history-truncation.test.ts
+++ b/packages/engine/src/__tests__/history-truncation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { transactionHistoryTool } from '../tools/history.js';
+import { budgetToolResult } from '../orchestration.js';
+
+/**
+ * [v1.5.2] Regression suite for the missing-rich-card bug:
+ * before this fix, `transaction_history` results > 8KB hit the generic
+ * truncation fallback in `budgetToolResult`, which returned a sliced
+ * string. The frontend `transaction_history` card renderer then saw
+ * `typeof data !== 'object'` and bailed, so the rich card never rendered.
+ *
+ * The custom `summarizeOnTruncate` keeps the result object-shaped by
+ * progressively halving the `transactions` array until the serialized
+ * payload fits the byte budget, then stamps `_truncated: true` and
+ * `_originalCount` so the LLM knows to recall with `limit` if needed.
+ */
+describe('transaction_history summarizeOnTruncate', () => {
+  function makeFakeTxs(n: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      digest: `0x${'a'.repeat(60)}${i}`,
+      action: i % 2 === 0 ? 'send' : 'lending',
+      amount: i + 1,
+      asset: 'USDC',
+      recipient: `0x${'b'.repeat(60)}`,
+      timestamp: 1_700_000_000_000 + i * 1000,
+      gasCost: 0.001,
+    }));
+  }
+
+  it('produces valid JSON-parseable output that stays object-shaped', () => {
+    const original = { transactions: makeFakeTxs(50), count: 50, date: null, action: null, lookbackDays: 30 };
+    const serialized = JSON.stringify(original);
+    expect(serialized.length).toBeGreaterThan(8000);
+
+    const summarizer = transactionHistoryTool.summarizeOnTruncate!;
+    const result = summarizer(serialized, 8_000);
+
+    expect(typeof result).toBe('string');
+    const parsed = JSON.parse(result);
+    expect(typeof parsed).toBe('object');
+    expect(Array.isArray(parsed.transactions)).toBe(true);
+    expect(parsed._truncated).toBe(true);
+    expect(parsed._originalCount).toBe(50);
+    expect(result.length).toBeLessThanOrEqual(8_000);
+  });
+
+  it('preserves at least one transaction in the result', () => {
+    const original = { transactions: makeFakeTxs(100), count: 100 };
+    const summarizer = transactionHistoryTool.summarizeOnTruncate!;
+    const result = summarizer(JSON.stringify(original), 1_000);
+    const parsed = JSON.parse(result);
+    expect(parsed.transactions.length).toBeGreaterThan(0);
+  });
+
+  it('returns a valid stub when input JSON itself is malformed', () => {
+    const summarizer = transactionHistoryTool.summarizeOnTruncate!;
+    const result = summarizer('{not valid json', 8_000);
+    const parsed = JSON.parse(result);
+    expect(parsed.transactions).toEqual([]);
+    expect(parsed._truncated).toBe(true);
+  });
+
+  it('end-to-end through budgetToolResult: result stays object-shaped', () => {
+    const original = { transactions: makeFakeTxs(50), count: 50, date: null, action: null };
+    const result = budgetToolResult(original, transactionHistoryTool);
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+    const obj = result as { transactions: unknown[]; _truncated?: boolean };
+    expect(Array.isArray(obj.transactions)).toBe(true);
+    expect(obj._truncated).toBe(true);
+  });
+
+  it('end-to-end: small payloads pass through untouched (no envelope)', () => {
+    const original = { transactions: makeFakeTxs(2), count: 2 };
+    const result = budgetToolResult(original, transactionHistoryTool);
+    expect(result).toEqual(original);
+  });
+});

--- a/packages/engine/src/__tests__/tool-budgeting.test.ts
+++ b/packages/engine/src/__tests__/tool-budgeting.test.ts
@@ -30,14 +30,24 @@ describe('budgetToolResult', () => {
     expect(budgetToolResult(bigData, tool)).toEqual(bigData);
   });
 
-  it('truncates data with hint when over limit', () => {
+  it('wraps oversized object data in a _truncated envelope (preserves object shape)', () => {
+    /**
+     * [v1.5.2] Regression guard for the missing-rich-card bug:
+     * the legacy fallback returned a raw sliced string for object data,
+     * which broke frontend card renderers that destructure tool.result.
+     * The envelope keeps the result object-shaped while still carrying
+     * the preview + recall hint for the LLM.
+     */
     const tool = fakeTool({ maxResultSizeChars: 50 });
     const data = { transactions: Array.from({ length: 100 }, (_, i) => ({ id: i, amount: i * 10 })) };
     const result = budgetToolResult(data, tool);
-    expect(typeof result).toBe('string');
-    expect((result as string).length).toBeLessThan(JSON.stringify(data).length);
-    expect(result).toContain('Truncated');
-    expect(result).toContain('test_tool');
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+    const env = result as { _truncated: boolean; _preview: string; _note: string };
+    expect(env._truncated).toBe(true);
+    expect(env._preview.length).toBeLessThanOrEqual(50);
+    expect(env._note).toContain('Truncated');
+    expect(env._note).toContain('test_tool');
   });
 
   it('uses custom summarizeOnTruncate when provided', () => {
@@ -50,12 +60,34 @@ describe('budgetToolResult', () => {
     expect(result).toEqual({ summary: 'custom', max: 20 });
   });
 
-  it('handles string data', () => {
+  it('handles string data with legacy concat (truncated string is fine — nothing to destructure)', () => {
     const tool = fakeTool({ maxResultSizeChars: 10 });
     const data = 'a'.repeat(100);
     const result = budgetToolResult(data, tool);
     expect(typeof result).toBe('string');
     expect(result).toContain('Truncated');
+  });
+
+  it('always returns object/string — never null/undefined — for any oversized payload', () => {
+    /**
+     * [v1.5.2] Frontend safety net: card renderers do
+     * `if (typeof data !== 'object') return null` and crash on undefined.
+     * The truncation path must never produce a value that fails both
+     * checks.
+     */
+    const tool = fakeTool({ maxResultSizeChars: 5 });
+    for (const payload of [
+      { a: 1, b: 2 },
+      [1, 2, 3],
+      'plain string',
+      { nested: { deep: { value: 'x'.repeat(1000) } } },
+    ]) {
+      const result = budgetToolResult(payload, tool);
+      expect(result).not.toBeUndefined();
+      expect(result).not.toBeNull();
+      const t = typeof result;
+      expect(t === 'object' || t === 'string').toBe(true);
+    }
   });
 
   it('does not truncate error results (budgetToolResult only sees data)', () => {

--- a/packages/engine/src/orchestration.ts
+++ b/packages/engine/src/orchestration.ts
@@ -198,6 +198,18 @@ export function budgetToolResult(
 
   const preview = serialized.slice(0, tool.maxResultSizeChars);
   const linesOmitted = serialized.split('\n').length - preview.split('\n').length;
-  const truncated = `${preview}\n\n[Truncated — ${linesOmitted} lines omitted. Call ${tool.name} with narrower parameters (e.g. smaller date range or limit) to see more.]`;
-  try { return JSON.parse(truncated); } catch { return truncated; }
+  const note = `[Truncated — ${linesOmitted} lines omitted. Call ${tool.name} with narrower parameters (e.g. smaller date range or limit) to see more.]`;
+  /**
+   * [v1.5.2] If the original payload was a JSON object, *don't* return a
+   * raw sliced string — the slice is invalid JSON, JSON.parse fails, and
+   * downstream consumers (frontend card renderers, history-replay logic,
+   * etc.) get a string they cannot destructure. Instead, wrap the
+   * preview in a structured `_truncated` envelope so the result stays
+   * object-shaped. Tools that genuinely return a string (rare) fall
+   * through to the legacy concat behavior.
+   */
+  if (typeof data === 'object' && data !== null) {
+    return { _truncated: true, _preview: preview, _note: note };
+  }
+  return `${preview}\n\n${note}`;
 }

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -236,6 +236,47 @@ export const transactionHistoryTool = buildTool({
   // `date` filter the dedupe is wrong post-write because the just-
   // executed write may now be in history. Never dedupe.
   cacheable: false,
+  /**
+   * [v1.5.2] Custom truncation that preserves the structured shape.
+   *
+   * The default `budgetToolResult` slices the JSON string at the byte
+   * limit, appends a "[Truncated…]" note, and tries `JSON.parse` — which
+   * always fails for sliced JSON, so the engine falls back to returning
+   * the raw string. The frontend's `transaction_history` card renderer
+   * then sees `typeof data !== 'object'` and bails, so the rich card
+   * never renders even though the LLM has the full text.
+   *
+   * Strategy: progressively halve the `transactions` array until the
+   * serialized payload fits, then stamp `_truncated: true` and the
+   * original length so the LLM knows to recall with `limit` if it needs
+   * older entries. Result is always valid JSON, always object-shaped.
+   */
+  summarizeOnTruncate(serialized, maxChars) {
+    type ParsedHistory = {
+      transactions: unknown[];
+      count: number;
+      [k: string]: unknown;
+    };
+    let parsed: ParsedHistory;
+    try {
+      parsed = JSON.parse(serialized) as ParsedHistory;
+    } catch {
+      return JSON.stringify({
+        transactions: [],
+        count: 0,
+        _truncated: true,
+        _note: 'Result exceeded size budget and could not be summarized.',
+      });
+    }
+    const original = Array.isArray(parsed.transactions) ? parsed.transactions : [];
+    let trimmed = original.slice();
+    let payload = JSON.stringify({ ...parsed, transactions: trimmed, _truncated: true, _originalCount: original.length });
+    while (payload.length > maxChars && trimmed.length > 1) {
+      trimmed = trimmed.slice(0, Math.max(1, Math.floor(trimmed.length / 2)));
+      payload = JSON.stringify({ ...parsed, transactions: trimmed, _truncated: true, _originalCount: original.length });
+    }
+    return payload;
+  },
 
   async call(
     input,


### PR DESCRIPTION
## Summary

When `transaction_history` (or any tool with a `maxResultSizeChars` budget) returned more data than its limit, `budgetToolResult`'s generic fallback in `orchestration.ts` sliced the JSON string at the byte limit, appended a `[Truncated…]` note, then tried `JSON.parse` — which **always** failed for sliced JSON, so the engine fell back to returning the raw string.

The frontend `transaction_history` card renderer in Audric then saw `typeof data !== 'object'` and bailed, so the rich transaction card never rendered even though the LLM had the full text.

## What changed

Two layers of defense:

1. **`transaction_history` ships a `summarizeOnTruncate`** that progressively halves the `transactions` array until the serialized payload fits the byte budget, then stamps `_truncated: true` and `_originalCount` so the LLM knows to recall with `limit` if it needs older entries.

2. **The generic `budgetToolResult` fallback** now wraps oversized object data in a `{ _truncated, _preview, _note }` envelope instead of returning a sliced string. This keeps results object-shaped for any future tool with `maxResultSizeChars` but no custom summarizer.

## Tests

- New `history-truncation.test.ts` (5 tests) covers the per-tool summarizer + end-to-end through `budgetToolResult`.
- Updated `tool-budgeting.test.ts` for the new envelope contract + a "never returns null/undefined" safety net.
- Updated `early-dispatcher.test.ts` to read `_note` from the envelope.
- **All 300 engine tests pass.**

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 25 files, 300 tests pass
- [ ] After release, bump Audric to 0.44.0 and verify the rich transaction card renders for "show me all transactions"

Made with [Cursor](https://cursor.com)