### PR TITLE
🐛 fix(engine): pre-spec-2 perf + routing fixes from baseline metrics

### DIFF
--- a/packages/engine/src/__tests__/classify-effort.test.ts
+++ b/packages/engine/src/__tests__/classify-effort.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { classifyEffort } from '../classify-effort.js';
+import type { Recipe } from '../recipes/index.js';
+
+const SONNET = 'claude-sonnet-4-6';
+const OPUS = 'claude-opus-4-6';
+
+function recipe(name: string, steps: number): Recipe {
+  return {
+    name,
+    description: `${name} test recipe`,
+    triggers: [],
+    steps: Array.from({ length: steps }, (_, i) => ({
+      name: `step${i}`,
+      purpose: 'test',
+    })),
+  } as unknown as Recipe;
+}
+
+describe('classifyEffort — post-0.47 routing', () => {
+  describe('low-effort (Haiku) routing', () => {
+    it('routes pure single-fact lookups to low', () => {
+      expect(classifyEffort(SONNET, 'whats my balance', null, 0)).toBe('low');
+      expect(classifyEffort(SONNET, 'what is the rate', null, 0)).toBe('low');
+      expect(classifyEffort(SONNET, 'check the price', null, 0)).toBe('low');
+      expect(classifyEffort(SONNET, 'apy', null, 0)).toBe('low');
+      expect(classifyEffort(SONNET, 'hf', null, 0)).toBe('low');
+    });
+
+    it('routes idle chitchat to low (no action keywords)', () => {
+      expect(classifyEffort(SONNET, 'hello', null, 0)).toBe('low');
+      expect(classifyEffort(SONNET, 'thanks', null, 0)).toBe('low');
+    });
+  });
+
+  describe('CRITICAL — broad-synthesis queries must NOT go to low', () => {
+    it('"show me X" queries are not low (Haiku loops on multi-record synthesis)', () => {
+      expect(classifyEffort(SONNET, 'show me all transactions', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'show me my history', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'show me everything', null, 0)).not.toBe('low');
+    });
+
+    it('"history" / "list" / "all" queries are not low', () => {
+      expect(classifyEffort(SONNET, 'transaction history', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'list my positions', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'all my savings', null, 0)).not.toBe('low');
+    });
+
+    it('"full report" / "summary" queries are not low', () => {
+      expect(classifyEffort(SONNET, 'give me a full report', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'account summary', null, 0)).not.toBe('low');
+      expect(classifyEffort(SONNET, 'portfolio breakdown', null, 0)).not.toBe('low');
+    });
+  });
+
+  describe('recipe gating — any recipe means at least medium', () => {
+    it('matched recipe with 1 step → medium (not low, even with simple wording)', () => {
+      expect(classifyEffort(SONNET, 'balance', recipe('check_balance', 1), 0)).toBe('medium');
+    });
+
+    it('matched recipe with 3+ steps → high', () => {
+      expect(classifyEffort(SONNET, 'check', recipe('account_report', 7), 0)).toBe('high');
+      expect(classifyEffort(SONNET, 'whatever', recipe('multi_step', 5), 0)).toBe('high');
+    });
+
+    it('safe_borrow / bulk_mail → high regardless of step count', () => {
+      expect(classifyEffort(SONNET, 'borrow', recipe('safe_borrow', 1), 0)).toBe('high');
+      expect(classifyEffort(SONNET, 'send', recipe('bulk_mail', 1), 0)).toBe('high');
+    });
+  });
+
+  describe('write actions in active session → high', () => {
+    it('action verbs after prior write → high', () => {
+      expect(classifyEffort(SONNET, 'borrow $100', null, 1)).toBe('high');
+      expect(classifyEffort(SONNET, 'withdraw 50 USDC', null, 1)).toBe('high');
+      expect(classifyEffort(SONNET, 'send to alice', null, 1)).toBe('high');
+      expect(classifyEffort(SONNET, 'swap SUI for USDC', null, 2)).toBe('high');
+    });
+
+    it('action verbs without prior write → medium (single write, fresh session)', () => {
+      expect(classifyEffort(SONNET, 'borrow $100', null, 0)).toBe('medium');
+      expect(classifyEffort(SONNET, 'withdraw 50 USDC', null, 0)).toBe('medium');
+    });
+  });
+
+  describe('opus-4-6 max routing', () => {
+    it('rebalance / DCA / close-position → max (opus only)', () => {
+      expect(classifyEffort(OPUS, 'rebalance my portfolio', null, 0)).toBe('max');
+      expect(classifyEffort(OPUS, 'dca setup for SUI', null, 0)).toBe('max');
+      expect(classifyEffort(OPUS, 'close my long position', null, 0)).toBe('max');
+    });
+
+    it('rebalance keywords on non-opus model → not max (falls through to medium/high)', () => {
+      const result = classifyEffort(SONNET, 'rebalance my portfolio', null, 0);
+      expect(result).not.toBe('max');
+    });
+  });
+});

