### PR TITLE
fix(engine): mpp_services full catalog by default + invokeReadTool API (v0.46.7)

### DIFF
--- a/packages/engine/src/__tests__/aci-constraints.test.ts
+++ b/packages/engine/src/__tests__/aci-constraints.test.ts
@@ -121,8 +121,27 @@ describe('[v1.4 ACI] mpp_services — category summary + filter', () => {
     ) as typeof fetch;
   });
 
-  it('returns category summary when no filters supplied', async () => {
+  // [v0.46.7] Default behavior changed: no-args now returns the FULL catalog
+  // as a renderable card, not a `_refine` payload. This kills the "DISCOVER
+  // SERVICES called 15 times in a turn" loop and the "Available Services /
+  // 0 total" empty-card regression where the model called with a category
+  // guess that matched nothing.
+  it('returns the full catalog as a card when no filters supplied (v0.46.7 default)', async () => {
     const res = await mppServicesTool.call({}, baseCtx);
+    const data = res.data as {
+      services: { id: string }[];
+      total: number;
+      mode: string;
+      _refine?: unknown;
+    };
+    expect(data._refine).toBeUndefined();
+    expect(data.mode).toBe('full');
+    expect(data.total).toBe(3);
+    expect(data.services.map((s) => s.id).sort()).toEqual(['tr', 'wx', 'wx2']);
+  });
+
+  it('returns the category summary only when mode:"summary" is explicitly requested', async () => {
+    const res = await mppServicesTool.call({ mode: 'summary' }, baseCtx);
     const data = res.data as {
       _refine: { reason: string };
       categories: { category: string; services: number }[];

--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -317,7 +317,6 @@ describe('QueryEngine', () => {
         required: ['q'],
       },
       isReadOnly: true,
-      isConcurrencySafe: true,
       async call(input) {
         return { data: { echoed: input.q, ts: 'fixed' } };
       },

--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -306,6 +306,111 @@ describe('QueryEngine', () => {
     expect(messages[0].content[0]).toEqual({ type: 'text', text: 'Previous message' });
   });
 
+  describe('invokeReadTool (v0.46.7)', () => {
+    const readTool: Tool = buildTool({
+      name: 'fake_read',
+      description: 'A read-only tool',
+      inputSchema: z.object({ q: z.string() }),
+      jsonSchema: {
+        type: 'object',
+        properties: { q: { type: 'string' } },
+        required: ['q'],
+      },
+      isReadOnly: true,
+      isConcurrencySafe: true,
+      async call(input) {
+        return { data: { echoed: input.q, ts: 'fixed' } };
+      },
+    });
+
+    const writeTool: Tool = buildTool({
+      name: 'fake_write',
+      description: 'A write tool',
+      inputSchema: z.object({ amount: z.number() }),
+      jsonSchema: {
+        type: 'object',
+        properties: { amount: { type: 'number' } },
+        required: ['amount'],
+      },
+      isReadOnly: false,
+      permissionLevel: 'confirm',
+      async call(input) {
+        return { data: { ok: true, amount: input.amount } };
+      },
+    });
+
+    it('runs a read-only tool out-of-band and returns its data', async () => {
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [readTool],
+        systemPrompt: 'Test',
+      });
+
+      const result = await engine.invokeReadTool('fake_read', { q: 'hello' });
+      expect(result.isError).toBe(false);
+      expect(result.data).toEqual({ echoed: 'hello', ts: 'fixed' });
+    });
+
+    it('throws when the tool is not registered', async () => {
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [readTool],
+        systemPrompt: 'Test',
+      });
+
+      await expect(engine.invokeReadTool('does_not_exist', {})).rejects.toThrow(
+        /tool not found/i,
+      );
+    });
+
+    it('throws when the tool is not read-only', async () => {
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [writeTool],
+        systemPrompt: 'Test',
+      });
+
+      await expect(engine.invokeReadTool('fake_write', { amount: 1 })).rejects.toThrow(
+        /not read-only/i,
+      );
+    });
+
+    it('throws on input schema validation failure', async () => {
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [readTool],
+        systemPrompt: 'Test',
+      });
+
+      await expect(engine.invokeReadTool('fake_read', { q: 42 })).rejects.toThrow(
+        /invalid input/i,
+      );
+    });
+
+    it('returns isError=true when the tool throws at runtime', async () => {
+      const throwingTool: Tool = buildTool({
+        name: 'fake_throw',
+        description: 'Throws',
+        inputSchema: z.object({}),
+        jsonSchema: { type: 'object', properties: {}, required: [] },
+        isReadOnly: true,
+        async call() {
+          throw new Error('boom');
+        },
+      });
+
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [throwingTool],
+        systemPrompt: 'Test',
+      });
+
+      const result = await engine.invokeReadTool('fake_throw', {});
+      expect(result.isError).toBe(true);
+      expect(result.data).toEqual({ error: 'boom' });
+    });
+  });
+
   it('yields pending_action for write tools when no agent is configured', async () => {
     const writeTool: Tool = buildTool({
       name: 'save_deposit',

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -373,6 +373,70 @@ export class QueryEngine {
     this.messages = [...messages];
   }
 
+  /**
+   * [v0.46.7] Run a read-only tool out-of-band, using the engine's tool
+   * registry and ToolContext. Used by hosts to deterministically pre-dispatch
+   * tools based on user-message intent (e.g. always call `balance_check` when
+   * the user says "what's my net worth?", regardless of whether the LLM would
+   * have otherwise re-called it).
+   *
+   * The host is responsible for:
+   *  - Streaming the synthetic `tool_start` + `tool_result` events to the UI
+   *    (so cards render as if the LLM had called the tool).
+   *  - Appending matching `tool_use` + `tool_result` ContentBlocks to the
+   *    engine's message history via `loadMessages([...getMessages(), ...synth])`
+   *    BEFORE calling `submitMessage`, so the LLM sees the fresh data and
+   *    doesn't re-call.
+   *
+   * Throws if the tool isn't registered, isn't read-only, or fails input
+   * validation. Tool execution errors are returned as `{ data, isError: true }`
+   * for the caller to handle (typically: skip the injection so the LLM falls
+   * back to its normal flow).
+   */
+  async invokeReadTool(
+    toolName: string,
+    input: unknown,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<{ data: unknown; isError: boolean }> {
+    const tool = findTool(this.tools, toolName);
+    if (!tool) throw new Error(`invokeReadTool: tool not found: ${toolName}`);
+    if (!tool.isReadOnly) {
+      throw new Error(`invokeReadTool: tool is not read-only: ${toolName} (write tools must go through the permission gate)`);
+    }
+
+    const parsed = tool.inputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new Error(
+        `invokeReadTool: invalid input for ${toolName}: ${parsed.error.issues.map((i) => i.message).join(', ')}`,
+      );
+    }
+
+    const signal = options.signal ?? new AbortController().signal;
+    const context: ToolContext = {
+      agent: this.agent,
+      mcpManager: this.mcpManager,
+      walletAddress: this.walletAddress,
+      suiRpcUrl: this.suiRpcUrl,
+      serverPositions: this.serverPositions,
+      positionFetcher: this.positionFetcher,
+      env: this.env,
+      signal,
+      priceCache: this.priceCache,
+      permissionConfig: this.permissionConfig,
+      sessionSpendUsd: this.sessionSpendUsd,
+    };
+
+    try {
+      const result = await tool.call(parsed.data, context);
+      return { data: result.data, isError: false };
+    } catch (err) {
+      return {
+        data: { error: err instanceof Error ? err.message : 'Tool execution failed' },
+        isError: true,
+      };
+    }
+  }
+
   setServerPositions(data: EngineConfig['serverPositions']): void {
     this.serverPositions = data;
   }

--- a/packages/engine/src/tools/mpp-services.ts
+++ b/packages/engine/src/tools/mpp-services.ts
@@ -34,6 +34,21 @@ async function fetchCatalog(): Promise<GatewayService[]> {
   return data;
 }
 
+function renderServices(catalog: GatewayService[]) {
+  return catalog.map((s) => ({
+    id: s.id,
+    name: s.name,
+    description: s.description,
+    categories: s.categories,
+    endpoints: s.endpoints.map((e) => ({
+      url: `${MPP_GATEWAY}/${s.id}${e.path}`,
+      method: e.method,
+      description: e.description,
+      price: `$${e.price}`,
+    })),
+  }));
+}
+
 function matchesQuery(service: GatewayService, q: string): boolean {
   const lower = q.toLowerCase();
   return (
@@ -48,20 +63,20 @@ function matchesQuery(service: GatewayService, q: string): boolean {
 export const mppServicesTool = buildTool({
   name: 'mpp_services',
   description:
-    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Use BEFORE calling pay_api. Modes: pass `query` for keyword search, `category` to filter by category, or `mode: "full"` to fetch the ENTIRE catalog in one card (for "show me all MPP services" / "full catalog" requests — never enumerate per category in a loop). Calling with no args returns a category summary so you can narrow.',
+    'Discover available MPP gateway services. Returns service names, descriptions, endpoints with required parameters, and pricing. Use BEFORE calling pay_api. With no args, returns the FULL catalog as a single card (default behavior — covers "show me available MPP services", "what services exist", "show me all MPP services"). Use `query` to keyword-search a specific need ("translate", "weather", "postcard"). Use `category` to filter to one category. Use `mode: "summary"` only if you explicitly want a category-counts overview without the full list.',
   inputSchema: z.object({
     query: z
       .string()
       .optional()
-      .describe('Filter by keyword (e.g. "postcard", "translate", "weather").'),
+      .describe('Filter by keyword (e.g. "postcard", "translate", "weather"). Returns matching services in one card.'),
     category: z
       .string()
       .optional()
-      .describe('Filter by category exactly (e.g. "weather", "image"). See category summary returned when called without filters.'),
+      .describe('Filter by category exactly (e.g. "weather", "image"). Use mode:"summary" first if you need to see the category list.'),
     mode: z
       .enum(['summary', 'full'])
       .optional()
-      .describe('"full" returns the entire catalog in a single card — use this for "show me all MPP services" / "full catalog" requests instead of looping per category. Default is "summary" (category counts only when no filter is supplied).'),
+      .describe('"full" (default) returns the entire catalog in one card. "summary" returns category counts only — use this only when the user explicitly asks for a category overview.'),
   }),
   jsonSchema: {
     type: 'object',
@@ -77,7 +92,7 @@ export const mppServicesTool = buildTool({
       mode: {
         type: 'string',
         enum: ['summary', 'full'],
-        description: '"full" returns the entire catalog in one card. Use for "show me all" requests.',
+        description: '"full" (default) returns the entire catalog in one card. "summary" returns category counts only.',
       },
     },
     required: [],
@@ -91,36 +106,25 @@ export const mppServicesTool = buildTool({
   async call(input): Promise<{ data: Record<string, unknown>; displayText: string }> {
     const catalog = await fetchCatalog();
 
-    // [v0.46.6] Explicit "show me everything" path. The previous
-    // "no-args returns category summary + _refine hint" behavior caused
-    // the model to interpret "show all MPP services" as an instruction
-    // to enumerate every category one by one — discover_services was
-    // observed firing 15 times in a single turn. mode:'full' breaks
-    // that loop by returning the whole catalog up front.
-    if (input.mode === 'full') {
-      const services = catalog.map((s) => ({
-        id: s.id,
-        name: s.name,
-        description: s.description,
-        categories: s.categories,
-        endpoints: s.endpoints.map((e) => ({
-          url: `${MPP_GATEWAY}/${s.id}${e.path}`,
-          method: e.method,
-          description: e.description,
-          price: `$${e.price}`,
-        })),
-      }));
+    // [v0.46.7] Default behavior is now "return the full catalog as a card."
+    // Previously no-args returned a `_refine` payload that nudged the model to
+    // re-call with a category — but in practice the model often re-called with
+    // a category that returned 0 services, leaving an empty card. The full
+    // catalog is small (~40 services, ~10KB) and fits comfortably in the
+    // result budget, so there's no real cost to making it the default.
+    //
+    // The "summary" path (category counts only) is still available via the
+    // explicit `mode:'summary'` opt-in for the rare case the user really wants
+    // a category overview rather than the full list.
+    if (input.mode !== 'summary' && !input.query && !input.category) {
+      const services = renderServices(catalog);
       return {
         data: { services, total: services.length, mode: 'full' },
         displayText: `Full MPP catalog: ${services.length} services.`,
       };
     }
 
-    // [v1.4 ACI] If neither query nor category is supplied, return a
-    // category summary rather than the unbounded full catalog. The model
-    // then re-calls with a filter, which keeps the context window tight
-    // and makes the MPP discovery flow two-step (categorize → drill down).
-    if (!input.query && !input.category) {
+    if (input.mode === 'summary' && !input.query && !input.category) {
       const counts = new Map<string, number>();
       for (const svc of catalog) {
         for (const cat of svc.categories) {
@@ -133,14 +137,14 @@ export const mppServicesTool = buildTool({
       return {
         data: {
           _refine: {
-            reason: 'MPP catalog has many services — pick a category, supply a query, or pass mode:"full" to fetch everything.',
+            reason: 'Category summary (mode:"summary"). Re-call with a category or omit mode for the full catalog.',
             suggestedParams: { category: categories[0]?.category ?? 'weather' },
             allModes: ['summary', 'full'],
           },
           categories,
           totalServices: catalog.length,
         },
-        displayText: `${catalog.length} services across ${categories.length} categories. Re-call with a category, query, or mode:"full".`,
+        displayText: `${catalog.length} services across ${categories.length} categories.`,
       };
     }
 
@@ -153,18 +157,7 @@ export const mppServicesTool = buildTool({
       filtered = filtered.filter((s) => matchesQuery(s, input.query!));
     }
 
-    const services = filtered.map((s) => ({
-      id: s.id,
-      name: s.name,
-      description: s.description,
-      categories: s.categories,
-      endpoints: s.endpoints.map((e) => ({
-        url: `${MPP_GATEWAY}/${s.id}${e.path}`,
-        method: e.method,
-        description: e.description,
-        price: `$${e.price}`,
-      })),
-    }));
+    const services = renderServices(filtered);
 
     const filterDesc = [
       input.query ? `query "${input.query}"` : null,


### PR DESCRIPTION
## Summary

Two coordinated fixes for read-tool reliability, surfaced by Spec 2 baseline testing.

### 1. mpp_services no-args returns the full catalog (was: refinement payload)

Previously, calling \`mpp_services\` with no args returned a \`_refine\` shape that nudged the LLM to re-call with a category. This caused two regressions:

- **\"DISCOVER SERVICES called 15 times in a turn\"** — the model interpreted the refinement hint as \"enumerate every category one by one\" and looped
- **Empty card** — the model called with a category guess that matched nothing, producing the \"Available Services / 0 total\" card seen across 3 of the user's last test prompts (\"Show all available MPP services\", \"Show me available MPP services\", \"What MPP services exist on Sui?\") and then dumped the full catalog as unformatted text in narration

\`mode: 'summary'\` is preserved as an explicit opt-in for the rare case the user wants a category-counts overview without the full list.

### 2. New \`engine.invokeReadTool(name, input)\` public API

Lets hosts run read-only tools out-of-band using the engine's tool registry and \`ToolContext\`. Used by audric's follow-up PR (\`intent-dispatcher\`) to deterministically pre-dispatch tools based on user-message intent — fixing the long-tail \"What's my net worth?\" / \"Am I at risk of liquidation?\" / \"Run a full health check\" misses where the LLM skipped the tool call because it judged earlier-turn data \"fresh enough\".

Properties:
- Throws on missing tool, non-readonly tool, and input validation failure
- Returns \`{ data, isError: true }\` for runtime errors so callers can gracefully fall back to the normal LLM flow
- Uses the same \`ToolContext\` (agent, mcpManager, walletAddress, suiRpcUrl, positions, env, signal, priceCache, permissionConfig, sessionSpendUsd) that the agent loop uses

### Why this matters

The user explicitly called out the prompt-rule approach as whack-a-mole. \`invokeReadTool\` is the architectural primitive that lets us move \"must re-call balance_check on direct read questions\" from a prompt rule (probabilistic, ignorable by the LLM) to deterministic code (0% miss rate by construction).

## Test plan

- [x] \`pnpm --filter @t2000/engine typecheck\` passes
- [x] \`pnpm --filter @t2000/engine test\` — 354/354 pass (5 new tests for \`invokeReadTool\` + 1 updated mpp_services test)
- [ ] After merge: trigger Release workflow with patch bump → \`v0.46.7\`
- [ ] Audric companion PR bumps \`@t2000/engine\` and \`@t2000/sdk\` to \`0.46.7\`

Made with [Cursor](https://cursor.com)