### PR TITLE
🐛 fix(sdk,engine): bidirectional tx amounts + swap labels + shared SDK parser

### DIFF
--- a/packages/engine/src/__tests__/history-labels.test.ts
+++ b/packages/engine/src/__tests__/history-labels.test.ts
@@ -233,6 +233,106 @@ describe('[v1.5.3] transaction_history label classifier', () => {
     expect(data.transactions[0].label).toBe('deposit');
   });
 
+  it('Cetus aggregator router calls label as "swap" (not "router")', async () => {
+    /**
+     * Pre-v0.46.2 regression: every swap rendered with the literal
+     * label "router". The real on-chain shape from the Cetus
+     * aggregator is multiple MoveCalls — router glue (setup,
+     * transfer, confirm) wrapping a per-DEX leg (`cetus::swap`,
+     * `flowx_amm::swap`, etc.). classifyAction matched the DEX leg
+     * → 'swap', but classifyLabel saw no LABEL_PATTERNS entry and
+     * fell through to the FIRST module name = "router".
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xswap',
+        moveCalls: [
+          { package: '0xrouter', module: 'router', function: 'new_swap_context_v' },
+          { package: '0xpath', module: 'cetus', function: 'swap' },
+          { package: '0xrouter', module: 'router', function: 'transfer_balance' },
+          { package: '0xrouter', module: 'router', function: 'confirm_swap' },
+        ],
+        balanceChanges: [
+          { owner: ADDR, coinType: USDC, amount: '-1000000' },
+          { owner: '0xpool', coinType: USDC, amount: '1000000' },
+        ],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as { transactions: { action: string; label?: string }[] };
+    expect(data.transactions[0].action).toBe('swap');
+    expect(data.transactions[0].label).toBe('swap');
+  });
+
+  it('emits direction=in for sponsored-gas withdraws (no SUI outflow)', async () => {
+    /**
+     * Pre-v0.46.2 regression: with sponsored gas, withdraws and
+     * borrows produced no user SUI outflow, and the old extractor
+     * only looked at outflows — so the card showed no amount and
+     * inferred a wrong sign from the label string.
+     *
+     * Now extractTransferDetails picks the user's largest non-SUI
+     * change regardless of sign and emits an explicit direction.
+     */
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xwd-spons',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'withdraw' }],
+        balanceChanges: [
+          { owner: ADDR, coinType: USDC, amount: '10140000' }, // user receives 10.14 USDC
+        ],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as {
+      transactions: { amount?: number; asset?: string; direction?: string; label?: string }[];
+    };
+    const tx = data.transactions[0];
+    expect(tx.label).toBe('withdraw');
+    expect(tx.direction).toBe('in');
+    expect(tx.amount).toBeCloseTo(10.14, 4);
+    expect(tx.asset).toBe('USDC');
+  });
+
+  it('emits direction=in for sponsored-gas borrows', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xborrow',
+        moveCalls: [{ package: '0xpkg', module: 'navi', function: 'borrow' }],
+        balanceChanges: [{ owner: ADDR, coinType: USDC, amount: '5000000' }],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as {
+      transactions: { amount?: number; asset?: string; direction?: string; label?: string }[];
+    };
+    const tx = data.transactions[0];
+    expect(tx.label).toBe('borrow');
+    expect(tx.direction).toBe('in');
+    expect(tx.amount).toBeCloseTo(5, 4);
+  });
+
+  it('emits direction=out for sends, with recipient', async () => {
+    mockFetchOnce([
+      makeRpcTx({
+        digest: '0xsendrec',
+        transferObjects: true,
+        balanceChanges: [
+          { owner: ADDR, coinType: USDC, amount: '-1000000' },
+          { owner: '0xfriend', coinType: USDC, amount: '1000000' },
+        ],
+      }),
+    ]);
+    const res = await transactionHistoryTool.call({ limit: 10 }, baseCtx);
+    const data = res.data as {
+      transactions: { amount?: number; asset?: string; direction?: string; recipient?: string }[];
+    };
+    const tx = data.transactions[0];
+    expect(tx.direction).toBe('out');
+    expect(tx.amount).toBeCloseTo(1, 4);
+    expect(tx.recipient).toBe('0xfriend');
+  });
+
   it('SUI-only balance changes do not trigger lending tiebreaker', async () => {
     /**
      * Gas-only SUI deltas appear on every tx. The tiebreaker explicitly

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
 import {
-  getDecimalsForCoinType,
-  resolveSymbol,
-  SUI_TYPE,
   classifyTransaction,
+  extractTransferDetails,
   type ClassifyBalanceChange,
+  type TxDirection,
 } from '@t2000/sdk';
 import { buildTool } from '../tool.js';
 import { requireAgent } from './utils.js';
@@ -39,15 +38,15 @@ interface TxRecord {
   amount?: number;
   asset?: string;
   recipient?: string;
+  /**
+   * [v0.46.2] Direction of the user's principal balance change on
+   * this tx (`'in'` → user received, `'out'` → user spent). Lets the
+   * card render the correct sign without parsing the textual label.
+   */
+  direction?: TxDirection;
   timestamp: number;
   date?: string;
   gasCost?: number;
-}
-
-function resolveOwner(owner: RpcBalanceChange['owner']): string | null {
-  if (typeof owner === 'object' && owner.AddressOwner) return owner.AddressOwner;
-  if (typeof owner === 'string') return owner;
-  return null;
 }
 
 function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
@@ -85,22 +84,7 @@ function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
   } catch { /* best effort */ }
 
   const changes = tx.balanceChanges ?? [];
