### PR TITLE
fix(engine): parse legacy 'transactions' field in RPC history (0.46.1)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/cli",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "A bank account for AI agents on Sui — guided setup, MCP integration, send, save, borrow, swap. Same 40 tools as the engine, scriptable from any shell.",
   "type": "module",
   "bin": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/engine",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Agent engine for conversational finance — QueryEngine with 40 tools (29 read, 11 write), 9-guard runner, 7 skill recipes, silent intelligence layer, streaming, canvas. Chat-first by design — every write requires user confirmation.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/engine/src/__tests__/history-labels.test.ts
+++ b/packages/engine/src/__tests__/history-labels.test.ts
@@ -31,15 +31,24 @@ function makeRpcTx(opts: {
   transferObjects?: boolean;
   /** balance changes — positive amount is owner credit, negative is debit */
   balanceChanges?: { owner: string; coinType: string; amount: string }[];
+  /**
+   * Field name for the programmable-tx command list. Prod Sui RPC
+   * uses the legacy `transactions` key; the SDK-builder side uses
+   * `commands`. Default `commands` mirrors the existing tests; flip
+   * to `transactions` to exercise the legacy-shape regression guard.
+   */
+  cmdField?: 'commands' | 'transactions';
 }) {
-  const commands: unknown[] = [];
-  if (opts.moveCalls) for (const mc of opts.moveCalls) commands.push({ MoveCall: mc });
-  if (opts.transferObjects) commands.push({ TransferObjects: {} });
+  const cmds: unknown[] = [];
+  if (opts.moveCalls) for (const mc of opts.moveCalls) cmds.push({ MoveCall: mc });
+  if (opts.transferObjects) cmds.push({ TransferObjects: {} });
+  const inner =
+    opts.cmdField === 'transactions' ? { transactions: cmds } : { commands: cmds };
   return {
     digest: opts.digest,
     timestampMs: String(Date.now()),
     effects: { gasUsed: { computationCost: '1000', storageCost: '1000', storageRebate: '0' } },
-    transaction: { data: { transaction: { commands } } },
+    transaction: { data: { transaction: inner } },
     balanceChanges: (opts.balanceChanges ?? []).map((c) => ({
       owner: { AddressOwner: c.owner },
       coinType: c.coinType,
@@ -197,6 +206,29 @@ describe('[v1.5.3] transaction_history label classifier', () => {
     const res = await transactionHistoryTool.call({ limit: 10, action: 'lending' }, baseCtx);
     const data = res.data as { transactions: { action: string; label?: string }[] };
     expect(data.transactions.length).toBe(1);
+    expect(data.transactions[0].action).toBe('lending');
+    expect(data.transactions[0].label).toBe('deposit');
+  });
+
+  it('parses commands when RPC uses legacy `transactions` field name', async () => {
+    /**
+     * Regression guard for the v0.46.0 deploy where every row in the
+     * card rendered as "On-chain". Root cause: prod `suix_queryTransactionBlocks`
+     * serializes the programmable-tx body with the legacy field name
+     * `transactions` (plural), but `parseRpcTx` was only checking
+     * `commands`. With no MoveCall targets extracted, every tx fell
+     * through to `fallbackLabel([])` → 'on-chain'.
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xlegacy',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'deposit' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '-10000000' }],
+        cmdField: 'transactions',
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
     expect(data.transactions[0].action).toBe('lending');
     expect(data.transactions[0].label).toBe('deposit');
   });

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -59,10 +59,19 @@ function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
   const moveCallTargets: string[] = [];
   const commandTypes: string[] = [];
   try {
+    /**
+     * Sui JSON-RPC `suix_queryTransactionBlocks` returns the
+     * ProgrammableTransaction body with the legacy field name
+     * `transactions` (plural). Newer SDK-side types refer to the same
+     * data as `commands`. Cover both — the v1.5.3 engine path was
+     * only checking `commands`, which always returned empty for prod
+     * RPC responses, so every row in the transaction history card
+     * fell back to `label: 'on-chain'`.
+     */
     const data = (tx.transaction as Record<string, unknown>)?.data as Record<string, unknown> | undefined;
     const inner = data?.transaction as Record<string, unknown> | undefined;
-    const commands = inner?.commands as Record<string, unknown>[] | undefined;
-    if (commands) {
+    const commands = (inner?.commands ?? inner?.transactions) as Record<string, unknown>[] | undefined;
+    if (Array.isArray(commands)) {
       for (const cmd of commands) {
         if (cmd.MoveCall) {
           const mc = cmd.MoveCall as { package: string; module: string; function: string };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/mcp",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "mcpName": "io.github.mission69b/t2000",
   "description": "MCP server for AI agent bank accounts on Sui — 29 tools, 15 prompts, stdio transport. Drop-in for Claude Desktop, Cursor, Cline, Continue, or any MCP-compatible client.",
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t2000/sdk",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "TypeScript SDK for AI agent bank accounts on Sui — send, save, borrow, swap. NAVI lending + Cetus aggregator routing, sponsored gas, zkLogin compatible.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Root cause

Prod Sui JSON-RPC \`suix_queryTransactionBlocks\` returns the ProgrammableTransaction body with the legacy field name **\`transactions\`** (plural). The v1.5.3 engine RPC parser was only checking \`commands\`, so for every transaction the MoveCall targets array was empty, fell through to \`fallbackLabel([])\` → \`'on-chain'\`, and the transaction history card rendered \"On-chain\" for every row — masking the v0.45.0 + v0.46.0 fine-grained label work entirely.

The SDK extractor already handled both shapes (\`'commands' in inner ?? 'transactions' in inner\`); the engine RPC path was the missing piece. Now the engine also tries both: \`inner.commands ?? inner.transactions\`.

## Why the SDK fix didn't catch it

Audric's \`engine-factory.ts\` doesn't pass an \`agent\` to the engine — only \`walletAddress\` + \`suiRpcUrl\`. So \`transaction_history\` always takes the engine RPC path, never \`agent.history()\`. The SDK consolidation in #56 was correct (and needed for non-Audric SDK consumers) but didn't help prod.

## Test

Adds a regression test in \`history-labels.test.ts\` pinning the legacy field name (\`cmdField: 'transactions'\`) so this can't silently regress again. All 310 engine tests pass.

## Test plan

- [x] \`pnpm --filter @t2000/engine typecheck\`
- [x] \`pnpm --filter @t2000/engine test\` — 310/310 (1 new)
- [ ] After merge: tag v0.46.1, npm publish, bump audric, deploy, verify \"show me all transactions\" → card now shows specific labels per row.

Patch bump to 0.46.1 across sdk/engine/mcp/cli.

Made with [Cursor](https://cursor.com)