### PR TITLE
✨ feat(skills): account_report recipe — deterministic 6-card snapshot

### DIFF
--- a/packages/engine/src/prompt.ts
+++ b/packages/engine/src/prompt.ts
@@ -37,7 +37,7 @@ Only offer to execute actions you have tools for. If you retrieved a quote, data
 - withdraw supports legacy positions: USDC, USDe, USDsui, SUI. Pass asset param to withdraw a specific token.
 - "Deposit SUI to earn yield": volo_stake for SUI liquid staking. save_deposit is USDC only.
 - "What protocols are on Sui?": defillama_sui_protocols → defillama_protocol_info for details.
-- "Full account report" / "give me everything" / "complete overview" / "account summary": call balance_check + savings_info + health_check + activity_summary + yield_summary + portfolio_analysis IN PARALLEL — all six are required, never skip any. The user is asking for the complete picture; missing any card breaks the report. After the tools return, give a 2-3 sentence headline (net worth, health factor, top insight). Do not narrate the cards' contents — they render themselves.
+- "Full account report" / "account summary" / "give me everything" / "complete overview": triggers the \`account_report\` recipe — when the recipe block appears, follow EVERY step including all six tool calls. Each step renders a distinct rich card; skipping a step means a missing card.
 
 ## Safety
 - Never encourage risky financial behavior.

--- a/t2000-skills/recipes/account-report.yaml
+++ b/t2000-skills/recipes/account-report.yaml
@@ -1,0 +1,59 @@
+name: account_report
+description: Render a complete account snapshot — six rich cards covering wallet, savings, debt, activity, yield, and portfolio
+triggers:
+  - "full report"
+  - "full account report"
+  - "account report"
+  - "account summary"
+  - "give me everything"
+  - "complete overview"
+  - "show me everything"
+  - "everything about my account"
+  - "full overview"
+
+steps:
+  - name: render_balance_card
+    tool: balance_check
+    purpose: Render the BALANCE CHECK card (wallet, savings, debt, total)
+    gate: none
+    notes: "REQUIRED — even if portfolio_analysis returns the same data, this tool call is what renders the BALANCE CHECK card. Skipping it = missing card."
+
+  - name: render_savings_card
+    tool: savings_info
+    purpose: Render the SAVINGS INFO card (positions, supply/borrow APY, daily earnings)
+    gate: none
+    notes: "REQUIRED — renders the SAVINGS INFO card with per-position breakdown."
+
+  - name: render_health_card
+    tool: health_check
+    purpose: Render the HEALTH CHECK card (HF, supplied, borrowed, max borrow, liq threshold)
+    gate: none
+    notes: "REQUIRED — renders the HEALTH CHECK card."
+
+  - name: render_activity_card
+    tool: activity_summary
+    purpose: Render the ACTIVITY SUMMARY card (monthly tx breakdown by category)
+    gate: none
+    notes: "REQUIRED — renders the ACTIVITY SUMMARY card."
+
+  - name: render_yield_card
+    tool: yield_summary
+    purpose: Render the YIELD SUMMARY card (today/week/month/all-time earnings, APY, projected yearly)
+    gate: none
+    notes: "REQUIRED — renders the YIELD SUMMARY card."
+
+  - name: render_portfolio_card
+    tool: portfolio_analysis
+    purpose: Render the PORTFOLIO ANALYSIS card (allocation %, week change, insights)
+    gate: none
+    notes: "REQUIRED — renders the PORTFOLIO ANALYSIS card."
+
+  - name: write_headline
+    purpose: After all six cards render, write a 2-3 sentence headline summarizing net worth, health factor, and the single biggest opportunity
+    gate: none
+    rules:
+      - "Lead with net worth and weekly change."
+      - "Mention health factor in one phrase."
+      - "End with the single most actionable insight (idle USDC, debt, etc)."
+      - "Do NOT narrate the cards' contents — they render themselves. Do NOT list asset percentages, APYs, or savings positions in prose."
+      - "Maximum 3 sentences total."


### PR DESCRIPTION
## Summary
Adds an \`account_report\` recipe so prompts like "full report" / "give me everything" / "complete overview" / "account summary" deterministically fire all six summary tools. Each step renders a distinct rich card — skipping any = missing card.

## Why a recipe (not a prompt bullet)
v0.46.3 added a bullet to prompt.ts but the LLM kept ignoring it. Production rendered 3 of 6 cards because \`portfolio_analysis\` returns overlapping data (totalValue / walletValue / savingsValue / debtValue / healthFactor / allocations / weekChange / savingsApy / dailyEarning), so the LLM "intelligently" deduped.

Recipes inject a prominent \`## Active Recipe:\` block when triggers match — much stronger than a bullet buried under "Multi-step flows". Each step's \`notes:\` field explicitly explains that the tool call IS what renders the card, even when data overlaps.

## Trigger coverage verified locally
- ✓ "Give me a full account report"
- ✓ "give me everything"
- ✓ "complete overview"
- ✓ "account summary"
- ✓ "full overview"
- ✓ "show me everything"
- ✗ "show me all transactions" (correctly no match)
- ✗ "whats my balance" (correctly no match)

## Headline rules pinned
2-3 sentences max, lead with net worth + weekly change, mention HF in one phrase, end with one actionable insight, do NOT narrate card contents in prose. Prevents the markdown-table dump regression that v1.4/v1.5 worked to suppress.

## Companion PR
Audric's web app embeds these YAMLs inline in \`lib/engine/recipes.ts\` (serverless can't read filesystem recipes); a companion PR adds the same recipe there.

## Test plan
- [x] All 314 engine tests pass locally
- [x] Recipe trigger matcher returns expected results
- [ ] Live: "Give me a full account report" → expect 6 cards
- [ ] Live: "give me everything" → expect 6 cards
- [ ] Live: "complete overview" → expect 6 cards

Made with [Cursor](https://cursor.com)