### PR TITLE
feat(engine): card-rendering tool filters + descriptions (v0.46.6)

### DIFF
--- a/packages/engine/src/__tests__/tool-filters.test.ts
+++ b/packages/engine/src/__tests__/tool-filters.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { _internal as ratesInternal } from '../tools/rates.js';
+
+const SAMPLE_RATES = {
+  USDC: { saveApy: 0.0396, borrowApy: 0.0357 },
+  USDT: { saveApy: 0.0339, borrowApy: 0.703 },
+  USDSUI: { saveApy: 0.069, borrowApy: 0.0354 },
+  SUI: { saveApy: 0.0271, borrowApy: 0.0184 },
+  WAL: { saveApy: 0.1694, borrowApy: 0.1351 },
+  NS: { saveApy: 0.1888, borrowApy: 0.1101 },
+  LOFI: { saveApy: 0.0123, borrowApy: 0.05 },
+  XAUm: { saveApy: 0.0507, borrowApy: 0.0803 },
+};
+
+describe('rates_info — applyFilters (v0.46.6)', () => {
+  it('default behavior: top 8 sorted desc by saveApy', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, { topN: 8 });
+    const symbols = Object.keys(out);
+    expect(symbols.length).toBe(8);
+    expect(symbols[0]).toBe('NS');
+    expect(symbols[1]).toBe('WAL');
+  });
+
+  it('topN: 50 returns all entries', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, { topN: 50 });
+    expect(Object.keys(out).length).toBe(Object.keys(SAMPLE_RATES).length);
+  });
+
+  it('assets: ["USDC"] returns only USDC', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, { assets: ['USDC'] });
+    expect(Object.keys(out)).toEqual(['USDC']);
+    expect(out.USDC.saveApy).toBeCloseTo(0.0396);
+  });
+
+  it('assets is case-insensitive', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, { assets: ['usdc', 'sui'] });
+    expect(new Set(Object.keys(out))).toEqual(new Set(['USDC', 'SUI']));
+  });
+
+  it('stableOnly: returns only USD-pegged assets', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, { stableOnly: true });
+    const symbols = new Set(Object.keys(out));
+    expect(symbols.has('USDC')).toBe(true);
+    expect(symbols.has('USDT')).toBe(true);
+    expect(symbols.has('USDSUI')).toBe(true);
+    expect(symbols.has('WAL')).toBe(false);
+    expect(symbols.has('SUI')).toBe(false);
+    expect(symbols.has('XAUm')).toBe(false); // gold-pegged, not USD
+    expect(symbols.has('LOFI')).toBe(false);
+  });
+
+  it('assets takes precedence over stableOnly', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, {
+      assets: ['WAL'],
+      stableOnly: true,
+    });
+    expect(Object.keys(out)).toEqual(['WAL']);
+  });
+
+  it('topN clips after filtering, not before', () => {
+    const out = ratesInternal.applyFilters(SAMPLE_RATES, {
+      stableOnly: true,
+      topN: 2,
+    });
+    expect(Object.keys(out).length).toBe(2);
+    // Top stables by APY: USDSUI (6.9%), USDC (3.96%)
+    expect(Object.keys(out)[0]).toBe('USDSUI');
+    expect(Object.keys(out)[1]).toBe('USDC');
+  });
+
+  it('isStable matches lowercase variants', () => {
+    expect(ratesInternal.isStable('USDC')).toBe(true);
+    expect(ratesInternal.isStable('usdc')).toBe(true);
+    expect(ratesInternal.isStable('UsDsUi')).toBe(true);
+    expect(ratesInternal.isStable('SUI')).toBe(false);
+    expect(ratesInternal.isStable('XAUm')).toBe(false);
+  });
+});

--- a/packages/engine/src/tools/defillama.ts
+++ b/packages/engine/src/tools/defillama.ts
@@ -52,23 +52,53 @@ function fmtToolTvl(tvl: number): string {
   return `$${tvl}`;
 }
 