--- a/packages/engine/src/classify-effort.ts
+++ b/packages/engine/src/classify-effort.ts
@@ -27,8 +27,19 @@ export function classifyEffort(
   if (matchedRecipe?.name === 'safe_borrow' || matchedRecipe?.name === 'bulk_mail') return 'high';
   if (sessionWriteCount > 0 && /borrow|withdraw|send|swap/i.test(msg)) return 'high';
 
-  if (/balance|rate|how much|what is|check|history|show|price/i.test(msg)) return 'low';
-  if (!matchedRecipe && !/deposit|send|swap|borrow|withdraw|save|pay/i.test(msg)) return 'low';
+  // Any matched recipe means multi-step tool work — never route to Haiku
+  // regardless of message wording. Haiku struggles with the synthesis these
+  // recipes require and ends up looping through more tool rounds than Sonnet,
+  // costing more in practice. (Confirmed by 0.46.x TurnMetrics baseline:
+  // low-effort Haiku turns averaged $0.040 vs $0.017 for medium-effort Sonnet.)
+  if (matchedRecipe) return 'medium';
+
+  // Pure simple lookups — single-fact questions Haiku handles well.
+  // Explicitly excludes `show|history|all|list|everything` which imply
+  // multi-record synthesis (the original regex sent these to Haiku and
+  // they bottomed out the cost/latency curves).
+  if (/\b(balance|rate|how much|what is|check|price|apy|hf)\b/i.test(msg)) return 'low';
+  if (!/\b(deposit|send|swap|borrow|withdraw|save|pay|transfer|show|history|all|list|everything|report|summary|breakdown)\b/i.test(msg)) return 'low';
 
   return 'medium';
 }

--- a/packages/engine/src/defillama-prices.ts
+++ b/packages/engine/src/defillama-prices.ts
@@ -2,33 +2,51 @@ const DEFILLAMA_PRICES_URL = 'https://coins.llama.fi/prices/current';
 const CACHE_TTL = 60_000;
 
 let cache: { prices: Record<string, number>; ts: number } | null = null;
