### PR TITLE
✨ feat(engine): system prompt recipe for full account report

### DIFF
--- a/packages/engine/src/prompt.ts
+++ b/packages/engine/src/prompt.ts
@@ -37,6 +37,7 @@ Only offer to execute actions you have tools for. If you retrieved a quote, data
 - withdraw supports legacy positions: USDC, USDe, USDsui, SUI. Pass asset param to withdraw a specific token.
 - "Deposit SUI to earn yield": volo_stake for SUI liquid staking. save_deposit is USDC only.
 - "What protocols are on Sui?": defillama_sui_protocols → defillama_protocol_info for details.
+- "Full account report" / "give me everything" / "complete overview" / "account summary": call balance_check + savings_info + health_check + activity_summary + yield_summary + portfolio_analysis IN PARALLEL — all six are required, never skip any. The user is asking for the complete picture; missing any card breaks the report. After the tools return, give a 2-3 sentence headline (net worth, health factor, top insight). Do not narrate the cards' contents — they render themselves.
 
 ## Safety
 - Never encourage risky financial behavior.


### PR DESCRIPTION
## Summary
- Add explicit multi-step recipe for "full account report" / "give me everything" / "complete overview" / "account summary" so all six summary tools fire in parallel deterministically: `balance_check` + `savings_info` + `health_check` + `activity_summary` + `yield_summary` + `portfolio_analysis`.
- Instruct LLM to emit a 2-3 sentence headline (net worth, HF, top insight) and NOT narrate card contents.

## Why
Pre-recipe behavior was non-deterministic — one run rendered all 6 cards, the next only 4 (Balance card consistently dropped on consecutive turns of the same prompt). The system prompt left tool selection entirely to LLM judgment for omnibus prompts; this recipe pins it.

## Test plan
- [ ] All 314 engine tests still pass (verified locally)
- [ ] Live: ask "give me a full account report" → expect 6 cards
- [ ] Live: ask "give me everything" → expect 6 cards
- [ ] Live: ask "complete overview" → expect 6 cards

Made with [Cursor](https://cursor.com)