### PR TITLE
🐛 fix(engine): retry Anthropic overloaded/rate-limit streams + friendly error messages

### DIFF
--- a/packages/engine/src/__tests__/anthropic-retry.test.ts
+++ b/packages/engine/src/__tests__/anthropic-retry.test.ts
@@ -4,37 +4,44 @@ import { _internal } from '../providers/anthropic.js';
 
 const { isRetriableError, friendlyErrorMessage, computeBackoffMs } = _internal;
 
+// The SDK's `Headers` type is its own class (not the global Fetch Headers).
+// In tests we don't care about the headers value — only the status — so we
+// pass an empty headers-like through `any` to keep the test ergonomics clean.
+function apiError(status: number, body: { type: string; message: string }) {
+  return new Anthropic.APIError(
+    status,
+    body,
+    body.message,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    {} as any,
+  );
+}
+
 describe('AnthropicProvider retry classification', () => {
   describe('isRetriableError', () => {
     it('retries Anthropic 529 overloaded errors', () => {
-      const err = new Anthropic.APIError(
-        529,
-        { type: 'overloaded_error', message: 'Overloaded' },
-        'Overloaded',
-        new Headers(),
-      );
-      expect(isRetriableError(err)).toBe(true);
+      expect(
+        isRetriableError(
+          apiError(529, { type: 'overloaded_error', message: 'Overloaded' }),
+        ),
+      ).toBe(true);
     });
 
     it('retries Anthropic 429 rate-limit errors', () => {
-      const err = new Anthropic.APIError(
-        429,
-        { type: 'rate_limit_error', message: 'Rate limited' },
-        'Rate limited',
-        new Headers(),
-      );
-      expect(isRetriableError(err)).toBe(true);
+      expect(
+        isRetriableError(
+          apiError(429, { type: 'rate_limit_error', message: 'Rate limited' }),
+        ),
+      ).toBe(true);
     });
 
     it('retries 5xx server errors', () => {
       for (const status of [502, 503, 504]) {
-        const err = new Anthropic.APIError(
-          status,
-          { type: 'api_error', message: 'transient' },
-          'transient',
-          new Headers(),
-        );
-        expect(isRetriableError(err)).toBe(true);
+        expect(
+          isRetriableError(
+            apiError(status, { type: 'api_error', message: 'transient' }),
+          ),
+        ).toBe(true);
       }
     });
 
@@ -56,13 +63,14 @@ describe('AnthropicProvider retry classification', () => {
 
     it('does NOT retry 4xx client errors (except 408/429)', () => {
       for (const status of [400, 401, 403, 404]) {
-        const err = new Anthropic.APIError(
-          status,
-          { type: 'invalid_request_error', message: 'bad request' },
-          'bad request',
-          new Headers(),
-        );
-        expect(isRetriableError(err)).toBe(false);
+        expect(
+          isRetriableError(
+            apiError(status, {
+              type: 'invalid_request_error',
+              message: 'bad request',
+            }),
+          ),
+        ).toBe(false);
       }
     });
 
@@ -85,13 +93,13 @@ describe('AnthropicProvider retry classification', () => {
     });
 
     it('produces a clean string for rate-limit errors', () => {
-      const err = new Anthropic.APIError(
-        429,
-        { type: 'rate_limit_error', message: 'Rate limited' },
-        'Rate limited',
-        new Headers(),
+      const err = apiError(429, {
+        type: 'rate_limit_error',
+        message: 'Rate limited',
+      });
+      expect(friendlyErrorMessage(err).toLowerCase()).toContain(
+        'too many requests',
       );
-      expect(friendlyErrorMessage(err).toLowerCase()).toContain('too many requests');
     });
 
     it('produces a clean string for network errors', () => {
@@ -100,13 +108,13 @@ describe('AnthropicProvider retry classification', () => {
     });
 
     it('produces a clean string for auth errors', () => {
-      const err = new Anthropic.APIError(
-        401,
-        { type: 'authentication_error', message: 'bad key' },
-        'bad key',
-        new Headers(),
+      const err = apiError(401, {
+        type: 'authentication_error',
+        message: 'bad key',
+      });
+      expect(friendlyErrorMessage(err).toLowerCase()).toContain(
+        'authentication failed',
       );
-      expect(friendlyErrorMessage(err).toLowerCase()).toContain('authentication failed');
     });
 
     it('falls back to a generic message for unknown errors', () => {

--- a/packages/engine/src/__tests__/anthropic-retry.test.ts
+++ b/packages/engine/src/__tests__/anthropic-retry.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
+import { _internal } from '../providers/anthropic.js';
+
+const { isRetriableError, friendlyErrorMessage, computeBackoffMs } = _internal;
+
+describe('AnthropicProvider retry classification', () => {
+  describe('isRetriableError', () => {
+    it('retries Anthropic 529 overloaded errors', () => {
+      const err = new Anthropic.APIError(
+        529,
+        { type: 'overloaded_error', message: 'Overloaded' },
+        'Overloaded',
+        new Headers(),
+      );
+      expect(isRetriableError(err)).toBe(true);
+    });
+
+    it('retries Anthropic 429 rate-limit errors', () => {
+      const err = new Anthropic.APIError(
+        429,
+        { type: 'rate_limit_error', message: 'Rate limited' },
+        'Rate limited',
+        new Headers(),
+      );
+      expect(isRetriableError(err)).toBe(true);
+    });
+
+    it('retries 5xx server errors', () => {
+      for (const status of [502, 503, 504]) {
+        const err = new Anthropic.APIError(
+          status,
+          { type: 'api_error', message: 'transient' },
+          'transient',
+          new Headers(),
+        );
+        expect(isRetriableError(err)).toBe(true);
+      }
+    });
+
+    it('retries when error message contains overloaded JSON shape', () => {
+      // This is what the Anthropic streaming SDK actually surfaces in
+      // production: an Error whose .message is the raw SSE error payload.
+      const err = new Error(
+        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      );
+      expect(isRetriableError(err)).toBe(true);
+    });
+
+    it('retries common transient network errors', () => {
+      expect(isRetriableError(new Error('ECONNRESET'))).toBe(true);
+      expect(isRetriableError(new Error('socket hang up'))).toBe(true);
+      expect(isRetriableError(new Error('fetch failed'))).toBe(true);
+      expect(isRetriableError(new Error('ETIMEDOUT'))).toBe(true);
+    });
+
+    it('does NOT retry 4xx client errors (except 408/429)', () => {
+      for (const status of [400, 401, 403, 404]) {
+        const err = new Anthropic.APIError(
+          status,
+          { type: 'invalid_request_error', message: 'bad request' },
+          'bad request',
+          new Headers(),
+        );
+        expect(isRetriableError(err)).toBe(false);
+      }
+    });
+
+    it('does NOT retry plain unknown errors', () => {
+      expect(isRetriableError(new Error('something exploded'))).toBe(false);
+      expect(isRetriableError(null)).toBe(false);
+      expect(isRetriableError(undefined)).toBe(false);
+    });
+  });
+
+  describe('friendlyErrorMessage', () => {
+    it('produces a clean string for overloaded errors — never raw JSON', () => {
+      const err = new Error(
+        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+      );
+      const msg = friendlyErrorMessage(err);
+      expect(msg).not.toContain('{');
+      expect(msg).not.toContain('overloaded_error');
+      expect(msg.toLowerCase()).toContain('over capacity');
+    });
+
+    it('produces a clean string for rate-limit errors', () => {
+      const err = new Anthropic.APIError(
+        429,
+        { type: 'rate_limit_error', message: 'Rate limited' },
+        'Rate limited',
+        new Headers(),
+      );
+      expect(friendlyErrorMessage(err).toLowerCase()).toContain('too many requests');
+    });
+
+    it('produces a clean string for network errors', () => {
+      const msg = friendlyErrorMessage(new Error('ECONNRESET'));
+      expect(msg.toLowerCase()).toContain("couldn't reach anthropic");
+    });
+
+    it('produces a clean string for auth errors', () => {
+      const err = new Anthropic.APIError(
+        401,
+        { type: 'authentication_error', message: 'bad key' },
+        'bad key',
+        new Headers(),
+      );
+      expect(friendlyErrorMessage(err).toLowerCase()).toContain('authentication failed');
+    });
+
+    it('falls back to a generic message for unknown errors', () => {
+      expect(friendlyErrorMessage(new Error('???'))).toBe(
+        'Something went wrong. Please try again.',
+      );
+    });
+  });
+
+  describe('computeBackoffMs', () => {
+    it('grows exponentially with jitter', () => {
+      // attempt=1 → 1000-1250ms, attempt=2 → 2000-2250ms, attempt=3 → 4000-4250ms
+      const a1 = computeBackoffMs(1);
+      const a2 = computeBackoffMs(2);
+      const a3 = computeBackoffMs(3);
+      expect(a1).toBeGreaterThanOrEqual(1000);
+      expect(a1).toBeLessThan(1300);
+      expect(a2).toBeGreaterThanOrEqual(2000);
+      expect(a2).toBeLessThan(2300);
+      expect(a3).toBeGreaterThanOrEqual(4000);
+      expect(a3).toBeLessThan(4300);
+    });
+
+    it('caps at the configured maximum', () => {
+      // attempt=10 would be 1000 * 2^9 = 512000ms — must be clamped.
+      const big = computeBackoffMs(10);
+      expect(big).toBeLessThan(8500);
+    });
+  });
+});

--- a/packages/engine/src/providers/anthropic.ts
+++ b/packages/engine/src/providers/anthropic.ts
@@ -13,24 +13,69 @@ import type {
 const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
 const DEFAULT_MAX_TOKENS = 4096;
 
+// Anthropic occasionally returns 529 overloaded_error or 429 rate_limit_error
+// when their infrastructure is over capacity. The SDK does NOT auto-retry
+// streaming requests once the connection opens, so we wrap the stream call
+// ourselves: if the stream errors before yielding any events, we retry with
+// exponential backoff. Once tokens have started flowing we propagate, because
+// retrying mid-stream would corrupt engine state (double-counted tokens, etc.).
+const DEFAULT_MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+const RETRY_MAX_DELAY_MS = 8000;
+
 export interface AnthropicProviderConfig {
   apiKey: string;
   defaultModel?: string;
   defaultMaxTokens?: number;
+  /** Max retry attempts for retriable errors (overloaded, rate-limited, network). Default 3. */
+  maxRetries?: number;
 }
 
 export class AnthropicProvider implements LLMProvider {
   private client: Anthropic;
   private defaultModel: string;
   private defaultMaxTokens: number;
+  private maxRetries: number;
 
   constructor(config: AnthropicProviderConfig) {
     this.client = new Anthropic({ apiKey: config.apiKey });
     this.defaultModel = config.defaultModel ?? DEFAULT_MODEL;
     this.defaultMaxTokens = config.defaultMaxTokens ?? DEFAULT_MAX_TOKENS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
   }
 
   async *chat(params: ChatParams): AsyncGenerator<ProviderEvent> {
+    let attempt = 0;
+    while (true) {
+      let yieldedAnything = false;
+      const inner = this.streamOnce(params);
+      try {
+        for (;;) {
+          const next = await inner.next();
+          if (next.done) return;
+          yieldedAnything = true;
+          yield next.value;
+        }
+      } catch (err) {
+        // Best-effort: tell the inner generator to release the underlying stream.
+        try { await inner.return?.(undefined); } catch { /* noop */ }
+
+        if (!yieldedAnything && isRetriableError(err) && attempt < this.maxRetries) {
+          attempt++;
+          const delayMs = computeBackoffMs(attempt);
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[anthropic] retriable error (attempt ${attempt}/${this.maxRetries}, retrying in ${delayMs}ms): ${rawErrorMessage(err)}`,
+          );
+          await sleep(delayMs);
+          continue;
+        }
+        throw new Error(friendlyErrorMessage(err));
+      }
+    }
+  }
+
+  private async *streamOnce(params: ChatParams): AsyncGenerator<ProviderEvent> {
     const messages = sanitizeAnthropicMessages(
       params.messages.map(toAnthropicMessage),
     );
@@ -202,6 +247,113 @@ export class AnthropicProvider implements LLMProvider {
       stream.abort();
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Error classification + retry helpers
+// ---------------------------------------------------------------------------
+
+// Exported for testing. Not part of the public provider API.
+export const _internal = {
+  isRetriableError: (err: unknown) => isRetriableError(err),
+  friendlyErrorMessage: (err: unknown) => friendlyErrorMessage(err),
+  computeBackoffMs: (attempt: number) => computeBackoffMs(attempt),
+};
+
+function isRetriableError(err: unknown): boolean {
+  if (!err) return false;
+
+  // Anthropic SDK error classes (status-based)
+  if (err instanceof Anthropic.APIError) {
+    // 529 overloaded, 408 timeout, 502/503/504 transient
+    if (err.status === 529 || err.status === 408) return true;
+    if (err.status === 502 || err.status === 503 || err.status === 504) return true;
+    // 429 rate-limited — retry but the user may need to slow down regardless
+    if (err.status === 429) return true;
+    return false;
+  }
+
+  // Sometimes streaming errors arrive as plain Error with the JSON message
+  // baked into err.message (e.g. {"type":"error","error":{"type":"overloaded_error",...}})
+  const msg = rawErrorMessage(err).toLowerCase();
+  if (
+    msg.includes('overloaded_error') ||
+    msg.includes('"overloaded"') ||
+    msg.includes('rate_limit_error') ||
+    msg.includes('econnreset') ||
+    msg.includes('etimedout') ||
+    msg.includes('socket hang up') ||
+    msg.includes('fetch failed') ||
+    msg.includes('network error')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function rawErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+/**
+ * Map a raw provider error to a clean, user-facing message.
+ *
+ * Most users see this as the chat error bubble — never leak raw JSON or
+ * stack traces. Any string returned here is safe to render verbatim in UI.
+ */
+function friendlyErrorMessage(err: unknown): string {
+  const msg = rawErrorMessage(err).toLowerCase();
+
+  if (
+    msg.includes('overloaded_error') ||
+    msg.includes('"overloaded"') ||
+    (err instanceof Anthropic.APIError && err.status === 529)
+  ) {
+    return "Anthropic's servers are over capacity right now. Please try again in 30 seconds.";
+  }
+  if (
+    msg.includes('rate_limit_error') ||
+    (err instanceof Anthropic.APIError && err.status === 429)
+  ) {
+    return 'Too many requests in a short window. Please wait a moment and try again.';
+  }
+  if (
+    msg.includes('econnreset') ||
+    msg.includes('etimedout') ||
+    msg.includes('socket hang up') ||
+    msg.includes('fetch failed') ||
+    msg.includes('network error')
+  ) {
+    return "Couldn't reach Anthropic. Check your connection and try again.";
+  }
+  if (err instanceof Anthropic.APIError && err.status === 401) {
+    return 'Authentication failed. Please check the Anthropic API key configuration.';
+  }
+  if (err instanceof Anthropic.APIError && err.status === 400) {
+    return 'The request was rejected by Anthropic. This is likely a bug — please retry, and if it persists, contact support.';
+  }
+  if (err instanceof Anthropic.APIError && err.status >= 500) {
+    return 'Anthropic returned a server error. Please try again in a moment.';
+  }
+
+  return 'Something went wrong. Please try again.';
+}
+
+function computeBackoffMs(attempt: number): number {
+  const base = Math.min(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), RETRY_MAX_DELAY_MS);
+  const jitter = Math.floor(Math.random() * 250);
+  return base + jitter;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Production-grade error handling for the Anthropic provider. Today when the
upstream API returns 529 (overloaded) or 429 (rate-limited), the raw SSE
JSON payload bubbles all the way to the chat UI:

\`\`\`
{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_..."}
\`\`\`

After this PR:
- The `AnthropicProvider` retries with exponential backoff (1s/2s/4s + jitter, capped at 8s, 3 attempts) on 529/429/408/5xx and common transient network errors. Retry only fires if no events have been yielded yet so engine state is never corrupted mid-stream.
- All known provider errors are mapped to clean, user-facing strings before throwing — e.g. "Anthropic's servers are over capacity right now. Please try again in 30 seconds." Raw JSON never reaches the UI.
- 14 new unit tests cover retry classification, friendly messages, and backoff math.

## Why now

Real production hit just now: user got `{"type":"error","error":{"type":"overloaded_error",...}}` rendered verbatim in the chat for `Show my savings details` and `Show my activity heatmap`. The product is unusable when Anthropic has a bad 30 seconds.

## Test plan
- [x] `pnpm vitest run anthropic-retry` — 14/14 pass
- [x] Full engine suite — 340/340 pass
- [x] `pnpm typecheck` clean
- [ ] After merge: cut `v0.46.5`, audric bumps + deploys
- [ ] Watch chat error rate / Sentry for "Overloaded" — should now be retried silently most of the time


Made with [Cursor](https://cursor.com)