### PR TITLE
Consolidate tx classifier into shared SDK module (engine+sdk 0.46.0)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/cli",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "A bank account for AI agents on Sui — guided setup, MCP integration, send, save, borrow, swap. Same 40 tools as the engine, scriptable from any shell.",
   "type": "module",
   "bin": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/engine",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "Agent engine for conversational finance — QueryEngine with 40 tools (29 read, 11 write), 9-guard runner, 7 skill recipes, silent intelligence layer, streaming, canvas. Chat-first by design — every write requires user confirmation.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -1,73 +1,17 @@
 import { z } from 'zod';
-import { getDecimalsForCoinType, resolveSymbol, SUI_TYPE } from '@t2000/sdk';
+import {
+  getDecimalsForCoinType,
+  resolveSymbol,
+  SUI_TYPE,
+  classifyTransaction,
+  type ClassifyBalanceChange,
+} from '@t2000/sdk';
 import { buildTool } from '../tool.js';
 import { requireAgent } from './utils.js';
 
 const SUI_MAINNET_URL = 'https://fullnode.mainnet.sui.io:443';
 
-const KNOWN_TARGETS: [RegExp, string][] = [
-  [/::suilend|::obligation/, 'lending'],
-  [/::navi|::incentive_v\d+|::oracle_pro/, 'lending'],
-  [/::cetus|::pool/, 'swap'],
-  [/::deepbook/, 'swap'],
-  [/::transfer::public_transfer/, 'send'],
-];
-
-/**
- * [v1.5.3] Finer-grained display labels — derived from MoveCall
- * function names. The card renders `label ?? action`, so when this
- * map matches we get "Deposit" / "Withdraw" / "Borrow" / "Repay" /
- * "Payment link" instead of the generic "Lending" or "Transaction".
- *
- * Order matters: more specific patterns first. Each entry is
- * (regex, label) where the regex is matched against the
- * fully-qualified MoveCall target `pkg::module::function`.
- */
-const LABEL_PATTERNS: [RegExp, string][] = [
-  [/::pay(?:ment_kit|_kit)?::|::create_payment_link|::pay_link/, 'payment_link'],
-  [/::create_invoice|::invoice::/, 'invoice'],
-  [/::deposit|::supply|::mint_ctokens/, 'deposit'],
-  [/::withdraw|::redeem|::redeem_ctokens/, 'withdraw'],
-  [/::borrow/, 'borrow'],
-  [/::repay/, 'repay'],
-  [/::claim_reward|::claim::|::claim_incentive/, 'claim'],
-  [/::stake/, 'stake'],
-  [/::unstake|::burn::/, 'unstake'],
-  [/::liquidate/, 'liquidate'],
-];
-
-/**
- * [v1.5.3] Fallback label when no `LABEL_PATTERNS` match.
- *
- * Returns the first MoveCall's *module* name (e.g. "navi", "cetus",
- * "spam") so the card shows something more useful than the literal
- * word "transaction". When no MoveCall exists, returns 'on-chain'
- * instead — that's strictly more informative than "transaction" and
- * matches the language users intuit for "did something on-chain".
- */
-function fallbackLabel(targets: string[]): string {
-  if (!targets.length) return 'on-chain';
-  const first = targets[0];
-  const parts = first.split('::');
-  if (parts.length >= 2 && parts[1]) return parts[1].toLowerCase();
-  return 'on-chain';
-}
-
-function classifyLabel(targets: string[], commandTypes: string[]): string {
-  for (const target of targets) {
-    for (const [pattern, label] of LABEL_PATTERNS) {
-      if (pattern.test(target)) return label;
-    }
-  }
-  if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
-  return fallbackLabel(targets);
-}
-
-interface RpcBalanceChange {
-  owner: { AddressOwner?: string } | string;
-  coinType: string;
-  amount: string;
-}
+type RpcBalanceChange = ClassifyBalanceChange;
 
 interface RpcTxBlock {
   digest: string;
@@ -104,16 +48,6 @@ function resolveOwner(owner: RpcBalanceChange['owner']): string | null {
   if (typeof owner === 'object' && owner.AddressOwner) return owner.AddressOwner;
   if (typeof owner === 'string') return owner;
   return null;
-}
-
-function classifyAction(targets: string[], commandTypes: string[]): string {
-  for (const target of targets) {
-    for (const [pattern, label] of KNOWN_TARGETS) {
-      if (pattern.test(target)) return label;
-    }
-  }
-  if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
-  return 'transaction';
 }
 
 function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
@@ -160,38 +94,7 @@ function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
   }
 
   const timestampMs = Number(tx.timestampMs ?? 0);