-  const outflows = changes.filter((c) => resolveOwner(c.owner) === address && BigInt(c.amount) < 0n);
-  const inflows = changes.filter((c) => resolveOwner(c.owner) !== address && BigInt(c.amount) > 0n);
-  const primaryOutflow = outflows.filter((c) => c.coinType !== SUI_TYPE).sort((a, b) => Number(BigInt(a.amount) - BigInt(b.amount)))[0] ?? outflows[0];
-
-  let amount: number | undefined;
-  let asset: string | undefined;
-  let recipient: string | undefined;
-
-  if (primaryOutflow) {
-    const coinType = primaryOutflow.coinType;
-    const decimals = getDecimalsForCoinType(coinType);
-    amount = Math.abs(Number(BigInt(primaryOutflow.amount))) / 10 ** decimals;
-    asset = resolveSymbol(coinType);
-    const recipientChange = inflows.find((c) => c.coinType === coinType);
-    recipient = recipientChange ? resolveOwner(recipientChange.owner) ?? undefined : undefined;
-  }
+  const { amount, asset, recipient, direction } = extractTransferDetails(changes, address);
 
   const timestampMs = Number(tx.timestampMs ?? 0);
   const { action, label } = classifyTransaction(moveCallTargets, commandTypes, changes, address);
@@ -112,6 +96,7 @@ function parseRpcTx(tx: RpcTxBlock, address: string): TxRecord {
     amount,
     asset,
     recipient,
+    direction,
     timestamp: timestampMs,
     date: timestampMs > 0 ? new Date(timestampMs).toISOString() : undefined,
     gasCost,

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -60,8 +60,27 @@ export {
   fallbackLabel,
   refineLendingLabel,
   classifyTransaction,
+  extractTransferDetails,
 } from './wallet/classify.js';
-export type { ClassifyBalanceChange, ClassifyResult } from './wallet/classify.js';
+export type {
+  ClassifyBalanceChange,
+  ClassifyResult,
+  ExtractedTransfer,
+  TxDirection,
+} from './wallet/classify.js';
+/**
+ * RPC tx parsing helpers. Safe in the browser — they only do shape
+ * inspection / classification and do not import any Node-only modules.
+ * `queryHistory` and `queryTransaction` are not re-exported here
+ * because they take a Node `SuiJsonRpcClient`; consumers can build
+ * the same flow with `parseSuiRpcTx` + their own RPC fetch.
+ */
+export {
+  parseSuiRpcTx,
+  extractTxSender,
+  extractTxCommands,
+} from './wallet/history.js';
+export type { SuiRpcTxBlock } from './wallet/history.js';
 export {
   mistToSui,
   suiToMist,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -70,8 +70,22 @@ export {
   fallbackLabel,
   refineLendingLabel,
   classifyTransaction,
+  extractTransferDetails,
 } from './wallet/classify.js';
-export type { ClassifyBalanceChange, ClassifyResult } from './wallet/classify.js';
+export type {
+  ClassifyBalanceChange,
+  ClassifyResult,
+  ExtractedTransfer,
+  TxDirection,
+} from './wallet/classify.js';
+export {
+  parseSuiRpcTx,
+  extractTxSender,
+  extractTxCommands,
+  queryHistory,
+  queryTransaction,
+} from './wallet/history.js';
+export type { SuiRpcTxBlock } from './wallet/history.js';
 export {
   mistToSui,
   suiToMist,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -171,6 +171,15 @@ export interface TransactionRecord {
   amount?: number;
   asset?: string;
   recipient?: string;
+  /**
+   * Direction of the user's principal (non-gas) balance movement on
+   * this tx — `'out'` if they spent, `'in'` if they received.
+   * Computed from on-chain balance changes (NOT from `label`), so the
+   * card can render the correct sign even for opaque actions like
+   * `swap`/`router`. Undefined when no user balance change is
+   * detectable (e.g. pure read-only or admin txs).
+   */
+  direction?: 'in' | 'out';
   timestamp: number;
   gasCost?: number;
   gasMethod?: GasMethod;

--- a/packages/sdk/src/wallet/classify.test.ts
+++ b/packages/sdk/src/wallet/classify.test.ts
@@ -3,11 +3,12 @@ import {
   classifyAction,
   classifyLabel,
   classifyTransaction,
+  extractTransferDetails,
   fallbackLabel,
   refineLendingLabel,
   type ClassifyBalanceChange,
 } from './classify.js';
-import { SUI_TYPE } from '../token-registry.js';
+import { SUI_TYPE, USDC_TYPE } from '../token-registry.js';
 
 /**
  * Shared classifier tests. Mirrors the engine's `history-labels.test.ts`
@@ -22,7 +23,9 @@ import { SUI_TYPE } from '../token-registry.js';
  */
 
 const ADDR = '0xowner';
-const USDC = '0x2::usdc::USDC';
+// Use the canonical mainnet USDC type so getDecimalsForCoinType returns 6
+// and the bidirectional extractor produces realistic amounts in the tests.
+const USDC = USDC_TYPE;
 
 function bc(owner: string, coinType: string, amount: string): ClassifyBalanceChange {
   return { owner: { AddressOwner: owner }, coinType, amount };
@@ -79,8 +82,37 @@ describe('classifyLabel (fine-grained display)', () => {
     expect(classifyAction(['0xpkg::lending_core::entry_deposit'], ['MoveCall'])).toBe('lending');
   });
 
-  it('returns module name when no LABEL_PATTERNS match', () => {
+  it('returns module name only when the coarse action is also generic', () => {
+    // `spam_token` doesn't match any KNOWN_TARGETS (action='transaction')
+    // AND doesn't match any LABEL_PATTERNS, so the module name
+    // becomes the last-resort fallback.
     expect(classifyLabel(['0xpkg::spam_token::do'], ['MoveCall'])).toBe('spam_token');
+  });
+
+  it('returns the action bucket when LABEL_PATTERNS misses but action is specific', () => {
+    // Pre-v0.46.2 regression: Cetus aggregator emits a sequence of
+    // MoveCalls — `router::new_swap_context`, `cetus::swap`,
+    // `router::transfer_balance`, `router::confirm_swap`. The
+    // `cetus::swap` pattern correctly bucketed action='swap', but
+    // classifyLabel saw no LABEL_PATTERNS match and fell back to
+    // the FIRST MoveCall's module name = "router".
+    const cetusAggregatorTargets = [
+      '0xrouter::router::new_swap_context_v',
+      '0xpath::cetus::swap',
+      '0xrouter::router::transfer_balance',
+      '0xrouter::router::confirm_swap',
+    ];
+    expect(classifyLabel(cetusAggregatorTargets, ['MoveCall', 'MoveCall', 'MoveCall', 'MoveCall'])).toBe('swap');
+    expect(classifyLabel(['0xpkg::deepbook::place_order'], ['MoveCall'])).toBe('swap');
+    // Direct (non-aggregator) DEX calls are bucketed as swap too.
+    expect(classifyLabel(['0xpath::flowx_amm::swap'], ['MoveCall'])).toBe('swap');
+    expect(classifyLabel(['0xpath::aftermath::swap'], ['MoveCall'])).toBe('swap');
+  });
+
+  it('lending generic call falls back to "lending" not module name', () => {
+    // Generic NAVI entry without deposit/withdraw keyword — action
+    // bucket says 'lending'; refineLendingLabel handles direction.
+    expect(classifyLabel(['0xpkg::navi::entry_action'], ['MoveCall'])).toBe('lending');
   });
 
   it('returns on-chain when no MoveCalls and no transfer', () => {
@@ -174,7 +206,126 @@ describe('classifyTransaction (combined)', () => {
       ADDR,
     );
     expect(result.action).toBe('transaction');
+    // Action is generic 'transaction', so we surface the module name
+    // as a last-resort fallback instead of the literal "transaction".
     expect(result.label).toBe('unknown');
     expect(result.label).not.toBe('');
+  });
+
+  it('classifies Cetus aggregator router calls as swap (not "router")', () => {
+    // Real Cetus aggregator emits multiple MoveCalls per swap: a
+    // router setup + per-DEX leg + router cleanup. The first target
+    // is the router glue, NOT the DEX leg, so the classifier must
+    // not return 'router' from the module fallback.
+    const result = classifyTransaction(
+      [
+        '0xrouter::router::new_swap_context_v',
+        '0xpath::cetus::swap',
+        '0xrouter::router::transfer_balance',
+        '0xrouter::router::confirm_swap',
+      ],
+      ['MoveCall', 'MoveCall', 'MoveCall', 'MoveCall'],
+      [
+        bc(ADDR, USDC, '-1000000'),
+        { owner: { AddressOwner: '0xpool' }, coinType: USDC, amount: '1000000' },
+      ],
+      ADDR,
+    );
+    expect(result.action).toBe('swap');
+    expect(result.label).toBe('swap');
+  });
+});
+
+describe('extractTransferDetails (bidirectional)', () => {
+  it('returns outflow for a send: user USDC -1, recipient USDC +1', () => {
+    const out = extractTransferDetails(
+      [
+        bc(ADDR, USDC, '-1000000'),
+        { owner: { AddressOwner: '0xfriend' }, coinType: USDC, amount: '1000000' },
+      ],
+      ADDR,
+    );
+    expect(out.amount).toBe(1);
+    expect(out.asset).toBe('USDC');
+    expect(out.direction).toBe('out');
+    expect(out.recipient).toBe('0xfriend');
+  });
+
+  it('returns inflow for a withdraw: user USDC +10 (no SUI outflow, sponsored gas)', () => {
+    // Pre-v0.46.2 regression: withdraws / borrows / claims showed
+    // no amount on the card because the old extractor only looked
+    // at the user's outflows.
+    const out = extractTransferDetails([bc(ADDR, USDC, '10000000')], ADDR);
+    expect(out.amount).toBe(10);
+    expect(out.asset).toBe('USDC');
+    expect(out.direction).toBe('in');
+    expect(out.recipient).toBeUndefined();
+  });
+
+  it('returns inflow for a borrow: user USDC +5 with NAVI -5', () => {
+    const out = extractTransferDetails(
+      [
+        bc(ADDR, USDC, '5000000'),
+        { owner: { AddressOwner: '0xnavi' }, coinType: USDC, amount: '-5000000' },
+      ],
+      ADDR,
+    );
+    expect(out.amount).toBe(5);
+    expect(out.direction).toBe('in');
+  });
+
+  it('prefers non-SUI principal: user USDC -1, user SUI +0.5 (swap output)', () => {
+    // Cetus swap USDC→SUI: user loses USDC, gains SUI. SUI gain is
+    // the actual swap output but USDC loss is the user's intent —
+    // pick the larger non-SUI principal so the card reads "−1 USDC".
+    const out = extractTransferDetails(
+      [
+        bc(ADDR, USDC, '-1000000'),
+        bc(ADDR, SUI_TYPE, '500000000'),
+      ],
+      ADDR,
+    );
+    expect(out.amount).toBe(1);
+    expect(out.asset).toBe('USDC');
+    expect(out.direction).toBe('out');
+  });
+
+  it('falls back to SUI when only SUI changes exist (e.g. native send)', () => {
+    const out = extractTransferDetails(
+      [
+        bc(ADDR, SUI_TYPE, '-2000000000'),
+        { owner: { AddressOwner: '0xfriend' }, coinType: SUI_TYPE, amount: '2000000000' },
+      ],
+      ADDR,
+    );
+    expect(out.amount).toBe(2);
+    expect(out.asset).toBe('SUI');
+    expect(out.direction).toBe('out');
+    expect(out.recipient).toBe('0xfriend');
+  });
+
+  it('returns empty when there are no balance changes', () => {
+    expect(extractTransferDetails([], ADDR)).toEqual({});
+    expect(extractTransferDetails(undefined, ADDR)).toEqual({});
+  });
+
+  it('returns empty when no user balance changes are present', () => {
+    const out = extractTransferDetails(
+      [{ owner: { AddressOwner: '0xother' }, coinType: USDC, amount: '5000000' }],
+      ADDR,
+    );
+    expect(out).toEqual({});
+  });
+
+  it('does not set recipient on inflows (no symmetric outflow exists)', () => {
+    const out = extractTransferDetails(
+      [
+        bc(ADDR, USDC, '10000000'),
+        { owner: { AddressOwner: '0xnavi' }, coinType: USDC, amount: '-10000000' },
+      ],
+      ADDR,
+    );
+    expect(out.direction).toBe('in');
+    expect(out.recipient).toBeUndefined();
   });
 });

--- a/packages/sdk/src/wallet/classify.ts
+++ b/packages/sdk/src/wallet/classify.ts
@@ -9,19 +9,38 @@
  * already producing fine-grained labels.
  */
 
-import { SUI_TYPE } from '../token-registry.js';
+import { getDecimalsForCoinType, resolveSymbol, SUI_TYPE } from '../token-registry.js';
 
 /**
  * Coarse action bucket — one of `'send' | 'lending' | 'swap' |
  * 'transaction'`. Used by the ACI `action` filter on the
  * `transaction_history` tool. STABLE: downstream queries depend on
  * exactly these values.
+ *
+ * Order matters: more specific buckets first. Lending patterns precede
+ * swap patterns so a NAVI `::swap` helper (if one ever existed) would
+ * still bucket as lending.
  */
 export const KNOWN_TARGETS: readonly [RegExp, string][] = [
   [/::suilend|::obligation/, 'lending'],
   [/::navi|::lending_core|::incentive_v\d+|::oracle_pro/, 'lending'],
-  [/::cetus|::pool/, 'swap'],
-  [/::deepbook/, 'swap'],
+  /**
+   * DEX modules — both direct calls and aggregator legs. The Cetus
+   * aggregator dispatches through a per-DEX module (e.g.
+   * `cetus::swap`, `flowx_amm::swap`, `aftermath::swap`, …) plus
+   * router glue functions. We list every DEX module the aggregator
+   * supports today so a single-DEX call still classifies cleanly.
+   */
+  [/::cetus(?:_dlmm)?::|::pool::|::deepbook|::flowx_(?:amm|clmm)::|::kriya_(?:amm|clmm)::|::turbos::|::aftermath::|::afsui::|::bluefin::|::bluemove::|::ferra_(?:clmm|dlmm)::|::haedal_hmm::|::hasui::|::hawal::|::magma::|::momentum::|::obric::|::springsui::|::steamm_cpmm::|::fullsail::|::alphafi::|::volo_swap::/, 'swap'],
+  /**
+   * Cetus aggregator router glue. These are the swap-context and
+   * balance-handling helpers the aggregator emits around per-DEX
+   * legs. Without this entry a tx that ONLY had router calls
+   * (theoretically possible for setup/cleanup) would slip through;
+   * in practice these always coexist with a DEX leg, but the entry
+   * is cheap insurance.
+   */
+  [/::router::(?:new_swap_context(?:_v)?|confirm_swap|transfer_balance|take_balance|transfer_or_destroy_coin)/, 'swap'],
   [/::transfer::public_transfer/, 'send'],
 ];
 
@@ -71,12 +90,15 @@ export function classifyAction(targets: string[], commandTypes: string[]): strin
 }
 
 /**
- * Fallback label when no `LABEL_PATTERNS` match.
+ * Last-resort fallback when neither `LABEL_PATTERNS` nor the action
+ * bucket produces something useful.
  *
- * Returns the first MoveCall's *module* name (e.g. "navi", "cetus",
- * "spam") so the card shows something more useful than the literal
- * word "transaction". When no MoveCall exists, returns 'on-chain'
- * instead — strictly more informative than "transaction".
+ * Returns the first MoveCall's *module* name (e.g. "navi", "spam") so
+ * the card shows something better than the literal word "transaction".
+ * When no MoveCall exists, returns 'on-chain'.
+ *
+ * Note: callers should prefer `classifyLabel` which now layers
+ * pattern-match → coarse action → module name (see commentary there).
  */
 export function fallbackLabel(targets: string[]): string {
   if (!targets.length) return 'on-chain';
@@ -86,6 +108,20 @@ export function fallbackLabel(targets: string[]): string {
   return 'on-chain';
 }
 
+/**
+ * Three-tier label resolution for the transaction history card:
+ *   1. Specific keyword match in `LABEL_PATTERNS` ("deposit",
+ *      "payment_link", …).
+ *   2. Coarse action bucket from `classifyAction` ("swap", "send",
+ *      "lending") — prevents leaking opaque internal module names like
+ *      "router" (Cetus aggregator) or "cross_swap" (third-party DEX
+ *      aggregators) for txs that we already classified as a swap.
+ *   3. Module name from the first MoveCall (`fallbackLabel`) — only
+ *      used when the action bucket itself is the generic "transaction".
+ *
+ * Pre-v0.46.2 we skipped tier 2, so swaps showed labels like "router",
+ * "cross_swap", "scallop_router", etc. instead of the clean "swap".
+ */
 export function classifyLabel(targets: string[], commandTypes: string[]): string {
   for (const target of targets) {
     for (const [pattern, label] of LABEL_PATTERNS) {
@@ -93,6 +129,8 @@ export function classifyLabel(targets: string[], commandTypes: string[]): string
     }
   }
   if (commandTypes.includes('TransferObjects') && !commandTypes.includes('MoveCall')) return 'send';
+  const action = classifyAction(targets, commandTypes);
+  if (action !== 'transaction') return action;
   return fallbackLabel(targets);
 }
 
@@ -154,4 +192,93 @@ export function classifyTransaction(
   const baseLabel = classifyLabel(moveCallTargets, commandTypes);
   const label = refineLendingLabel(action, baseLabel, moveCallTargets, balanceChanges, address);
   return { action, label };
+}
+
+/**
+ * Direction of the user's net non-gas movement for this transaction.
+ *
+ *   - `'out'` — the user spent the asset (sends, deposits, repays,
+ *     swap-in, payment-link payouts).
+ *   - `'in'`  — the user received the asset (withdraws, borrows,
+ *     swap-out, claims, deposits credited from another wallet).
+ *
+ * Used by the `TransactionHistoryCard` to choose the `+`/`−` sign and
+ * color. Direction is computed from the actual on-chain balance change
+ * — never from the textual label — so opaque action types (`'router'`,
+ * `'cross_swap'`, …) still render the correct sign.
+ */
+export type TxDirection = 'in' | 'out';
+
+export interface ExtractedTransfer {
+  amount?: number;
+  asset?: string;
+  recipient?: string;
+  direction?: TxDirection;
+}
+
+/**
+ * Extracts the principal amount/asset/direction for a transaction
+ * from its `balanceChanges`.
+ *
+ * Algorithm:
+ *   1. Restrict to the user's *own* balance changes.
+ *   2. Prefer non-SUI changes (gas-only SUI deltas are noise).
+ *   3. Pick the change with the largest absolute value — the "principal".
+ *   4. If no non-SUI change exists, fall back to the largest SUI change
+ *      so pure-SUI transfers (stake/unstake/native send) still render.
+ *   5. Direction follows the sign of the principal.
+ *   6. Recipient is set only on outflows, by finding a matching inflow
+ *      on a *non-user* address with the same coinType.
+ *
+ * Pre-v0.46.2 this function only inspected outflows, so withdraws,
+ * borrows, claims, swap-receives and payment-link receives all
+ * rendered with no amount on the rich card (and with a wrong sign,
+ * because the card guessed direction from the label string).
+ */
+export function extractTransferDetails(
+  changes: ClassifyBalanceChange[] | undefined,
+  sender: string,
+): ExtractedTransfer {
+  if (!changes || changes.length === 0) return {};
+
+  const userChanges = changes.filter((c) => resolveOwner(c.owner) === sender);
+  if (userChanges.length === 0) return {};
+
+  const userNonSui = userChanges.filter((c) => c.coinType !== SUI_TYPE);
+  const pool = userNonSui.length > 0 ? userNonSui : userChanges;
+
+  let primary = pool[0];
+  let primaryAbs = bigintAbs(BigInt(primary.amount));
+  for (let i = 1; i < pool.length; i++) {
+    const abs = bigintAbs(BigInt(pool[i].amount));
+    if (abs > primaryAbs) {
+      primary = pool[i];
+      primaryAbs = abs;
+    }
+  }
+
+  const raw = BigInt(primary.amount);
+  if (raw === 0n) return {};
+
+  const decimals = getDecimalsForCoinType(primary.coinType);
+  const amount = Number(primaryAbs) / 10 ** decimals;
+  const asset = resolveSymbol(primary.coinType);
+  const direction: TxDirection = raw < 0n ? 'out' : 'in';
+
+  let recipient: string | undefined;
+  if (direction === 'out') {
+    const recipientChange = changes.find(
+      (c) =>
+        resolveOwner(c.owner) !== sender &&
+        c.coinType === primary.coinType &&
+        BigInt(c.amount) > 0n,
+    );
+    recipient = recipientChange ? resolveOwner(recipientChange.owner) ?? undefined : undefined;
+  }
+
+  return { amount, asset, recipient, direction };
+}
+
+function bigintAbs(n: bigint): bigint {
+  return n < 0n ? -n : n;
 }

--- a/packages/sdk/src/wallet/history.ts
+++ b/packages/sdk/src/wallet/history.ts
@@ -1,7 +1,10 @@
 import type { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
 import type { TransactionRecord } from '../types.js';
-import { getDecimalsForCoinType, resolveSymbol, SUI_TYPE } from '../token-registry.js';
-import { classifyTransaction, type ClassifyBalanceChange } from './classify.js';
+import {
+  classifyTransaction,
+  extractTransferDetails,
+  type ClassifyBalanceChange,
+} from './classify.js';
 
 export async function queryHistory(
   client: SuiJsonRpcClient,
@@ -15,7 +18,7 @@ export async function queryHistory(
     order: 'descending',
   });
 
-  return txns.data.map((tx) => parseTxRecord(tx as unknown as TxBlock, address));
+  return txns.data.map((tx) => parseTxRecord(tx as unknown as SuiRpcTxBlock, address));
 }
 
 export async function queryTransaction(
@@ -28,13 +31,19 @@ export async function queryTransaction(
       digest,
       options: { showEffects: true, showInput: true, showBalanceChanges: true },
     });
-    return parseTxRecord(tx as unknown as TxBlock, senderAddress);
+    return parseTxRecord(tx as unknown as SuiRpcTxBlock, senderAddress);
   } catch {
     return null;
   }
 }
 
-interface TxBlock {
+/**
+ * Shape of a transaction block as returned by `suix_queryTransactionBlocks`
+ * with `showEffects | showInput | showBalanceChanges` enabled. Exported so
+ * downstream consumers (audric dashboard `/api/history`, `/api/activity`,
+ * etc.) can type their RPC calls without redeclaring the structure.
+ */
+export interface SuiRpcTxBlock {
   digest: string;
   timestampMs?: string;
   transaction?: unknown;
@@ -42,7 +51,51 @@ interface TxBlock {
   balanceChanges?: ClassifyBalanceChange[];
 }
 
-function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
+/**
+ * Convert a single Sui RPC transaction block to a {@link TransactionRecord}
+ * using the canonical (shared) classifier and balance-change extractor.
+ *
+ * This is the single source of truth for transaction parsing across the
+ * agent-tool path AND the dashboard-API path. Use it instead of writing
+ * a bespoke parser per surface.
+ *
+ * @param tx      Raw RPC tx block (must include `effects`, `input`, `balanceChanges`).
+ * @param address Wallet address whose perspective we're parsing from.
+ */
+export function parseSuiRpcTx(tx: SuiRpcTxBlock, address: string): TransactionRecord {
+  return parseTxRecord(tx, address);
+}
+
+/**
+ * Extract the sender (signer) address from a raw RPC tx block.
+ * Returns `null` if the block shape is unexpected.
+ */
+export function extractTxSender(txBlock: unknown): string | null {
+  try {
+    if (!txBlock || typeof txBlock !== 'object') return null;
+    const data = 'data' in txBlock ? (txBlock as Record<string, unknown>).data : undefined;
+    if (!data || typeof data !== 'object') return null;
+    return ((data as Record<string, unknown>).sender as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract MoveCall targets (`<pkg>::<module>::<function>`) and the
+ * sequence of programmable-transaction command types (e.g. `MoveCall`,
+ * `TransferObjects`) from a raw RPC tx block. Tolerates both the
+ * legacy `inner.transactions` field and the newer `inner.commands`
+ * field.
+ */
+export function extractTxCommands(txBlock: unknown): {
+  moveCallTargets: string[];
+  commandTypes: string[];
+} {
+  return extractCommands(txBlock);
+}
+
+function parseTxRecord(tx: SuiRpcTxBlock, address: string): TransactionRecord {
   const gasUsed = tx.effects?.gasUsed;
   const gasCost = gasUsed
     ? (Number(gasUsed.computationCost) +
@@ -53,7 +106,7 @@ function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
 
   const { moveCallTargets, commandTypes } = extractCommands(tx.transaction);
   const balanceChanges = tx.balanceChanges ?? [];
-  const { amount, asset, recipient } = extractTransferDetails(balanceChanges, address);
+  const { amount, asset, recipient, direction } = extractTransferDetails(balanceChanges, address);
   const { action, label } = classifyTransaction(
     moveCallTargets,
     commandTypes,
@@ -68,42 +121,10 @@ function parseTxRecord(tx: TxBlock, address: string): TransactionRecord {
     amount,
     asset,
     recipient,
+    direction,
     timestamp: Number(tx.timestampMs ?? 0),
     gasCost,
   };
-}
-
-function resolveOwner(owner: ClassifyBalanceChange['owner']): string | null {
-  if (typeof owner === 'object' && owner.AddressOwner) return owner.AddressOwner;
-  if (typeof owner === 'string') return owner;
-  return null;
-}
-
-function extractTransferDetails(
-  changes: ClassifyBalanceChange[] | undefined,
-  sender: string,
-): { amount?: number; asset?: string; recipient?: string } {
-  if (!changes || changes.length === 0) return {};
-
-  const outflows = changes.filter((c) => resolveOwner(c.owner) === sender && BigInt(c.amount) < 0n);
-  const inflows = changes.filter((c) => resolveOwner(c.owner) !== sender && BigInt(c.amount) > 0n);
-
-  const primaryOutflow = outflows
-    .filter((c) => c.coinType !== SUI_TYPE)
-    .sort((a, b) => Number(BigInt(a.amount) - BigInt(b.amount)))[0]
-    ?? outflows[0];
-
-  if (!primaryOutflow) return {};
-
-  const coinType = primaryOutflow.coinType;
-  const decimals = getDecimalsForCoinType(coinType);
-  const amount = Math.abs(Number(BigInt(primaryOutflow.amount))) / 10 ** decimals;
-  const asset = resolveSymbol(coinType);
-
-  const recipientChange = inflows.find((c) => c.coinType === coinType);
-  const recipient = recipientChange ? resolveOwner(recipientChange.owner) ?? undefined : undefined;
-
-  return { amount, asset, recipient };
 }
 
 interface CommandInfo {


### PR DESCRIPTION
## Summary

Fixes the three remaining classification bugs the user surfaced after the v0.46.1 deploy:

1. **Cetus aggregator swaps mislabeled \"router\"** — `KNOWN_TARGETS` only matched `::cetus|::pool`, so the aggregator's per-DEX legs (`flowx_amm`, `aftermath`, `kriya`, …) and router-glue functions (`new_swap_context`, `confirm_swap`, …) fell through. `classifyAction` returned `'transaction'` and `classifyLabel` printed the first MoveCall's module name = `\"router\"`.
2. **Withdraw / borrow rows missing amounts** — `extractTransferDetails` only inspected user *outflows*, so any inflow-principal tx (sponsored-gas withdraws, borrows, receives) showed no amount and the wrong sign.
3. **Audric dashboard had its OWN duplicate classifier** — `apps/web/app/api/history/route.ts` and `…/api/activity/route.ts` each maintained their own `KNOWN_TARGETS` + `classifyAction` + inflow/outflow extraction. They diverged from the engine on Cetus router patterns AND `/api/history` only read `inner.commands` (missing the legacy `inner.transactions` field — same bug we patched in the engine in v0.46.1).

## What changed (this PR — t2000)

- **`packages/sdk/src/wallet/classify.ts`** — expanded `KNOWN_TARGETS` to cover every Cetus aggregator DEX + router glue function. Pulled `extractTransferDetails` into the shared module, made it bidirectional, added explicit `direction: 'in' | 'out'` return.
- **`packages/sdk/src/types.ts`** — `TransactionRecord.direction?: 'in' | 'out'`.
- **`packages/sdk/src/wallet/history.ts`** — exports `parseSuiRpcTx`, `extractTxSender`, `extractTxCommands`, `SuiRpcTxBlock` so audric (and any other consumer) stops re-implementing the parser.
- **`packages/engine/src/tools/history.ts`** — uses the shared extractor + propagates `direction`.
- **`packages/sdk/src/index.ts` + `browser.ts`** — re-export the new helpers.
- **Tests** — 12 new cases in `classify.test.ts` (bidirectional extraction + Cetus aggregator pattern) + regression tests in `history-labels.test.ts` (swap labels, sponsored-gas withdraw/borrow direction+amount, outbound send).

## Paired audric PR

Audric's `/api/history` and `/api/activity` routes have been refactored to use the new shared SDK exports — both bespoke classifiers deleted (~250 LOC removed). Will land after `0.46.2` publishes.

## Test plan

- [x] `pnpm test` — all 8 packages green (313 engine tests, 34 classify tests)
- [x] `pnpm --filter @t2000/sdk --filter @t2000/engine typecheck` — clean
- [ ] Live verify after deploy: `show me all transactions` displays \"Swap\" (not \"router\") for Cetus txs, with correct +/− on withdraws and borrows
- [ ] Dashboard activity feed shows the same labels as the chat card (parser parity)

Made with [Cursor](https://cursor.com)