-let pendingRequest: Promise<Record<string, number>> | null = null;
+// Per-missing-set in-flight dedupe. The previous global `pendingRequest` would
+// return stale results to a caller asking for a different coin set; this
+// variant keys by the sorted missing-coins signature so concurrent identical
+// requests (e.g. parallel `account_report` tools) coalesce, while distinct
+// requests still fire independently.
+const pendingFetches = new Map<string, Promise<Record<string, number>>>();
 
 /**
  * Batch-fetch USD prices for Sui coin types from DefiLlama.
  * Returns a map of `coinType -> usdPrice`. Tokens not found return no entry.
- * Results are cached for 60s. Free API, no auth required.
+ *
+ * Cache behavior (post-0.47): merge-on-miss. If the cache is valid but missing
+ * a few requested coin types, we fetch ONLY the missing ones and merge them
+ * into the cached map — instead of throwing the entire cache away. This is
+ * the common path when a wallet adds one new memecoin to a portfolio that
+ * already has USDC/SUI prices cached. Saves ~0.5–1.5s on warm calls.
  */
 export async function fetchTokenPrices(
   coinTypes: string[],
 ): Promise<Record<string, number>> {
   if (coinTypes.length === 0) return {};
 
-  if (cache && Date.now() - cache.ts < CACHE_TTL) {
-    const allHit = coinTypes.every((ct) => ct in cache!.prices);
-    if (allHit) return cache.prices;
-  }
+  const now = Date.now();
+  const cacheValid = cache !== null && now - cache.ts < CACHE_TTL;
+  const cachedPrices = cacheValid ? cache!.prices : {};
 
-  if (pendingRequest) {
-    return pendingRequest;
-  }
+  const missing = coinTypes.filter((ct) => !(ct in cachedPrices));
+  if (missing.length === 0) return cachedPrices;
 
-  pendingRequest = doFetch(coinTypes);
-  try {
-    return await pendingRequest;
-  } finally {
-    pendingRequest = null;
+  const sig = missing.slice().sort().join('|');
+  let inflight = pendingFetches.get(sig);
+  if (!inflight) {
+    inflight = doFetch(missing).finally(() => {
+      pendingFetches.delete(sig);
+    });
+    pendingFetches.set(sig, inflight);
   }
+  const fresh = await inflight;
+
+  const merged = { ...cachedPrices, ...fresh };
+  // Preserve original timestamp when extending an existing cache so we don't
+  // accidentally extend the TTL by trickling new tokens in. A fully-stale
+  // cache gets a fresh `now` stamp.
+  cache = { prices: merged, ts: cacheValid ? cache!.ts : now };
+  return merged;
 }
 
 async function doFetch(coinTypes: string[]): Promise<Record<string, number>> {

--- a/packages/engine/src/tools/balance.ts
+++ b/packages/engine/src/tools/balance.ts
@@ -47,17 +47,28 @@ export const balanceCheckTool = buildTool({
       const address = getWalletAddress(context);
       const mgr = getMcpManager(context);
 
+      // [v0.47] When a host-side `positionFetcher` is configured (Audric
+      // production), savings/debt/rewards come from the host instead of
+      // NAVI MCP. Skip those MCP calls entirely — they were previously
+      // fetched in parallel and then discarded, wasting 1–4s on the
+      // critical path.
+      const hasPositionFetcher = !!(context.positionFetcher && context.walletAddress);
+
       const [walletCoins, positions, rewards] = await Promise.all([
         fetchWalletCoins(address, context.suiRpcUrl).catch((err) => {
           console.warn('[balance_check] Sui RPC coin fetch failed, falling back to MCP:', err);
           return null;
         }),
-        callNavi(mgr, NaviTools.GET_POSITIONS, {
-          address,
-          protocols: 'navi',
-          format: 'json',
-        }),
-        callNavi(mgr, NaviTools.GET_AVAILABLE_REWARDS, { address }),
+        hasPositionFetcher
+          ? Promise.resolve(null)
+          : callNavi(mgr, NaviTools.GET_POSITIONS, {
+              address,
+              protocols: 'navi',
+              format: 'json',
+            }),
+        hasPositionFetcher
+          ? Promise.resolve(null)
+          : callNavi(mgr, NaviTools.GET_AVAILABLE_REWARDS, { address }),
       ]);
 
       let coins = walletCoins;
@@ -75,10 +86,22 @@ export const balanceCheckTool = buildTool({
 
       const VSUI_COIN_TYPE = '0x549e8b69270defbfafd4f94e17ec44cdbdd99820b33bda2278dea3b9a32d3f55::cert::CERT';
       const coinTypes = coins.map((c) => c.coinType).filter(Boolean);
-      const prices = await fetchTokenPrices(coinTypes).catch((err) => {
-        console.warn('[balance_check] DefiLlama price fetch failed:', err);
-        return {} as Record<string, number>;
-      });
+
+      // [v0.47] Run prices and host positionFetcher in parallel. Both depend
+      // only on the now-resolved coin list / address — no need to chain them.
+      // Was previously serial: prices → positionFetcher, costing ~2s extra.
+      const [prices, serverPositions] = await Promise.all([
+        fetchTokenPrices(coinTypes).catch((err) => {
+          console.warn('[balance_check] DefiLlama price fetch failed:', err);
+          return {} as Record<string, number>;
+        }),
+        hasPositionFetcher
+          ? context.positionFetcher!(context.walletAddress!).catch((err) => {
+              console.warn('[balance_check] positionFetcher failed:', err);
+              return null;
+            })
+          : Promise.resolve(null),
+      ]);
 
       if (coins.some((c) => c.coinType === VSUI_COIN_TYPE) && !prices[VSUI_COIN_TYPE]) {
         try {
@@ -134,11 +157,12 @@ export const balanceCheckTool = buildTool({
       let debt: number;
       let pendingRewardsUsd: number;
 
-      if (context.positionFetcher && context.walletAddress) {
-        const sp = await context.positionFetcher(context.walletAddress);
-        savings = sp.savings;
-        debt = sp.borrows;
-        pendingRewardsUsd = sp.pendingRewards;
+      if (serverPositions) {
+        // [v0.47] `serverPositions` was already fetched in the parallel
+        // batch above when `positionFetcher` is configured.
+        savings = serverPositions.savings;
+        debt = serverPositions.borrows;
+        pendingRewardsUsd = serverPositions.pendingRewards;
       } else {
         const posEntries = transformPositions(positions);
         const rewardEntries = transformRewards(rewards);

--- a/packages/engine/src/tools/portfolio-analysis.ts
+++ b/packages/engine/src/tools/portfolio-analysis.ts
@@ -63,7 +63,30 @@ export const portfolioAnalysisTool = buildTool({
 
     const DUST_USD = 0.01;
 
-    const coins = await fetchWalletCoins(address, rpcUrl);
+    // [v0.47] Fan out three independent fetches in parallel: wallet coins
+    // (Sui RPC), positions (host fetcher), and 7-day portfolio history
+    // (Audric internal API). Was previously a serial chain costing the sum
+    // of all three; now bound by the slowest. Prices still chain after
+    // coins because they need the resolved coin types.
+    const apiUrl = context.env?.AUDRIC_INTERNAL_API_URL;
+    const [coins, positions, weekHistResult] = await Promise.all([
+      fetchWalletCoins(address, rpcUrl),
+      context.positionFetcher
+        ? context.positionFetcher(address).catch((err) => {
+            console.warn('[portfolio_analysis] positionFetcher failed:', err);
+            return null;
+          })
+        : Promise.resolve(null),
+      apiUrl
+        ? fetch(
+            `${apiUrl}/api/analytics/portfolio-history?days=7`,
+            { headers: { 'x-sui-address': address }, signal: context.signal },
+          )
+            .then((res) => (res.ok ? res.json() as Promise<{ change?: WeekChange }> : null))
+            .catch(() => null)
+        : Promise.resolve(null),
+    ]);
+
     const nonZero = coins.filter((c) => Number(c.totalBalance) > 0);
     const prices = await fetchTokenPrices(nonZero.map((c) => c.coinType)).catch(() => ({} as Record<string, number>));
 
@@ -86,34 +109,19 @@ export const portfolioAnalysisTool = buildTool({
     let savingsApy: number | undefined;
     let dailyEarning: number | undefined;
 
-    if (context.positionFetcher) {
-      try {
-        const positions = await context.positionFetcher(address);
-        savingsValue = positions.savings ?? 0;
-        debtValue = positions.borrows ?? 0;
-        healthFactor = positions.healthFactor ?? null;
-        if (typeof positions.savingsRate === 'number' && positions.savingsRate > 0) {
-          savingsApy = positions.savingsRate;
-          dailyEarning = savingsValue * savingsApy / 365;
-        }
-      } catch { /* fallback to wallet only */ }
+    if (positions) {
+      savingsValue = positions.savings ?? 0;
+      debtValue = positions.borrows ?? 0;
+      healthFactor = positions.healthFactor ?? null;
+      if (typeof positions.savingsRate === 'number' && positions.savingsRate > 0) {
+        savingsApy = positions.savingsRate;
+        dailyEarning = savingsValue * savingsApy / 365;
+      }
     }
 
     let weekChange: WeekChange | undefined;
-    const apiUrl = context.env?.AUDRIC_INTERNAL_API_URL;
-    if (apiUrl && address) {
-      try {
-        const histRes = await fetch(
-          `${apiUrl}/api/analytics/portfolio-history?days=7`,
-          { headers: { 'x-sui-address': address }, signal: context.signal },
-        );
-        if (histRes.ok) {
-          const hist = (await histRes.json()) as { change?: WeekChange };
-          if (hist.change && hist.change.absoluteUsd !== 0) {
-            weekChange = hist.change;
-          }
-        }
-      } catch { /* supplementary data */ }
+    if (weekHistResult?.change && weekHistResult.change.absoluteUsd !== 0) {
+      weekChange = weekHistResult.change;
     }
 
     const totalValue = walletValue + savingsValue;


### PR DESCRIPTION
## Summary

Three bug-fix tracks surfaced by the v0.46.3 TurnMetrics baseline run. All blocking Spec 2 work; addressed together so re-baseline is one clean read.

### 1. Effort classifier no longer routes broad queries to Haiku
- `show me all transactions`, `transaction history`, `account summary`, `full report`, `breakdown` were all matching the `low` regex → routed to Haiku
- Haiku then looped multiple tool rounds trying to synthesize 50+ records, costing **2.3× more than Sonnet medium** ($0.040 vs $0.017 avg) at near-identical 8s wall time
- New rules: any matched recipe is at least `medium`; `show|history|all|list|everything|report|summary|breakdown` excluded from low-effort

### 2. balance_check parallelization (was 8.9s p95)
- Skip the `GET_POSITIONS` / `GET_AVAILABLE_REWARDS` MCP calls when host-side `positionFetcher` is configured (they were fetched and discarded)
- Run `fetchTokenPrices` and `positionFetcher` in a single `Promise.all` (both depend only on the resolved coin list)
- **Expected p95 win: 2-4s**

### 3. portfolio_analysis parallelization (was 5.2s p95)
- Restructured to fan out three independent fetches at the start: wallet coins + positions + 7-day history
- Prices still chain after coins resolve (needs the resolved coin types)
- **Expected p95 win: 1-2s**

### 4. defillama-prices: merge cached prices instead of full-invalidate
- Was: any miss in cache → refetch all coins
- Now: fetch only the missing keys, merge into existing cache
- In-flight dedupe keyed by missing-set signature so concurrent identical requests still coalesce
- **Expected p95 win: 0.5-1.5s on warm calls**

## Test plan

- [x] All 314 engine tests pass
- [x] 12 new tests in `classify-effort.test.ts` lock in routing rules with explicit "must NOT be low" assertions for the broad-synthesis cases
- [x] typecheck clean
- [ ] Re-run baseline metrics 3-5 days post-deploy to validate p95 latency wins
- [ ] Audric-side fixes (per-model cost rates + truncation-counts-as-refinement) ship in companion PR after this engine release lands on npm

## Refs

TurnMetrics baseline analysis: 73 turns over 0.77 days revealed three smoking guns
- ACI refinement 0% on transaction_history → fixed in audric companion PR (metric definition gap, not engine bug)
- Haiku costs more than Sonnet → engine PR (this) + audric per-model cost calc
- 6 of 9 read tools p95 > 3s → engine PR (this) parallelization

Made with [Cursor](https://cursor.com)