-  const action = classifyAction(moveCallTargets, commandTypes);
-  let label = classifyLabel(moveCallTargets, commandTypes);
-
-  /**
-   * [v1.5.3] Balance-direction tiebreaker for ambiguous lending
-   * calls. Many lending modules expose generic entry points
-   * (`navi::lending::entry_*`, NAVI's bundled flash actions, etc.)
-   * that don't carry a `deposit`/`withdraw`/`borrow`/`repay` keyword
-   * in the function name. When `classifyLabel` falls back to a bare
-   * module name like `"lending"` for a known lending tx, we infer
-   * direction from the user's non-SUI balance change:
-   *   - net outflow of the supplied asset → deposit OR repay
-   *     (both reduce wallet balance into the protocol). We pick
-   *     deposit because it's the dominant case at this stage of
-   *     Audric usage; repay-without-keyword is essentially never
-   *     emitted by NAVI.
-   *   - net inflow of the supplied asset → withdraw OR borrow.
-   *     Same reasoning — withdraw dominates.
-   * If `LABEL_PATTERNS` matched a specific keyword, we keep that
-   * label and skip the inference entirely.
-   */
-  const labelMatchedSpecific = LABEL_PATTERNS.some(([p]) => moveCallTargets.some((t) => p.test(t)));
-  if (action === 'lending' && !labelMatchedSpecific) {
-    const userNonSuiOutflow = changes.find((c) =>
-      resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) < 0n,
-    );
-    const userNonSuiInflow = changes.find((c) =>
-      resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) > 0n,
-    );
-    if (userNonSuiOutflow) label = 'deposit';
-    else if (userNonSuiInflow) label = 'withdraw';
-  }
+  const { action, label } = classifyTransaction(moveCallTargets, commandTypes, changes, address);
 
   return {
     digest: tx.digest,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/mcp",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "mcpName": "io.github.mission69b/t2000",
   "description": "MCP server for AI agent bank accounts on Sui — 29 tools, 15 prompts, stdio transport. Drop-in for Claude Desktop, Cursor, Cline, Continue, or any MCP-compatible client.",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/sdk",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "TypeScript SDK for AI agent bank accounts on Sui — send, save, borrow, swap. NAVI lending + Cetus aggregator routing, sponsored gas, zkLogin compatible.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -53,6 +53,16 @@ export {
 // Utilities
 export { validateAddress, truncateAddress } from './utils/sui.js';
 export {
+  KNOWN_TARGETS,
+  LABEL_PATTERNS,
+  classifyAction,
+  classifyLabel,
+  fallbackLabel,
+  refineLendingLabel,
+  classifyTransaction,
+} from './wallet/classify.js';
+export type { ClassifyBalanceChange, ClassifyResult } from './wallet/classify.js';
+export {
   mistToSui,
   suiToMist,
   usdcToRaw,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -63,6 +63,16 @@ export {
 export type { Operation } from './constants.js';
 export { validateAddress, truncateAddress } from './utils/sui.js';
 export {
+  KNOWN_TARGETS,
+  LABEL_PATTERNS,
+  classifyAction,
+  classifyLabel,
+  fallbackLabel,
+  refineLendingLabel,
+  classifyTransaction,
+} from './wallet/classify.js';
+export type { ClassifyBalanceChange, ClassifyResult } from './wallet/classify.js';
+export {
   mistToSui,
   suiToMist,
   usdcToRaw,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -159,7 +159,15 @@ export interface PaymentRequest {
 
 export interface TransactionRecord {
   digest: string;
+  /** Coarse bucket — `'send' | 'lending' | 'swap' | 'transaction'`. STABLE. */
   action: string;
+  /**
+   * Finer-grained display label derived from the Move-call function
+   * name (e.g. `'deposit'`, `'withdraw'`, `'payment_link'`,
+   * `'on-chain'`). Optional — frontends should fall back to `action`
+   * when missing. Never used by ACI filters.
+   */
+  label?: string;
   amount?: number;
   asset?: string;
   recipient?: string;

--- a/packages/sdk/src/wallet/classify.test.ts
+++ b/packages/sdk/src/wallet/classify.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyAction,
+  classifyLabel,
+  classifyTransaction,
+  fallbackLabel,
+  refineLendingLabel,
+  type ClassifyBalanceChange,
+} from './classify.js';
+import { SUI_TYPE } from '../token-registry.js';
+
+/**
+ * Shared classifier tests. Mirrors the engine's `history-labels.test.ts`
+ * but pinned at the SDK boundary — this is the single source of truth
+ * consumed by both the engine RPC path and the SDK agent path.
+ *
+ * Regression guard: pre-consolidation the SDK had its own
+ * `classifyAction` that emitted `'transaction'` for everything that
+ * wasn't NAVI/Cetus/transfer, which the frontend rendered as
+ * "On-chain" — wiping out the fine-grained labels the engine had
+ * already shipped.
+ */
+
+const ADDR = '0xowner';
+const USDC = '0x2::usdc::USDC';
+
+function bc(owner: string, coinType: string, amount: string): ClassifyBalanceChange {
+  return { owner: { AddressOwner: owner }, coinType, amount };
+}
+
+describe('classifyAction (coarse bucket)', () => {
+  it('maps NAVI MoveCall targets to lending', () => {
+    expect(classifyAction(['0xpkg::navi::deposit'], ['MoveCall'])).toBe('lending');
+  });
+
+  it('maps suilend MoveCall targets to lending', () => {
+    expect(classifyAction(['0xpkg::suilend::repay'], ['MoveCall'])).toBe('lending');
+  });
+
+  it('maps Cetus pool MoveCall targets to swap', () => {
+    expect(classifyAction(['0xpkg::cetus::route'], ['MoveCall'])).toBe('swap');
+  });
+
+  it('maps deepbook MoveCall targets to swap', () => {
+    expect(classifyAction(['0xpkg::deepbook::place'], ['MoveCall'])).toBe('swap');
+  });
+
+  it('classifies plain TransferObjects without MoveCall as send', () => {
+    expect(classifyAction([], ['TransferObjects'])).toBe('send');
+  });
+
+  it('falls back to transaction for unknown MoveCall', () => {
+    expect(classifyAction(['0xpkg::other::do'], ['MoveCall'])).toBe('transaction');
+  });
+});
+
+describe('classifyLabel (fine-grained display)', () => {
+  it('labels deposit functions as deposit', () => {
+    expect(classifyLabel(['0xpkg::navi::deposit_with_account_cap'], ['MoveCall'])).toBe('deposit');
+  });
+
+  it('labels withdraw functions as withdraw', () => {
+    expect(classifyLabel(['0xpkg::navi::withdraw'], ['MoveCall'])).toBe('withdraw');
+  });
+
+  it('labels borrow functions as borrow', () => {
+    expect(classifyLabel(['0xpkg::navi::borrow'], ['MoveCall'])).toBe('borrow');
+  });
+
+  it('labels repay functions as repay', () => {
+    expect(classifyLabel(['0xpkg::navi::repay'], ['MoveCall'])).toBe('repay');
+  });
+
+  it('labels payment-kit calls as payment_link', () => {
+    expect(classifyLabel(['0xmysten::payment_kit::create'], ['MoveCall'])).toBe('payment_link');
+  });
+
+  it('labels suilend lending_core entry as lending action via classifyAction', () => {
+    expect(classifyAction(['0xpkg::lending_core::entry_deposit'], ['MoveCall'])).toBe('lending');
+  });
+
+  it('returns module name when no LABEL_PATTERNS match', () => {
+    expect(classifyLabel(['0xpkg::spam_token::do'], ['MoveCall'])).toBe('spam_token');
+  });
+
+  it('returns on-chain when no MoveCalls and no transfer', () => {
+    expect(classifyLabel([], [])).toBe('on-chain');
+  });
+});
+
+describe('fallbackLabel', () => {
+  it('returns on-chain for empty targets', () => {
+    expect(fallbackLabel([])).toBe('on-chain');
+  });
+  it('returns lowercased module name when present', () => {
+    expect(fallbackLabel(['0xpkg::SomeModule::fn'])).toBe('somemodule');
+  });
+});
+
+describe('refineLendingLabel (balance-direction tiebreaker)', () => {
+  it('infers deposit from net non-SUI outflow on generic lending call', () => {
+    const out = refineLendingLabel(
+      'lending',
+      'navi',
+      ['0xpkg::navi::entry_action'],
+      [bc(ADDR, USDC, '-10000000')],
+      ADDR,
+    );
+    expect(out).toBe('deposit');
+  });
+
+  it('infers withdraw from net non-SUI inflow on generic lending call', () => {
+    const out = refineLendingLabel(
+      'lending',
+      'navi',
+      ['0xpkg::navi::entry_action'],
+      [bc(ADDR, USDC, '10000000')],
+      ADDR,
+    );
+    expect(out).toBe('withdraw');
+  });
+
+  it('does not override a specific label that matched LABEL_PATTERNS', () => {
+    const out = refineLendingLabel(
+      'lending',
+      'borrow',
+      ['0xpkg::navi::borrow'],
+      [bc(ADDR, USDC, '10000000')],
+      ADDR,
+    );
+    expect(out).toBe('borrow');
+  });
+
+  it('skips SUI-only changes (gas) so no-op lending stays unchanged', () => {
+    const out = refineLendingLabel(
+      'lending',
+      'navi',
+      ['0xpkg::navi::entry_noop'],
+      [bc(ADDR, SUI_TYPE, '-5000')],
+      ADDR,
+    );
+    expect(out).toBe('navi');
+  });
+
+  it('does nothing when action is not lending', () => {
+    const out = refineLendingLabel(
+      'send',
+      'send',
+      [],
+      [bc(ADDR, USDC, '-10000000')],
+      ADDR,
+    );
+    expect(out).toBe('send');
+  });
+});
+
+describe('classifyTransaction (combined)', () => {
+  it('returns both action and label in a single call', () => {
+    const result = classifyTransaction(
+      ['0xpkg::navi::deposit'],
+      ['MoveCall'],
+      [bc(ADDR, USDC, '-10000000')],
+      ADDR,
+    );
+    expect(result.action).toBe('lending');
+    expect(result.label).toBe('deposit');
+  });
+
+  it('always populates label field even for unknown txs', () => {
+    const result = classifyTransaction(
+      ['0xpkg::unknown::do'],
+      ['MoveCall'],
+      [],
+      ADDR,
+    );
+    expect(result.action).toBe('transaction');
+    expect(result.label).toBe('unknown');
+    expect(result.label).not.toBe('');
+  });
+});

--- a/packages/sdk/src/wallet/classify.ts
+++ b/packages/sdk/src/wallet/classify.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared transaction classifier.
+ *
+ * Consumed by both the SDK's `parseTxRecord` (production agent path) and
+ * the engine's `transaction_history` tool (cold-start RPC path). Keeping
+ * a single source of truth here prevents the two paths from drifting —
+ * see v1.5.3 regression where the SDK path was emitting `action:
+ * 'transaction'` (rendered as "On-chain") while the engine path was
+ * already producing fine-grained labels.
+ */
+
+import { SUI_TYPE } from '../token-registry.js';
+
+/**
+ * Coarse action bucket — one of `'send' | 'lending' | 'swap' |
+ * 'transaction'`. Used by the ACI `action` filter on the
+ * `transaction_history` tool. STABLE: downstream queries depend on
+ * exactly these values.
+ */
+export const KNOWN_TARGETS: readonly [RegExp, string][] = [
+  [/::suilend|::obligation/, 'lending'],
+  [/::navi|::lending_core|::incentive_v\d+|::oracle_pro/, 'lending'],
+  [/::cetus|::pool/, 'swap'],
+  [/::deepbook/, 'swap'],
+  [/::transfer::public_transfer/, 'send'],
+];
+
+/**
+ * Finer-grained display labels — derived from MoveCall function names.
+ * The card renders `label ?? action`, so when this map matches we get
+ * "Deposit" / "Withdraw" / "Borrow" / "Repay" / "Payment link" instead
+ * of the generic "Lending" or "Transaction".
+ *
+ * Order matters: more specific patterns first. Each entry is
+ * (regex, label) where the regex is matched against the
+ * fully-qualified MoveCall target `pkg::module::function`.
+ */
+export const LABEL_PATTERNS: readonly [RegExp, string][] = [
+  [/::pay(?:ment_kit|_kit)?::|::create_payment_link|::pay_link/, 'payment_link'],
+  [/::create_invoice|::invoice::/, 'invoice'],
+  [/::deposit|::supply|::mint_ctokens/, 'deposit'],
+  [/::withdraw|::redeem|::redeem_ctokens/, 'withdraw'],
+  [/::borrow/, 'borrow'],
+  [/::repay/, 'repay'],
+  [/::claim_reward|::claim::|::claim_incentive/, 'claim'],
+  [/::stake/, 'stake'],
+  [/::unstake|::burn::/, 'unstake'],
+  [/::liquidate/, 'liquidate'],
+];
+
+export interface ClassifyBalanceChange {
+  owner: { AddressOwner?: string } | string;
+  coinType: string;
+  amount: string;
+}
+
+function resolveOwner(owner: ClassifyBalanceChange['owner']): string | null {
+  if (typeof owner === 'object' && owner.AddressOwner) return owner.AddressOwner;
+  if (typeof owner === 'string') return owner;
+  return null;
+}
+
+export function classifyAction(targets: string[], commandTypes: string[]): string {
+  for (const target of targets) {
+    for (const [pattern, label] of KNOWN_TARGETS) {
+      if (pattern.test(target)) return label;
+    }
+  }
+  if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
+  return 'transaction';
+}
+
+/**
+ * Fallback label when no `LABEL_PATTERNS` match.
+ *
+ * Returns the first MoveCall's *module* name (e.g. "navi", "cetus",
+ * "spam") so the card shows something more useful than the literal
+ * word "transaction". When no MoveCall exists, returns 'on-chain'
+ * instead — strictly more informative than "transaction".
+ */
+export function fallbackLabel(targets: string[]): string {
+  if (!targets.length) return 'on-chain';
+  const first = targets[0];
+  const parts = first.split('::');
+  if (parts.length >= 2 && parts[1]) return parts[1].toLowerCase();
+  return 'on-chain';
+}
+
+export function classifyLabel(targets: string[], commandTypes: string[]): string {
+  for (const target of targets) {
+    for (const [pattern, label] of LABEL_PATTERNS) {
+      if (pattern.test(target)) return label;
+    }
+  }
+  if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
+  return fallbackLabel(targets);
+}
+
+/**
+ * Balance-direction tiebreaker for ambiguous lending calls.
+ *
+ * Many lending modules expose generic entry points (NAVI's bundled
+ * flash actions, `lending_core::*::entry_*`, etc.) that don't carry
+ * a `deposit`/`withdraw`/`borrow`/`repay` keyword in the function
+ * name. When `classifyLabel` falls back to a bare module name like
+ * `"lending"` for a known lending tx, infer direction from the user's
+ * non-SUI balance change:
+ *   - net outflow of the supplied asset → deposit (also covers repay,
+ *     but repay-without-keyword is essentially never emitted).
+ *   - net inflow of the supplied asset → withdraw (also covers borrow).
+ * SUI is excluded so gas-only transactions don't get mislabeled.
+ *
+ * If `LABEL_PATTERNS` matched a specific keyword, the existing label is
+ * returned unchanged.
+ */
+export function refineLendingLabel(
+  currentAction: string,
+  currentLabel: string,
+  moveCallTargets: string[],
+  changes: ClassifyBalanceChange[],
+  address: string,
+): string {
+  if (currentAction !== 'lending') return currentLabel;
+  const labelMatchedSpecific = LABEL_PATTERNS.some(([p]) =>
+    moveCallTargets.some((t) => p.test(t)),
+  );
+  if (labelMatchedSpecific) return currentLabel;
+
+  const userNonSuiOutflow = changes.find(
+    (c) => resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) < 0n,
+  );
+  if (userNonSuiOutflow) return 'deposit';
+
+  const userNonSuiInflow = changes.find(
+    (c) => resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) > 0n,
+  );
+  if (userNonSuiInflow) return 'withdraw';
+
+  return currentLabel;
+}
+
+export interface ClassifyResult {
+  action: string;
+  label: string;
+}
+
+export function classifyTransaction(
+  moveCallTargets: string[],
+  commandTypes: string[],
+  balanceChanges: ClassifyBalanceChange[],
+  address: string,
+): ClassifyResult {
+  const action = classifyAction(moveCallTargets, commandTypes);
+  const baseLabel = classifyLabel(moveCallTargets, commandTypes);
+  const label = refineLendingLabel(action, baseLabel, moveCallTargets, balanceChanges, address);
+  return { action, label };
+}

--- a/packages/sdk/src/wallet/history.ts
+++ b/packages/sdk/src/wallet/history.ts
@@ -1,14 +1,7 @@
 import type { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
 import type { TransactionRecord } from '../types.js';
 import { getDecimalsForCoinType, resolveSymbol, SUI_TYPE } from '../token-registry.js';
-
-const KNOWN_TARGETS: [RegExp, string][] = [
-  [/::suilend|::obligation/, 'lending'],
-  [/::navi|::incentive_v\d+|::oracle_pro/, 'lending'],
-  [/::cetus|::pool/, 'swap'],
-  [/::deepbook/, 'swap'],
-  [/::transfer::public_transfer/, 'send'],
-];
+import { classifyTransaction, type ClassifyBalanceChange } from './classify.js';
 
 export async function queryHistory(
   client: SuiJsonRpcClient,
@@ -46,7 +39,7 @@ interface TxBlock {
   timestampMs?: string;
   transaction?: unknown;
   effects?: { gasUsed?: { computationCost: string; storageCost: string; storageRebate: string } };
-  balanceChanges?: BalanceChange[];
+  balanceChanges?: ClassifyBalanceChange[];
 }
 
 function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
@@ -59,12 +52,19 @@ function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
     : undefined;
 
   const { moveCallTargets, commandTypes } = extractCommands(tx.transaction);
-  const { amount, asset, recipient } = extractTransferDetails(tx.balanceChanges, address);
-  const action = classifyAction(moveCallTargets, commandTypes);
+  const balanceChanges = tx.balanceChanges ?? [];
+  const { amount, asset, recipient } = extractTransferDetails(balanceChanges, address);
+  const { action, label } = classifyTransaction(
+    moveCallTargets,
+    commandTypes,
+    balanceChanges,
+    address,
+  );
 
   return {
     digest: tx.digest,
     action,
+    label,
     amount,
     asset,
     recipient,
@@ -73,20 +73,14 @@ function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
   };
 }
 
-interface BalanceChange {
-  owner: { AddressOwner?: string } | string;
-  coinType: string;
-  amount: string;
-}
-
-function resolveOwner(owner: BalanceChange['owner']): string | null {
+function resolveOwner(owner: ClassifyBalanceChange['owner']): string | null {
   if (typeof owner === 'object' && owner.AddressOwner) return owner.AddressOwner;
   if (typeof owner === 'string') return owner;
   return null;
 }
 
 function extractTransferDetails(
-  changes: BalanceChange[] | undefined,
+  changes: ClassifyBalanceChange[] | undefined,
   sender: string,
 ): { amount?: number; asset?: string; recipient?: string } {
   if (!changes || changes.length === 0) return {};
@@ -145,20 +139,4 @@ function extractCommands(txBlock: unknown): CommandInfo {
     }
   } catch { /* best effort */ }
   return result;
-}
-
-function classifyAction(targets: string[], commandTypes: string[]): string {
-  for (const target of targets) {
-    for (const [pattern, label] of KNOWN_TARGETS) {
-      if (pattern.test(target)) return label;
-    }
-  }
-
-  const hasTransfer = commandTypes.includes('TransferObjects');
-  const hasMoveCall = commandTypes.includes('MoveCall');
-
-  if (hasTransfer && !hasMoveCall) return 'send';
-  if (hasMoveCall) return 'transaction';
-
-  return 'transaction';
 }


### PR DESCRIPTION
## Summary

Pre-fix, the SDK's `wallet/history.ts` had its own `classifyAction` that emitted only the coarse `'send' | 'lending' | 'swap' | 'transaction'` bucket. The engine's RPC path got the v1.5.3 fine-grained `label` (deposit, withdraw, payment_link, …) but the SDK agent path — what production actually hits via `agent.history()` — kept emitting `action: 'transaction'` for everything outside NAVI/Cetus/transfer. The frontend then rendered those as **\"On-chain\"** for every row of the transaction history card.

This PR collapses the two paths onto a single shared classifier in the SDK.

## Changes

- New \`packages/sdk/src/wallet/classify.ts\` as the single source of truth: \`KNOWN_TARGETS\` + \`LABEL_PATTERNS\` + \`classifyAction\` + \`classifyLabel\` + \`fallbackLabel\` + \`refineLendingLabel\` (balance-direction tiebreaker for ambiguous lending entry points) + \`classifyTransaction\` (combined helper).
- \`TransactionRecord\` gains optional \`label\` field — frontends fall back to \`action\` when absent (backwards compatible).
- SDK \`wallet/history.ts\` and engine \`tools/history.ts\` both delegate to the shared classifier. Engine drops ~80 lines of duplicate code.
- Extended NAVI regex with \`::lending_core\` so bundled entry points classify as lending without relying on the tiebreaker.
- 23 new SDK classifier tests pinning every branch.
- All 373 SDK + 309 engine tests pass.

Bumps to **0.46.0** across sdk / engine / mcp / cli.

## Test plan

- [x] \`pnpm --filter @t2000/sdk typecheck\`
- [x] \`pnpm --filter @t2000/sdk test\` — 373/373
- [x] \`pnpm --filter @t2000/engine typecheck\`
- [x] \`pnpm --filter @t2000/engine test\` — 309/309 (incl. existing \`history-labels.test.ts\` which still pass against the shared classifier)
- [x] \`pnpm --filter @t2000/sdk build\`
- [x] \`pnpm --filter @t2000/engine build\`
- [ ] After merge: publish 0.46.0 to npm, bump audric \`apps/web/package.json\`, deploy and verify the transaction card on the \"show me all transactions\" prompt no longer shows \"On-chain\" for NAVI deposits / payment links / sends.

Made with [Cursor](https://cursor.com)