+/**
+ * [v0.46.6] Pool-side stablecoin allow-list (uppercase) used by the
+ * `stableOnly` filter on `defillama_yield_pools`. DefiLlama returns
+ * pool symbols as `LEG1-LEG2` (uppercase by convention) — we want
+ * BOTH legs to be USD-pegged before counting a pool as "all stable".
+ * Excludes XAUm (gold-pegged), all LSTs/LRTs, and any volatile pair.
+ */
+const POOL_STABLE_LEGS = new Set<string>([
+  'USDC',
+  'WUSDC',
+  'USDT',
+  'WUSDT',
+  'SUIUSDT',
+  'USDY',
+  'USDSUI',
+  'USDE',
+  'AUSD',
+  'FDUSD',
+  'BUCK',
+  'DAI',
+  'LUSD',
+  'FRAX',
+  'GUSD',
+  'PYUSD',
+  'USDS',
+  'CRVUSD',
+]);
+
 export const defillamaYieldPoolsTool = buildTool({
   name: 'defillama_yield_pools',
   description:
-    'Get top DeFi yield pools across protocols. Filter by chain (e.g. "Sui"), project (e.g. "navi-lending"), and minimum TVL. For NAVI lending rates, use project "navi-lending".',
+    'Cross-protocol LP / vault yields with IMPERMANENT-LOSS RISK (Cetus, Bluefin, Full Sail, etc.). ONLY call when the user explicitly asks about LP pools, DeFi farming, or "higher yield with more risk". For safe single-sided lending yields (USDC save, NAVI, etc.) use rates_info instead — NEVER both in the same turn. Filter by chain (e.g. "Sui"), project, and minimum TVL.',
   inputSchema: z.object({
     chain: z.string().optional().describe('Filter by chain name (e.g. "Sui", "Ethereum")'),
-    project: z.string().optional().describe('Filter by protocol project name (e.g. "navi-lending", "cetus-clmm")'),
+    project: z.string().optional().describe('Filter by protocol project name (e.g. "cetus-clmm", "bluefin-spot")'),
     limit: z.number().min(1).max(20).optional().describe('Max results (default 5)'),
     minTvl: z.number().optional().describe('Minimum TVL in USD to filter out small/risky pools (default 100000)'),
+    stableOnly: z.boolean().optional().describe('When true, only return pools where every leg is a stablecoin (USDC, USDT, USDSUI, etc.). Use this for "show stablecoin yield options" — keeps volatile-pair LPs (WAL-SUI, DEEP-SUI) out.'),
   }),
   jsonSchema: {
     type: 'object',
     properties: {
       chain: { type: 'string', description: 'Filter by chain name' },
-      project: { type: 'string', description: 'Filter by protocol project name (e.g. "navi-lending")' },
+      project: { type: 'string', description: 'Filter by protocol project name (e.g. "cetus-clmm")' },
       limit: { type: 'number', description: 'Max results (default 5)' },
       minTvl: { type: 'number', description: 'Minimum TVL in USD (default 100000)' },
+      stableOnly: { type: 'boolean', description: 'When true, only return all-stablecoin pools.' },
     },
     required: [],
   },
@@ -118,6 +148,17 @@ export const defillamaYieldPoolsTool = buildTool({
 
     const minTvl = input.minTvl ?? 100_000;
     pools = pools.filter((p) => p.tvlUsd >= minTvl);
+
+    // [v0.46.6] `stableOnly` keeps only pools where EVERY leg of the
+    // pair is a known stablecoin. The pool symbol is always rendered as
+    // `LEG1-LEG2` (or just `LEG1` for single-asset vaults), so split on
+    // `-` and check each side. Single-asset stable vaults pass too.
+    if (input.stableOnly) {
+      pools = pools.filter((p) => {
+        const legs = p.symbol.split('-');
+        return legs.every((leg) => POOL_STABLE_LEGS.has(leg.trim().toUpperCase()));
+      });
+    }
 
     pools.sort((a, b) => b.apy - a.apy);
     const limit = input.limit ?? 5;

--- a/packages/engine/src/tools/history.ts
+++ b/packages/engine/src/tools/history.ts
@@ -199,11 +199,14 @@ const DEFAULT_LOOKBACK_DAYS = 30;
 export const transactionHistoryTool = buildTool({
   name: 'transaction_history',
   description:
-    'Retrieve recent transaction history (last 30 days by default): sends, saves, withdrawals, borrows, repayments, and rewards claims. Pass `date` (YYYY-MM-DD) for a specific day, `action` to filter by category (send/lending/swap), or both.',
+    'Retrieve recent transaction history (last 30 days by default): sends, saves, withdrawals, borrows, repayments, swaps, and rewards claims. Renders a rich transaction card. Filter args: `date` (YYYY-MM-DD), `action` (send/lending/swap), `minUsd` (minimum amount in USD — use this for "transactions over $X" instead of post-filtering), `assetSymbol` (e.g. "USDC", "SUI"), `direction` ("in" or "out"). The card itself respects all filters — never re-list the rows in narration.',
   inputSchema: z.object({
     limit: z.number().int().min(1).max(50).optional(),
     date: z.string().optional().describe('Specific date to search for transactions (YYYY-MM-DD format). Paginates back to find that day.'),
     action: z.enum(HISTORY_ACTIONS).optional().describe('Filter by action: send, lending, swap, or transaction.'),
+    minUsd: z.number().min(0).optional().describe('Minimum transaction amount in USD. Use this for "transactions over $X" — the amount is converted to USD using the asset price snapshot.'),
+    assetSymbol: z.string().optional().describe('Filter to a single asset symbol (case-insensitive, e.g. "USDC", "SUI", "LOFI"). Matches `tx.asset` exactly.'),
+    direction: z.enum(['in', 'out']).optional().describe('Filter by user-side balance flow: "in" = received, "out" = spent.'),
   }),
   jsonSchema: {
     type: 'object',
@@ -220,6 +223,19 @@ export const transactionHistoryTool = buildTool({
         type: 'string',
         enum: [...HISTORY_ACTIONS],
         description: 'Filter results by action category: send, lending, swap, or transaction.',
+      },
+      minUsd: {
+        type: 'number',
+        description: 'Minimum transaction amount in USD. Use this for "transactions over $X" queries.',
+      },
+      assetSymbol: {
+        type: 'string',
+        description: 'Filter to a single asset symbol (case-insensitive, e.g. "USDC", "SUI").',
+      },
+      direction: {
+        type: 'string',
+        enum: ['in', 'out'],
+        description: 'Filter by direction of user balance change: "in" = received, "out" = spent.',
       },
     },
   },
@@ -277,16 +293,72 @@ export const transactionHistoryTool = buildTool({
   ): Promise<{ data: Record<string, unknown>; displayText: string }> {
     const limit = input.limit ?? 10;
     const action = input.action as HistoryAction | undefined;
+    const assetSymbol = input.assetSymbol?.toLowerCase();
+    const direction = input.direction;
+    const minUsd = input.minUsd;
+
+    /**
+     * [v0.46.6] Price snapshot for `minUsd` filtering. Sourced from the
+     * session-injected token-price map (populated by the prefetch step
+     * in audric's engine-factory). Falls back to "no USD value known"
+     * when the asset isn't in the snapshot — those rows skip the
+     * `minUsd` filter rather than being silently dropped, since we
+     * don't have ground truth.
+     */
+    const prices: Record<string, number> | undefined = (
+      context as unknown as { tokenPrices?: Record<string, number> }
+    ).tokenPrices;
+    const priceFor = (sym: string | undefined): number | undefined => {
+      if (!sym || !prices) return undefined;
+      return prices[sym.toUpperCase()] ?? prices[sym.toLowerCase()] ?? prices[sym];
+    };
 
     /**
      * [v1.4] After fetching, narrow by `action` (when supplied), and trim
      * to a `DEFAULT_LOOKBACK_DAYS` window when no explicit date is given —
      * keeps results recent and bounded so the LLM doesn't over-summarize.
+     *
+     * [v0.46.6] Now also honors `assetSymbol`, `direction`, and `minUsd`
+     * so single questions like "show transactions over $5" or "show my
+     * USDC sends" produce a card whose rows already match the question —
+     * the LLM never needs to filter in narration.
      */
     const finalize = (records: TxRecord[]): TxRecord[] => {
       let scoped = records;
       if (action) scoped = scoped.filter((r) => r.action === action);
+      if (assetSymbol) {
+        scoped = scoped.filter((r) => r.asset?.toLowerCase() === assetSymbol);
+      }
+      if (direction) {
+        scoped = scoped.filter((r) => r.direction === direction);
+      }
+      if (minUsd != null && minUsd > 0) {
+        scoped = scoped.filter((r) => {
+          if (r.amount == null) return false;
+          // For USD-pegged assets we treat the unit amount as USD value.
+          // For others, multiply by the snapshot price when known.
+          const sym = r.asset?.toUpperCase() ?? '';
+          const isStableLike =
+            sym === 'USDC' || sym === 'USDT' || sym === 'WUSDC' || sym === 'WUSDT' ||
+            sym === 'SUIUSDT' || sym === 'USDY' || sym === 'USDSUI' || sym === 'USDE' ||
+            sym === 'AUSD' || sym === 'FDUSD' || sym === 'BUCK';
+          const usd = isStableLike ? r.amount : (priceFor(sym) ?? 0) * r.amount;
+          // When we genuinely don't know the price, KEEP the row rather
+          // than silently dropping it — better to over-include than to
+          // hide transactions the user expects to see.
+          if (!isStableLike && priceFor(sym) == null) return true;
+          return usd >= minUsd;
+        });
+      }
       return scoped.slice(0, limit);
+    };
+
+    const filterMeta = {
+      date: input.date ?? null,
+      action: action ?? null,
+      minUsd: minUsd ?? null,
+      assetSymbol: input.assetSymbol ?? null,
+      direction: direction ?? null,
     };
 
     if (context.agent) {
@@ -294,7 +366,7 @@ export const transactionHistoryTool = buildTool({
       const records = await agent.history({ limit: input.date ? limit : Math.max(limit * 4, 50) });
       const filtered = finalize(records);
       return {
-        data: { transactions: filtered, count: filtered.length, date: input.date ?? null, action: action ?? null },
+        data: { transactions: filtered, count: filtered.length, ...filterMeta },
         displayText: `${filtered.length} recent transaction(s)`,
       };
     }
@@ -313,7 +385,7 @@ export const transactionHistoryTool = buildTool({
       const filtered = finalize(records);
       const dateLabel = new Date(input.date).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
       return {
-        data: { transactions: filtered, count: filtered.length, date: input.date, action: action ?? null },
+        data: { transactions: filtered, count: filtered.length, ...filterMeta },
         displayText: filtered.length > 0
           ? `${filtered.length} transaction(s) on ${dateLabel}`
           : `No transactions found on ${dateLabel}`,
@@ -333,8 +405,7 @@ export const transactionHistoryTool = buildTool({
       data: {
         transactions: filtered,
         count: filtered.length,
-        date: null,
-        action: action ?? null,
+        ...filterMeta,
         lookbackDays: DEFAULT_LOOKBACK_DAYS,
       },
       displayText: `${filtered.length} transaction(s) in the last ${DEFAULT_LOOKBACK_DAYS} days`,

--- a/packages/engine/src/tools/mpp-services.ts
+++ b/packages/engine/src/tools/mpp-services.ts
@@ -48,7 +48,7 @@ function matchesQuery(service: GatewayService, q: string): boolean {
 export const mppServicesTool = buildTool({
   name: 'mpp_services',
   description:
-    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Pass `query` for keyword search or `category` to filter by category. Calling with NO filters returns a category summary (not the full catalog) — narrow first, then fetch endpoints. Use this BEFORE calling pay_api.',
+    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Use BEFORE calling pay_api. Modes: pass `query` for keyword search, `category` to filter by category, or `mode: "full"` to fetch the ENTIRE catalog in one card (for "show me all MPP services" / "full catalog" requests — never enumerate per category in a loop). Calling with no args returns a category summary so you can narrow.',
   inputSchema: z.object({
     query: z
       .string()
@@ -58,6 +58,10 @@ export const mppServicesTool = buildTool({
       .string()
       .optional()
       .describe('Filter by category exactly (e.g. "weather", "image"). See category summary returned when called without filters.'),
+    mode: z
+      .enum(['summary', 'full'])
+      .optional()
+      .describe('"full" returns the entire catalog in a single card — use this for "show me all MPP services" / "full catalog" requests instead of looping per category. Default is "summary" (category counts only when no filter is supplied).'),
   }),
   jsonSchema: {
     type: 'object',
@@ -70,14 +74,47 @@ export const mppServicesTool = buildTool({
         type: 'string',
         description: 'Filter by category exactly (e.g. "weather", "image").',
       },
+      mode: {
+        type: 'string',
+        enum: ['summary', 'full'],
+        description: '"full" returns the entire catalog in one card. Use for "show me all" requests.',
+      },
     },
     required: [],
   },
   isReadOnly: true,
-  maxResultSizeChars: 5_000,
+  // [v0.46.6] Bumped to fit the full catalog (~40 services) in one
+  // shot when `mode: 'full'` is used. The summarizeOnTruncate path
+  // still applies if the catalog ever exceeds the budget.
+  maxResultSizeChars: 12_000,
 
   async call(input): Promise<{ data: Record<string, unknown>; displayText: string }> {
     const catalog = await fetchCatalog();
+
+    // [v0.46.6] Explicit "show me everything" path. The previous
+    // "no-args returns category summary + _refine hint" behavior caused
+    // the model to interpret "show all MPP services" as an instruction
+    // to enumerate every category one by one — discover_services was
+    // observed firing 15 times in a single turn. mode:'full' breaks
+    // that loop by returning the whole catalog up front.
+    if (input.mode === 'full') {
+      const services = catalog.map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description,
+        categories: s.categories,
+        endpoints: s.endpoints.map((e) => ({
+          url: `${MPP_GATEWAY}/${s.id}${e.path}`,
+          method: e.method,
+          description: e.description,
+          price: `$${e.price}`,
+        })),
+      }));
+      return {
+        data: { services, total: services.length, mode: 'full' },
+        displayText: `Full MPP catalog: ${services.length} services.`,
+      };
+    }
 
     // [v1.4 ACI] If neither query nor category is supplied, return a
     // category summary rather than the unbounded full catalog. The model
@@ -96,13 +133,14 @@ export const mppServicesTool = buildTool({
       return {
         data: {
           _refine: {
-            reason: 'MPP catalog has many services — pick a category or supply a query first.',
+            reason: 'MPP catalog has many services — pick a category, supply a query, or pass mode:"full" to fetch everything.',
             suggestedParams: { category: categories[0]?.category ?? 'weather' },
+            allModes: ['summary', 'full'],
           },
           categories,
           totalServices: catalog.length,
         },
-        displayText: `${catalog.length} services across ${categories.length} categories. Re-call with a category or query.`,
+        displayText: `${catalog.length} services across ${categories.length} categories. Re-call with a category, query, or mode:"full".`,
       };
     }
 

--- a/packages/engine/src/tools/rates.ts
+++ b/packages/engine/src/tools/rates.ts
@@ -5,7 +5,55 @@ import { hasNaviMcpGlobal, getMcpManager, hasAgent, requireAgent } from './utils
 
 const YIELDS_API = 'https://yields.llama.fi';
 
-function formatRatesSummary(rates: Record<string, { saveApy: number; borrowApy: number }>): string {
+/**
+ * [v0.46.6] Stablecoin allow-list used by the `stableOnly` filter.
+ *
+ * Lower-cased symbol matching — covers the canonical USDC/USDT family
+ * and the Sui-native synthetic stables (USDSUI, USDY, suiUSDT, USDe,
+ * AUSD, FDUSD, BUCK). Excludes XAUm (gold-pegged, not USD-pegged) and
+ * any LST/LRT.
+ */
+const STABLECOIN_SYMBOLS = new Set<string>([
+  'usdc',
+  'wusdc',
+  'usdt',
+  'wusdt',
+  'suiusdt',
+  'usdy',
+  'usdsui',
+  'usde',
+  'ausd',
+  'fdusd',
+  'buck',
+]);
+
+type RateMap = Record<string, { saveApy: number; borrowApy: number }>;
+
+function isStable(symbol: string): boolean {
+  return STABLECOIN_SYMBOLS.has(symbol.toLowerCase());
+}
+
+function applyFilters(
+  rates: RateMap,
+  opts: { assets?: string[]; stableOnly?: boolean; topN?: number },
+): RateMap {
+  let entries = Object.entries(rates);
+  if (opts.assets && opts.assets.length) {
+    const wanted = new Set(opts.assets.map((a) => a.toLowerCase()));
+    entries = entries.filter(([sym]) => wanted.has(sym.toLowerCase()));
+  } else if (opts.stableOnly) {
+    entries = entries.filter(([sym]) => isStable(sym));
+  }
+  // Sort by save APY desc so `topN` picks the best yields when no
+  // explicit `assets` filter was supplied.
+  entries.sort(([, a], [, b]) => b.saveApy - a.saveApy);
+  if (opts.topN && opts.topN > 0) {
+    entries = entries.slice(0, opts.topN);
+  }
+  return Object.fromEntries(entries);
+}
+
+function formatRatesSummary(rates: RateMap): string {
   return Object.entries(rates)
     .map(([asset, r]) => `${asset}: Save ${(r.saveApy * 100).toFixed(2)}% / Borrow ${(r.borrowApy * 100).toFixed(2)}%`)
     .join(', ');
@@ -41,27 +89,73 @@ async function fetchRatesFromDefiLlama(): Promise<Record<string, { saveApy: numb
 export const ratesInfoTool = buildTool({
   name: 'rates_info',
   description:
-    'Get current NAVI Protocol lending/savings rates (APY) for supported assets on Sui. Returns save APY and borrow APY per asset.',
-  inputSchema: z.object({}),
-  jsonSchema: { type: 'object', properties: {}, required: [] },
+    'NAVI Protocol lending markets ONLY (single-sided save/borrow, no impermanent-loss risk). Use this for stablecoin and bluechip lending yields. Renders a rich rates card. Filter args: `assets` (specific symbols like ["USDC"]), `stableOnly` (true to show only USD-pegged assets), `topN` (max rows in card, default 8, max 50). Do NOT call defillama_yield_pools in the same turn — that tool is for LP/farming pools with IL risk, not lending.',
+  inputSchema: z.object({
+    assets: z
+      .array(z.string())
+      .optional()
+      .describe('Filter to specific asset symbols (e.g. ["USDC"], ["USDC","USDT","USDSUI"]). Case-insensitive.'),
+    stableOnly: z
+      .boolean()
+      .optional()
+      .describe('When true, return only stablecoin markets (USDC, USDT, USDSUI, USDY, suiUSDT, etc.). Ignored when `assets` is supplied.'),
+    topN: z
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('Cap the number of rows in the card (default 8). Use 50 to render the full NAVI catalog.'),
+  }),
+  jsonSchema: {
+    type: 'object',
+    properties: {
+      assets: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Filter to specific asset symbols (case-insensitive).',
+      },
+      stableOnly: {
+        type: 'boolean',
+        description: 'When true, return only stablecoin markets. Ignored when `assets` is supplied.',
+      },
+      topN: {
+        type: 'number',
+        description: 'Cap the number of rows in the card (default 8, max 50).',
+      },
+    },
+    required: [],
+  },
   isReadOnly: true,
 
-  async call(_input, context) {
+  async call(input, context) {
+    const opts = {
+      assets: input.assets,
+      stableOnly: input.stableOnly,
+      topN: input.topN ?? 8,
+    };
+
     // MCP first (real-time, includes borrow rates) — no wallet needed for global rates
     if (hasNaviMcpGlobal(context)) {
-      const rates = await fetchRates(getMcpManager(context));
-      return { data: rates, displayText: formatRatesSummary(rates) };
+      const all = await fetchRates(getMcpManager(context));
+      const filtered = applyFilters(all, opts);
+      return { data: filtered, displayText: formatRatesSummary(filtered) };
     }
 
     // SDK agent second
     if (hasAgent(context)) {
       const agent = requireAgent(context);
-      const rates = await agent.rates();
-      return { data: rates, displayText: formatRatesSummary(rates) };
+      const all = await agent.rates();
+      const filtered = applyFilters(all, opts);
+      return { data: filtered, displayText: formatRatesSummary(filtered) };
     }
 
     // DefiLlama fallback (supply-only, no borrow rates)
-    const rates = await fetchRatesFromDefiLlama();
-    return { data: rates, displayText: formatRatesSummary(rates) };
+    const all = await fetchRatesFromDefiLlama();
+    const filtered = applyFilters(all, opts);
+    return { data: filtered, displayText: formatRatesSummary(filtered) };
   },
 });
+
+// Exported for testing.
+export const _internal = { applyFilters, isStable, STABLECOIN_SYMBOLS };


### PR DESCRIPTION
## Summary

7-fix bundle (engine half) addressing baseline-test defects reported during Group A/B testing of the Spec 2 prompt runner. The audric-side companion PR (system prompt + chat-route detector) consumes this engine version.

### What changed

- **`rates_info`** — new \`assets\`, \`stableOnly\`, \`topN\` filter args so "USDC save APY" / "stablecoin lending only" / "all NAVI markets" produce a card whose rows already match the question. No more unfiltered cards followed by markdown-table dumps.
- **`transaction_history`** — new \`minUsd\`, \`assetSymbol\`, \`direction\` args so "transactions over \$5" or "USDC sends" filter at the source. \`minUsd\` uses the session price snapshot for non-stable assets and keeps unknown-price rows in (avoids silent drops).
- **`mpp_services`** — new \`mode: 'full'\` to fetch the entire catalog in one shot. Fixes the per-category enumeration loop that fired \`discover_services\` 15 times for a single "show all MPP services" prompt. Default no-args path still returns the category summary + new "or pass mode:full" hint.
- **`defillama_yield_pools`** — new \`stableOnly\` arg + tightened description so the model picks \`rates_info\` for lending and DefiLlama only for LP/farming. No more dual-tool calls in the same turn.

Tool descriptions now explicitly say "renders a card" and call out the filter args, so the LLM knows to use them at call time.

### Test plan

- [x] 8 new unit tests in \`tool-filters.test.ts\` (\`applyFilters\` covers default sort, topN, assets, stableOnly, precedence)
- [x] All 348 engine tests pass locally
- [x] Engine builds clean (\`pnpm --filter @t2000/engine build\`)
- [ ] After merge, run \`Release\` workflow (\`patch\` bump) → publishes \`@t2000/engine@0.46.6\` to npm
- [ ] Audric companion PR bumps engine pin and validates the 8 baseline defects against this build

Made with [Cursor](https://cursor.com)