### PR TITLE
feat(engine): finer-grained transaction labels — deposit/withdraw/payment_link

### DIFF
--- a/packages/engine/src/__tests__/history-labels.test.ts
+++ b/packages/engine/src/__tests__/history-labels.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { transactionHistoryTool } from '../tools/history.js';
+
+/**
+ * [v1.5.3] Regression suite for the finer-grained `label` field on
+ * `TxRecord`. Pre-v1.5.3 the engine returned only the coarse `action`
+ * bucket (send/lending/swap/transaction), so the rich card showed
+ * "Lending" for both deposits and withdrawals and "Transaction" for
+ * anything not on NAVI/Cetus/transfer. Now `parseRpcTx` also emits
+ * `label` derived from the MoveCall function name + balance direction.
+ *
+ * Frontend renders `label ?? action`, so these tests pin the label
+ * contract per common Audric tx pattern.
+ */
+
+const ADDR = '0xabc';
+const baseCtx = {
+  walletAddress: ADDR,
+  suiRpcUrl: 'https://stub',
+} as Parameters<typeof transactionHistoryTool.call>[1];
+
+interface MoveCmd {
+  package: string;
+  module: string;
+  function: string;
+}
+
+function makeRpcTx(opts: {
+  digest: string;
+  moveCalls?: MoveCmd[];
+  transferObjects?: boolean;
+  /** balance changes — positive amount is owner credit, negative is debit */
+  balanceChanges?: { owner: string; coinType: string; amount: string }[];
+}) {
+  const commands: unknown[] = [];
+  if (opts.moveCalls) for (const mc of opts.moveCalls) commands.push({ MoveCall: mc });
+  if (opts.transferObjects) commands.push({ TransferObjects: {} });
+  return {
+    digest: opts.digest,
+    timestampMs: String(Date.now()),
+    effects: { gasUsed: { computationCost: '1000', storageCost: '1000', storageRebate: '0' } },
+    transaction: { data: { transaction: { commands } } },
+    balanceChanges: (opts.balanceChanges ?? []).map((c) => ({
+      owner: { AddressOwner: c.owner },
+      coinType: c.coinType,
+      amount: c.amount,
+    })),
+  };
+}
+
+function mockFetchOnce(rpcResults: ReturnType<typeof makeRpcTx>[]) {
+  global.fetch = vi.fn(async () =>
+    new Response(
+      JSON.stringify({ result: { data: rpcResults, nextCursor: null, hasNextPage: false } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ),
+  ) as typeof fetch;
+}
+
+const USDC = '0x2::usdc::USDC';
+const SUI = '0x2::sui::SUI';
+
+describe('[v1.5.3] transaction_history label classifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('labels NAVI deposit calls as "deposit" via function-name match', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xdep',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'deposit' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-10000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions[0].action).toBe('lending');
+    expect(data.transactions[0].label).toBe('deposit');
+  });
+
+  it('labels NAVI withdraw calls as "withdraw" via function-name match', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xwd',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'withdraw' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '10000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { label?: string }[] };
+    expect(data.transactions[0].label).toBe('withdraw');
+  });
+
+  it('labels NAVI borrow as "borrow" and repay as "repay"', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xb',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'borrow' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '5000000' }],
+      }),
+      makeRpcTx({
+        digest: '0xr',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'repay' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-5000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { digest: string; label?: string }[] };
+    const byDigest = Object.fromEntries(data.transactions.map((t) => [t.digest, t.label]));
+    expect(byDigest['0xb']).toBe('borrow');
+    expect(byDigest['0xr']).toBe('repay');
+  });
+
+  it('labels payment-kit calls as "payment_link"', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xpl',
+        moveCalls: [{ package: '0xmysten', module: 'payment_kit', function: 'create' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-1000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { label?: string }[] };
+    expect(data.transactions[0].label).toBe('payment_link');
+  });
+
+  it('uses balance-direction tiebreaker when lending fn name is generic', async () => {
+    /**
+     * NAVI's bundled entry points (e.g. `entry_deposit_with_account_cap`)
+     * sometimes carry generic names that fall through `LABEL_PATTERNS`.
+     * The tiebreaker uses the user's non-SUI balance change direction.
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xgen-out',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'entry_action_a' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-25000000' }],
+      }),
+      makeRpcTx({
+        digest: '0xgen-in',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'entry_action_b' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '25000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { digest: string; label?: string }[] };
+    const byDigest = Object.fromEntries(data.transactions.map((t) => [t.digest, t.label]));
+    expect(byDigest['0xgen-out']).toBe('deposit');
+    expect(byDigest['0xgen-in']).toBe('withdraw');
+  });
+
+  it('plain transfer without MoveCall labels as "send"', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xsend',
+        transferObjects: true,
+        balanceChanges: [
+          { owner: ADDR, coinType: USDC, amount: '-1000000' },
+          { owner: '0xrecipient', coinType: USDC, amount: '1000000' },
+        ],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions[0].action).toBe('send');
+    expect(data.transactions[0].label).toBe('send');
+  });
+
+  it('unknown module falls back to module name (better than literal "transaction")', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xspam',
+        moveCalls: [{ package: '0xspam', module: 'spam_token', function: 'do_thing' }],
+        balanceChanges: [],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions[0].action).toBe('transaction');
+    expect(data.transactions[0].label).toBe('spam_token');
+  });
+
+  it('preserves the coarse `action` bucket so existing filters still work', async () => {
+    /**
+     * Regression guard for the v1.4 ACI `action` filter: callers can pass
+     * `action: 'lending'` to narrow results, and that filter compares
+     * against the coarse bucket. Adding `label` must not change `action`.
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xx',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'deposit' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-10000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10, action: 'lending' }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions.length).toBe(1);
+    expect(data.transactions[0].action).toBe('lending');
+    expect(data.transactions[0].label).toBe('deposit');
+  });
+
+  it('SUI-only balance changes do not trigger lending tiebreaker', async () => {
+    /**
+     * Gas-only SUI deltas appear on every tx. The tiebreaker explicitly
+     * excludes SUI to avoid mislabeling a no-op lending call as a
+     * deposit just because gas was paid.
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xnoop',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'entry_noop' }],
+        balanceChanges: [{ owner: ADDR, coinType: SUI, amount: '-5000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions[0].action).toBe('lending');
+    // No deposit/withdraw classification — tiebreaker skipped.
+    // Falls back to module name 'navi'.
+    expect(['lending', 'on-chain', 'navi']).toContain(data.transactions[0].label);
+  });
+});

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -13,6 +13,56 @@ const KNOWN_TARGETS: [RegExp, string][] = [
   [/::transfer::public_transfer/, 'send'],
 ];
 
+/**
+ * [v1.5.3] Finer-grained display labels — derived from MoveCall
+ * function names. The card renders `label ?? action`, so when this
+ * map matches we get "Deposit" / "Withdraw" / "Borrow" / "Repay" /
+ * "Payment link" instead of the generic "Lending" or "Transaction".
+ *
+ * Order matters: more specific patterns first. Each entry is
+ * (regex, label) where the regex is matched against the
+ * fully-qualified MoveCall target `pkg::module::function`.
+ */
+const LABEL_PATTERNS: [RegExp, string][] = [
+  [/::pay(?:ment_kit|_kit)?::|::create_payment_link|::pay_link/, 'payment_link'],
+  [/::create_invoice|::invoice::/, 'invoice'],
+  [/::deposit|::supply|::mint_ctokens/, 'deposit'],
+  [/::withdraw|::redeem|::redeem_ctokens/, 'withdraw'],
+  [/::borrow/, 'borrow'],
+  [/::repay/, 'repay'],
+  [/::claim_reward|::claim::|::claim_incentive/, 'claim'],
+  [/::stake/, 'stake'],
+  [/::unstake|::burn::/, 'unstake'],
+  [/::liquidate/, 'liquidate'],
+];
+
+/**
+ * [v1.5.3] Fallback label when no `LABEL_PATTERNS` match.
+ *
+ * Returns the first MoveCall's *module* name (e.g. "navi", "cetus",
+ * "spam") so the card shows something more useful than the literal
+ * word "transaction". When no MoveCall exists, returns 'on-chain'
+ * instead — that's strictly more informative than "transaction" and
+ * matches the language users intuit for "did something on-chain".
+ */
+function fallbackLabel(targets: string[]): string {
+  if (!targets.length) return 'on-chain';
+  const first = targets[0];
+  const parts = first.split('::');
+  if (parts.length >= 2 && parts[1]) return parts[1].toLowerCase();
+  return 'on-chain';
+}
+
+function classifyLabel(targets: string[], commandTypes: string[]): string {
+  for (const target of targets) {
+    for (const [pattern, label] of LABEL_PATTERNS) {
+      if (pattern.test(target)) return label;
+    }
+  }
+  if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
+  return fallbackLabel(targets);
+}
+
 interface RpcBalanceChange {
   owner: { AddressOwner?: string } | string;
   coinType: string;
@@ -29,7 +79,19 @@ interface RpcTxBlock {
 
 interface TxRecord {
   digest: string;
+  /**
+   * [v1.4] Coarse bucket — one of `'send' | 'lending' | 'swap' |
+   * 'transaction'`. Used by the ACI `action` filter and persisted
+   * downstream queries depend on these values, so they are STABLE.
+   */
   action: string;
+  /**
+   * [v1.5.3] Finer-grained display label derived from the
+   * Move-call function name (e.g. `'deposit'`, `'withdraw'`,
+   * `'payment_link'`, `'on-chain'`). Optional — frontends should
+   * fall back to `action` when missing. Never used by filters.
+   */
+  label?: string;
   amount?: number;
   asset?: string;
   recipient?: string;
@@ -98,9 +160,43 @@ function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
   }
 
   const timestampMs = Number(tx.timestampMs ?? 0);
+  const action = classifyAction(moveCallTargets, commandTypes);
+  let label = classifyLabel(moveCallTargets, commandTypes);
+
+  /**
+   * [v1.5.3] Balance-direction tiebreaker for ambiguous lending
+   * calls. Many lending modules expose generic entry points
+   * (`navi::lending::entry_*`, NAVI's bundled flash actions, etc.)
+   * that don't carry a `deposit`/`withdraw`/`borrow`/`repay` keyword
+   * in the function name. When `classifyLabel` falls back to a bare
+   * module name like `"lending"` for a known lending tx, we infer
+   * direction from the user's non-SUI balance change:
+   *   - net outflow of the supplied asset → deposit OR repay
+   *     (both reduce wallet balance into the protocol). We pick
+   *     deposit because it's the dominant case at this stage of
+   *     Audric usage; repay-without-keyword is essentially never
+   *     emitted by NAVI.
+   *   - net inflow of the supplied asset → withdraw OR borrow.
+   *     Same reasoning — withdraw dominates.
+   * If `LABEL_PATTERNS` matched a specific keyword, we keep that
+   * label and skip the inference entirely.
+   */
+  const labelMatchedSpecific = LABEL_PATTERNS.some(([p]) => moveCallTargets.some((t) => p.test(t)));
+  if (action === 'lending' && !labelMatchedSpecific) {
+    const userNonSuiOutflow = changes.find((c) =>
+      resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) < 0n,
+    );
+    const userNonSuiInflow = changes.find((c) =>
+      resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) > 0n,
+    );
+    if (userNonSuiOutflow) label = 'deposit';
+    else if (userNonSuiInflow) label = 'withdraw';
+  }
+
   return {
     digest: tx.digest,
-    action: classifyAction(moveCallTargets, commandTypes),
+    action,
+    label,
     amount,
     asset,
     recipient,


### PR DESCRIPTION
## Summary

Pre-v1.5.3, `transaction_history` returned only a coarse `action` bucket (send / lending / swap / transaction). The Audric rich card rendered that string verbatim, so a NAVI deposit, a NAVI withdraw, and a NAVI repay all showed as "Lending", and anything outside the four known modules (Mysten payment-kit, Suins, etc.) showed as the literal word "Transaction".

This adds an optional `label` field on each `TxRecord`, derived from three signals:

1. **Function-name patterns** — match the MoveCall function against deposit/withdraw/borrow/repay/claim/stake/payment_link/invoice/liquidate/etc.
2. **Balance-direction tiebreaker** — when the lending action bucket matched but no keyword did, the user's non-SUI balance change picks deposit (outflow) vs withdraw (inflow). SUI excluded so gas-only deltas don't false-positive.
3. **Module-name fallback** — when nothing else matches, return the first MoveCall's module (`navi`, `payment_kit`, `spam_token`, …) instead of the literal "transaction".

## Backwards compatibility

- Coarse `action` field is **unchanged** (still send/lending/swap/transaction).
- The v1.4 ACI `action` filter still works on the bucket.
- Frontends should render `label ?? action`. Old SDK consumers see `label === undefined` and fall through to the existing render path.

## Tests

9 new cases in `history-labels.test.ts`: keyword match, balance tiebreaker, plain transfer, payment-kit, unknown module fallback, ACI filter compat, SUI-only no-op exclusion. **All 309 engine tests pass.**

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test --run` — 26 files, 309 tests
- [ ] After release + Audric bump, verify "show me all transactions" renders Deposit / Withdraw / Payment link / Send labels in the card.

Made with [Cursor](https://cursor.com)