### PR TITLE
fix(engine): TurnReadCache eliminates duplicate read-tool cards (v0.46.8)

### DIFF
--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -410,6 +410,231 @@ describe('QueryEngine', () => {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // [v0.46.8] Intra-turn read tool cache (TurnReadCache)
+  //
+  // The agent loop must not double-render cards when the same read-only
+  // tool is called twice in one turn. This block exercises every entry
+  // point that touches the cache:
+  //   - host pre-dispatch via `invokeReadTool`
+  //   - LLM-driven `tool_use` mid-turn
+  //   - cache invalidation on a successful write
+  //   - cache reset at turn boundaries
+  // ---------------------------------------------------------------------------
+  describe('TurnReadCache (v0.46.8)', () => {
+    function buildCountingReadTool(name: string): { tool: Tool; getCallCount: () => number } {
+      let calls = 0;
+      const tool: Tool = buildTool({
+        name,
+        description: `Counting read tool ${name}`,
+        inputSchema: z.object({ q: z.string().optional() }),
+        jsonSchema: {
+          type: 'object',
+          properties: { q: { type: 'string' } },
+        },
+        isReadOnly: true,
+        async call(input) {
+          calls++;
+          return { data: { name, q: input.q ?? null, callNumber: calls } };
+        },
+      });
+      return { tool, getCallCount: () => calls };
+    }
+
+    function buildCountingWriteTool(name: string): { tool: Tool; getCallCount: () => number } {
+      let calls = 0;
+      const tool: Tool = buildTool({
+        name,
+        description: `Counting write tool ${name}`,
+        inputSchema: z.object({ amount: z.number() }),
+        jsonSchema: {
+          type: 'object',
+          properties: { amount: { type: 'number' } },
+          required: ['amount'],
+        },
+        isReadOnly: false,
+        permissionLevel: 'auto',
+        async call(input) {
+          calls++;
+          return { data: { ok: true, amount: input.amount, callNumber: calls } };
+        },
+      });
+      return { tool, getCallCount: () => calls };
+    }
+
+    it('LLM calling the same read tool twice in one turn dedups the second call', async () => {
+      const { tool, getCallCount } = buildCountingReadTool('balance_check');
+
+      // Provider scripts THREE turns:
+      //   1. LLM calls balance_check
+      //   2. LLM calls balance_check AGAIN (TurnReadCache should dedup)
+      //   3. LLM responds with text (microcompact may emit a retroactive
+      //      cross-turn dedup marker for the second call here — that's
+      //      a separate, complementary mechanism and is fine)
+      const provider = createMockProvider([
+        [{ type: 'tool_call', id: 'tc-1', name: 'balance_check', input: { q: 'first' } }],
+        [{ type: 'tool_call', id: 'tc-2', name: 'balance_check', input: { q: 'first' } }],
+        [{ type: 'text', text: 'done' }],
+      ]);
+
+      const engine = new QueryEngine({
+        provider,
+        tools: [tool],
+        systemPrompt: 'Test',
+      });
+
+      const events = await collectEvents(engine.submitMessage('What is my balance?'));
+
+      // The actual tool implementation should run exactly ONCE — this
+      // is the contract that prevents duplicate cards in the UI.
+      expect(getCallCount()).toBe(1);
+
+      // Filter to dispatcher-emitted tool_results (preserve the real
+      // toolName). Microcompact emits its own cross-turn dedup events
+      // with `toolName: '__deduped__'` which we exclude here.
+      const dispatcherResults = events.filter(
+        (e): e is Extract<EngineEvent, { type: 'tool_result' }> =>
+          e.type === 'tool_result' && e.toolName !== '__deduped__',
+      );
+      expect(dispatcherResults).toHaveLength(2);
+      expect(dispatcherResults[0].resultDeduped).toBeFalsy();
+      // The second dispatch hits the TurnReadCache and is flagged.
+      expect(dispatcherResults[1].resultDeduped).toBe(true);
+      // The deduped event still carries the cached result so the LLM
+      // can satisfy its tool_use_id obligation.
+      expect(dispatcherResults[1].result).toEqual(dispatcherResults[0].result);
+      expect(dispatcherResults[1].toolName).toBe('balance_check');
+    });
+
+    it('different inputs to the same read tool do NOT dedup', async () => {
+      const { tool, getCallCount } = buildCountingReadTool('rates_info');
+
+      const provider = createMockProvider([
+        [{ type: 'tool_call', id: 'tc-1', name: 'rates_info', input: { q: 'usdc' } }],
+        [{ type: 'tool_call', id: 'tc-2', name: 'rates_info', input: { q: 'sui' } }],
+        [{ type: 'text', text: 'done' }],
+      ]);
+
+      const engine = new QueryEngine({
+        provider,
+        tools: [tool],
+        systemPrompt: 'Test',
+      });
+
+      await collectEvents(engine.submitMessage('Show me rates'));
+
+      // Two distinct inputs → two real executions.
+      expect(getCallCount()).toBe(2);
+    });
+
+    it('host pre-dispatch via invokeReadTool causes a subsequent LLM call to dedup', async () => {
+      const { tool, getCallCount } = buildCountingReadTool('balance_check');
+
+      const provider = createMockProvider([
+        // LLM (somehow) decides to call balance_check too — must dedup
+        // against the host pre-dispatch.
+        [{ type: 'tool_call', id: 'tc-llm', name: 'balance_check', input: {} }],
+        [{ type: 'text', text: 'done' }],
+      ]);
+
+      const engine = new QueryEngine({
+        provider,
+        tools: [tool],
+        systemPrompt: 'Test',
+      });
+
+      // Simulate the host's pre-dispatch flow.
+      const preResult = await engine.invokeReadTool('balance_check', {});
+      expect(preResult.isError).toBe(false);
+      expect(getCallCount()).toBe(1);
+
+      // The host would also inject the synthetic tool_use+tool_result
+      // pair into the message ledger here. For this test we don't need
+      // to — we're just verifying the cache-based dedup of the LLM call.
+      const events = await collectEvents(engine.submitMessage('What is my balance?'));
+
+      // The LLM's call should NOT have re-executed the tool — cache hit.
+      expect(getCallCount()).toBe(1);
+
+      const toolResults = events.filter(
+        (e): e is Extract<EngineEvent, { type: 'tool_result' }> => e.type === 'tool_result',
+      );
+      // Exactly ONE tool_result event in the agent loop, flagged deduped.
+      expect(toolResults).toHaveLength(1);
+      expect(toolResults[0].resultDeduped).toBe(true);
+    });
+
+    it('invokeReadTool is itself idempotent within a turn (second call hits cache)', async () => {
+      const { tool, getCallCount } = buildCountingReadTool('balance_check');
+
+      const engine = new QueryEngine({
+        provider: createMockProvider([]),
+        tools: [tool],
+        systemPrompt: 'Test',
+      });
+
+      const r1 = await engine.invokeReadTool('balance_check', {});
+      const r2 = await engine.invokeReadTool('balance_check', {});
+
+      expect(getCallCount()).toBe(1);
+      expect(r2.data).toEqual(r1.data);
+    });
+
+    it('a successful write tool invalidates the read cache mid-turn', async () => {
+      const { tool: readTool, getCallCount: getReadCount } = buildCountingReadTool('balance_check');
+      const { tool: writeTool } = buildCountingWriteTool('save_deposit');
+
+      // Provider scripts:
+      //   1. LLM calls read
+      //   2. LLM calls write (auto-approved → executes inline, invalidates cache)
+      //   3. LLM calls read AGAIN (must NOT dedup — cache cleared by write)
+      //   4. LLM responds
+      const provider = createMockProvider([
+        [{ type: 'tool_call', id: 'r-1', name: 'balance_check', input: {} }],
+        [{ type: 'tool_call', id: 'w-1', name: 'save_deposit', input: { amount: 5 } }],
+        [{ type: 'tool_call', id: 'r-2', name: 'balance_check', input: {} }],
+        [{ type: 'text', text: 'done' }],
+      ]);
+
+      const engine = new QueryEngine({
+        provider,
+        // `agent` defined so the auto-approved write can execute server-side.
+        agent: {},
+        tools: [readTool, writeTool],
+        systemPrompt: 'Test',
+      });
+
+      await collectEvents(engine.submitMessage('Read, write, read'));
+
+      // Both reads should have actually executed — write invalidated the cache.
+      expect(getReadCount()).toBe(2);
+    });
+
+    it('cache resets between turns (turn N entries do NOT dedup turn N+1 calls)', async () => {
+      const { tool, getCallCount } = buildCountingReadTool('balance_check');
+
+      // Two separate user turns. Each calls balance_check once.
+      const provider = createMockProvider([
+        [{ type: 'tool_call', id: 'r-1', name: 'balance_check', input: {} }],
+        [{ type: 'text', text: 'done' }],
+        [{ type: 'tool_call', id: 'r-2', name: 'balance_check', input: {} }],
+        [{ type: 'text', text: 'done' }],
+      ]);
+
+      const engine = new QueryEngine({
+        provider,
+        tools: [tool],
+        systemPrompt: 'Test',
+      });
+
+      await collectEvents(engine.submitMessage('First'));
+      await collectEvents(engine.submitMessage('Second'));
+
+      // Both turns executed the tool — cache cleared at turn boundary.
+      expect(getCallCount()).toBe(2);
+    });
+  });
+
   it('yields pending_action for write tools when no agent is configured', async () => {
     const writeTool: Tool = buildTool({
       name: 'save_deposit',

--- a/packages/engine/src/__tests__/turn-read-cache.test.ts
+++ b/packages/engine/src/__tests__/turn-read-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { TurnReadCache } from '../turn-read-cache.js';
+
+describe('TurnReadCache.keyFor', () => {
+  it('produces the same key for empty input regardless of representation', () => {
+    expect(TurnReadCache.keyFor('balance_check', {})).toBe(
+      TurnReadCache.keyFor('balance_check', {}),
+    );
+  });
+
+  it('produces stable keys regardless of object key ordering', () => {
+    const a = TurnReadCache.keyFor('rates_info', { stableOnly: true, topN: 5 });
+    const b = TurnReadCache.keyFor('rates_info', { topN: 5, stableOnly: true });
+    expect(a).toBe(b);
+  });
+
+  it('handles nested objects with stable key ordering', () => {
+    const a = TurnReadCache.keyFor('q', { filter: { min: 1, max: 10 } });
+    const b = TurnReadCache.keyFor('q', { filter: { max: 10, min: 1 } });
+    expect(a).toBe(b);
+  });
+
+  it('different tool names produce different keys for identical inputs', () => {
+    const a = TurnReadCache.keyFor('balance_check', {});
+    const b = TurnReadCache.keyFor('health_check', {});
+    expect(a).not.toBe(b);
+  });
+
+  it('different inputs produce different keys for the same tool', () => {
+    const a = TurnReadCache.keyFor('rates_info', {});
+    const b = TurnReadCache.keyFor('rates_info', { stableOnly: true });
+    expect(a).not.toBe(b);
+  });
+
+  it('arrays preserve order in the key', () => {
+    const a = TurnReadCache.keyFor('q', { assets: ['USDC', 'SUI'] });
+    const b = TurnReadCache.keyFor('q', { assets: ['SUI', 'USDC'] });
+    // Arrays are order-significant — different ordering is a different
+    // semantic query, not equivalent.
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('TurnReadCache lifecycle', () => {
+  it('returns undefined for an unknown key', () => {
+    const cache = new TurnReadCache();
+    expect(cache.get('missing')).toBeUndefined();
+    expect(cache.has('missing')).toBe(false);
+  });
+
+  it('stores and retrieves entries', () => {
+    const cache = new TurnReadCache();
+    const key = TurnReadCache.keyFor('balance_check', {});
+    cache.set(key, { result: { total: 100 }, sourceToolUseId: 'tc-1' });
+    expect(cache.has(key)).toBe(true);
+    expect(cache.get(key)).toEqual({ result: { total: 100 }, sourceToolUseId: 'tc-1' });
+  });
+
+  it('overwrites prior entries when the same key is set again', () => {
+    const cache = new TurnReadCache();
+    const key = TurnReadCache.keyFor('balance_check', {});
+    cache.set(key, { result: { total: 100 }, sourceToolUseId: 'tc-1' });
+    cache.set(key, { result: { total: 200 }, sourceToolUseId: 'tc-2' });
+    expect(cache.get(key)?.result).toEqual({ total: 200 });
+    expect(cache.get(key)?.sourceToolUseId).toBe('tc-2');
+  });
+
+  it('clear() drops every entry', () => {
+    const cache = new TurnReadCache();
+    cache.set(TurnReadCache.keyFor('balance_check', {}), {
+      result: 1, sourceToolUseId: 'a',
+    });
+    cache.set(TurnReadCache.keyFor('health_check', {}), {
+      result: 2, sourceToolUseId: 'b',
+    });
+    expect(cache.size()).toBe(2);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+    expect(cache.has(TurnReadCache.keyFor('balance_check', {}))).toBe(false);
+  });
+});

--- a/packages/engine/src/early-dispatcher.ts
+++ b/packages/engine/src/early-dispatcher.ts
@@ -13,37 +13,82 @@
 import type { EngineEvent, Tool, ToolContext } from './types.js';
 import { findTool } from './tool.js';
 import { budgetToolResult, type PendingToolCall } from './orchestration.js';
+import { TurnReadCache } from './turn-read-cache.js';
 
 interface DispatchEntry {
   call: PendingToolCall;
   tool: Tool;
   promise: Promise<{ data: unknown; isError: boolean }>;
+  /**
+   * [v0.46.8] True when this entry was satisfied from the
+   * `TurnReadCache` rather than a fresh tool execution. The
+   * `collectResults` stream surfaces these as `resultDeduped: true` so
+   * hosts can skip rendering a duplicate card while the LLM still gets
+   * the data it needs to answer its `tool_use_id`.
+   */
+  deduped: boolean;
 }
 
 export class EarlyToolDispatcher {
   private entries: DispatchEntry[] = [];
   private readonly tools: Tool[];
   private readonly context: ToolContext;
+  private readonly turnReadCache: TurnReadCache | undefined;
   private abortController: AbortController;
 
-  constructor(tools: Tool[], context: ToolContext) {
+  constructor(tools: Tool[], context: ToolContext, turnReadCache?: TurnReadCache) {
     this.tools = tools;
     this.context = context;
+    this.turnReadCache = turnReadCache;
     this.abortController = new AbortController();
   }
 
   /**
    * Attempt to dispatch a tool call. Returns true if the tool was dispatched
    * (read-only + concurrency-safe), false if it should be queued for later.
+   *
+   * [v0.46.8] Cache-aware: if a `TurnReadCache` was supplied at
+   * construction and a prior call this turn already produced a result
+   * for the same `(toolName, input)`, the dispatcher returns true (the
+   * call IS handled here, not queued for the post-stream loop) but
+   * skips the tool execution entirely — `collectResults` will surface
+   * the cached value with `resultDeduped: true`. On a cache miss for
+   * a successful real execution, the result is written back to the
+   * cache so any later call within the same turn dedups too.
    */
   tryDispatch(call: PendingToolCall): boolean {
     const tool = findTool(this.tools, call.name);
     if (!tool || !tool.isReadOnly || !tool.isConcurrencySafe) return false;
 
-    const childContext = { ...this.context, signal: this.abortController.signal };
-    const promise = executeTool(tool, call, childContext);
+    if (this.turnReadCache) {
+      const cacheKey = TurnReadCache.keyFor(call.name, call.input);
+      const cached = this.turnReadCache.get(cacheKey);
+      if (cached) {
+        this.entries.push({
+          call,
+          tool,
+          promise: Promise.resolve({ data: cached.result, isError: false }),
+          deduped: true,
+        });
+        return true;
+      }
+    }
 
-    this.entries.push({ call, tool, promise });
+    const childContext = { ...this.context, signal: this.abortController.signal };
+    const promise = executeTool(tool, call, childContext).then((result) => {
+      // Populate the cache on a successful, non-cached execution so a
+      // later identical call this turn dedups instead of re-running.
+      if (!result.isError && this.turnReadCache) {
+        const cacheKey = TurnReadCache.keyFor(call.name, call.input);
+        this.turnReadCache.set(cacheKey, {
+          result: result.data,
+          sourceToolUseId: call.id,
+        });
+      }
+      return result;
+    });
+
+    this.entries.push({ call, tool, promise, deduped: false });
     return true;
   }
 
@@ -76,6 +121,7 @@ export class EarlyToolDispatcher {
           result: budgeted,
           isError: result.isError,
           wasEarlyDispatched: true,
+          ...(entry.deduped ? { resultDeduped: true } : {}),
         };
       } catch (err) {
         yield {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -34,6 +34,7 @@ import { ContextBudget, compactMessages } from './context.js';
 import { microcompact } from './compact/microcompact.js';
 import { resolvePermissionTier, resolveUsdValue, toolNameToOperation } from './permission-rules.js';
 import { EarlyToolDispatcher } from './early-dispatcher.js';
+import { TurnReadCache } from './turn-read-cache.js';
 
 const DEFAULT_MAX_TURNS = 10;
 const DEFAULT_MAX_TOKENS = 4096;
@@ -84,6 +85,18 @@ export class QueryEngine {
   private messages: Message[] = [];
   private abortController: AbortController | null = null;
   private guardEvents: GuardEvent[] = [];
+  // [v0.46.8] Intra-turn dedup cache for read-only tool calls. See
+  // `turn-read-cache.ts` for the full lifecycle. Key takeaway: the cache
+  // lives across the host's pre-dispatch (`invokeReadTool`) and the
+  // agent loop's LLM-driven tool execution within ONE user turn, then
+  // clears on `turn_complete` or after any successful write.
+  private readonly turnReadCache = new TurnReadCache();
+  // [v0.46.8] Set to `true` when the agent loop yields `pending_action`
+  // and returns (turn is paused awaiting user confirmation). The
+  // submitMessage / resumeWithToolResult wrappers consult this flag in
+  // their `finally` block so they DON'T clear the cache mid-turn — the
+  // pending write may resume, and the cache should survive the pause.
+  private turnPaused = false;
 
   constructor(config: EngineConfig) {
     this.provider = config.provider;
@@ -143,7 +156,22 @@ export class QueryEngine {
       content: [{ type: 'text', text: prompt }],
     });
 
-    yield* this.agentLoop(prompt, signal);
+    // [v0.46.8] Reset the pause flag at turn start. Any cache entries
+    // populated by the host's pre-dispatch (`invokeReadTool`) BEFORE
+    // this call MUST survive into the agent loop so LLM-driven calls
+    // for the same tools dedup. We do NOT clear the cache here.
+    this.turnPaused = false;
+    try {
+      yield* this.agentLoop(prompt, signal);
+    } finally {
+      // Turn boundary cleanup: drop the cache so the next user turn
+      // starts with a clean slate. Skip when the turn was paused via
+      // `pending_action` — the cache must survive the pause so the
+      // resumed turn (which is the SAME turn) keeps deduping.
+      if (!this.turnPaused) {
+        this.turnReadCache.clear();
+      }
+    }
   }
 
   /**
@@ -204,8 +232,16 @@ export class QueryEngine {
 
     if (!response.approved) {
       yield { type: 'turn_complete', stopReason: 'end_turn' };
+      // Turn ended (user declined) — drop the cache.
+      this.turnReadCache.clear();
       return;
     }
+
+    // [v0.46.8] A successful approved write MUTATES on-chain state, so
+    // any read-tool result cached during the pre-pause portion of this
+    // turn is now stale. Drop it before the post-write refresh fires —
+    // refresh tools will re-execute and re-populate with fresh data.
+    this.turnReadCache.clear();
 
     // [v1.5] Post-write refresh — eliminate the "LLM invents a wallet
     // total in the post-write narration" hallucination class by
@@ -216,7 +252,19 @@ export class QueryEngine {
     // narration even if RPC blips.
     yield* this.runPostWriteRefresh(action, response, signal);
 
-    yield* this.agentLoop(null, signal, false);
+    // [v0.46.8] Reset the pause flag and wrap the resumed agentLoop in
+    // try/finally for cache cleanup, mirroring submitMessage. The
+    // post-write refresh above re-populated the cache with fresh
+    // post-write reads; agentLoop may add more during follow-up tool
+    // calls; finally clears it at turn end (skipping when paused).
+    this.turnPaused = false;
+    try {
+      yield* this.agentLoop(null, signal, false);
+    } finally {
+      if (!this.turnPaused) {
+        this.turnReadCache.clear();
+      }
+    }
   }
 
   /**
@@ -328,8 +376,17 @@ export class QueryEngine {
     this.messages.push({ role: 'user', content: refreshResults });
 
     // Yield events so hosts log them in `TurnMetrics.toolsCalled[]` and
-    // the UI renders the refreshed cards in-line.
+    // the UI renders the refreshed cards in-line. Also populate the
+    // intra-turn cache so any LLM-driven `tool_use` for the same
+    // (name, input) during the resumed agent loop dedups instead of
+    // double-rendering on top of the refresh card.
     for (const r of refreshes) {
+      if (!r.isError) {
+        this.turnReadCache.set(
+          TurnReadCache.keyFor(r.tool.name, {}),
+          { result: r.data, sourceToolUseId: r.id },
+        );
+      }
       yield {
         type: 'tool_result',
         toolName: r.tool.name,
@@ -411,6 +468,17 @@ export class QueryEngine {
       );
     }
 
+    // [v0.46.8] Intra-turn cache: if the same tool was already invoked
+    // (either via a prior `invokeReadTool` call or by the LLM mid-turn),
+    // return the cached result without re-fetching. Makes pre-dispatch
+    // idempotent — calling `invokeReadTool('balance_check', {})` twice
+    // back-to-back hits RPC once, not twice.
+    const cacheKey = TurnReadCache.keyFor(toolName, parsed.data);
+    const cached = this.turnReadCache.get(cacheKey);
+    if (cached) {
+      return { data: cached.result, isError: false };
+    }
+
     const signal = options.signal ?? new AbortController().signal;
     const context: ToolContext = {
       agent: this.agent,
@@ -428,8 +496,17 @@ export class QueryEngine {
 
     try {
       const result = await tool.call(parsed.data, context);
+      // Cache the successful result so a subsequent LLM-driven
+      // `tool_use` for the same (name, input) hits the dedup path in
+      // the agent loop and the host doesn't render a duplicate card.
+      this.turnReadCache.set(cacheKey, {
+        result: result.data,
+        sourceToolUseId: 'invokeReadTool',
+      });
       return { data: result.data, isError: false };
     } catch (err) {
+      // Errors are NOT cached — the next call should retry, not see a
+      // stale failure.
       return {
         data: { error: err instanceof Error ? err.message : 'Tool execution failed' },
         isError: true,
@@ -493,7 +570,7 @@ export class QueryEngine {
         pendingToolCalls: [],
       };
 
-      const dispatcher = new EarlyToolDispatcher(this.tools, context);
+      const dispatcher = new EarlyToolDispatcher(this.tools, context, this.turnReadCache);
 
       try {
         // B.3: Zero-cost dedup of identical tool calls every turn.
@@ -706,6 +783,36 @@ export class QueryEngine {
       for (const call of acc.pendingToolCalls) {
         const tool = findTool(this.tools, call.name);
 
+        // [v0.46.8] Intra-turn dedup for read-only tools. If the host
+        // pre-dispatched this tool (via `invokeReadTool`) or the LLM
+        // already called it earlier in the same turn, skip execution
+        // and emit a deduped `tool_result` so the host can suppress
+        // a duplicate card render. The LLM still gets a valid
+        // `tool_result` block keyed to ITS `tool_use_id`, satisfying
+        // the Anthropic protocol requirement that every `tool_use`
+        // be answered by a matching `tool_result`.
+        if (tool && tool.isReadOnly) {
+          const cacheKey = TurnReadCache.keyFor(call.name, call.input);
+          const cached = this.turnReadCache.get(cacheKey);
+          if (cached) {
+            yield {
+              type: 'tool_result',
+              toolName: call.name,
+              toolUseId: call.id,
+              result: cached.result,
+              isError: false,
+              resultDeduped: true,
+            };
+            toolResultBlocks.push({
+              type: 'tool_result',
+              toolUseId: call.id,
+              content: JSON.stringify(cached.result),
+              isError: false,
+            });
+            continue;
+          }
+        }
+
         const needsConfirmation = (() => {
           if (!tool || tool.isReadOnly) return false;
           if (tool.permissionLevel === 'explicit') return true;
@@ -846,6 +953,26 @@ export class QueryEngine {
             ? { ...toolEvent, result: enrichedResult }
             : toolEvent;
 
+          // [v0.46.8] Maintain the intra-turn read cache:
+          //  - Successful read → populate so subsequent identical
+          //    calls within the same turn dedup.
+          //  - Successful write → invalidate the entire cache; on-chain
+          //    state has changed, any prior read snapshot is stale.
+          //  - Errored result → leave cache untouched; retry should
+          //    re-execute.
+          if (!finalEvent.isError && tool) {
+            if (tool.isReadOnly) {
+              const inputForKey = originalCall?.input ?? {};
+              const cacheKey = TurnReadCache.keyFor(finalEvent.toolName, inputForKey);
+              this.turnReadCache.set(cacheKey, {
+                result: finalEvent.result,
+                sourceToolUseId: finalEvent.toolUseId,
+              });
+            } else {
+              this.turnReadCache.clear();
+            }
+          }
+
           yield finalEvent;
 
           if (finalEvent.type === 'tool_result' && !finalEvent.isError) {
@@ -951,6 +1078,11 @@ export class QueryEngine {
         const modifiableFields = getModifiableFields(pendingWrite.call.name);
         const turnIndex = this.messages.filter((m) => m.role === 'assistant').length;
 
+        // [v0.46.8] Mark the turn as paused so the submitMessage /
+        // resumeWithToolResult `finally` blocks DON'T clear the cache.
+        // The pending write may resume; cache must survive the pause
+        // so post-resume execution still benefits from intra-turn dedup.
+        this.turnPaused = true;
         yield {
           type: 'pending_action',
           action: {

--- a/packages/engine/src/turn-read-cache.ts
+++ b/packages/engine/src/turn-read-cache.ts
@@ -1,0 +1,119 @@
+/**
+ * [v0.46.8] Intra-turn deduplication of read-only tool calls.
+ *
+ * # Problem
+ * Two independent execution paths can call the same read-only tool within
+ * the same user turn:
+ *   1. Host pre-dispatch via `engine.invokeReadTool()` (deterministic — runs
+ *      before the LLM ever sees the message; injects a synthetic
+ *      `tool_use`+`tool_result` pair into the ledger so the card renders
+ *      immediately and the LLM has the data).
+ *   2. The LLM itself, mid-turn, emitting a `tool_use` block for the same
+ *      tool (often because the prompt says "always call balance_check on
+ *      direct read questions" and the model doesn't trust the synthetic
+ *      pair).
+ *
+ * Both paths emit a `tool_result` SSE event, the host renders BOTH cards,
+ * the user sees a duplicate. Coordinating these two paths via prompt rules
+ * is probabilistic ("DO NOT re-call when you see a synthetic pair") and
+ * has empirically shown ~30% miss rate — the LLM still re-calls anyway.
+ *
+ * # Fix
+ * Idempotent intra-turn cache. Within one user turn:
+ *   - Calling the same read-only tool with the same args twice returns the
+ *     cached result on the second call.
+ *   - The second call yields a `tool_result` event with `resultDeduped:true`
+ *     so hosts can skip rendering a duplicate card while the LLM still gets
+ *     the data it needs to satisfy its `tool_use` id.
+ *
+ * # Lifecycle
+ *   - Cache lives on the `QueryEngine` instance.
+ *   - Populated by `invokeReadTool` (host pre-dispatch) AND by the agent
+ *     loop's tool-execution path (LLM-driven calls).
+ *   - Cleared on `turn_complete` (clean slate for the next user turn).
+ *   - Cleared whenever a WRITE tool executes successfully (writes mutate
+ *     on-chain state, so any subsequent read in the same turn must re-fetch
+ *     for freshness).
+ *   - Cleared on errors / abort (defensive cleanup).
+ *
+ * # Why not just extend microcompact?
+ * `microcompact` does CROSS-turn dedup, but explicitly excludes
+ * `cacheable: false` tools (balance_check, health_check, savings_info,
+ * transaction_history) so post-write refreshes always surface fresh data.
+ * Within a single turn (pre-write), those same tools are perfectly
+ * dedup-able — state can't change. This cache fills that exact gap.
+ *
+ * # Invariants
+ *   - Read-only tools only. Write tools never enter the cache.
+ *   - Errored results are NEVER cached (the next call should retry).
+ *   - Cache key includes the full input, stably stringified — different
+ *     filter args (e.g. `transaction_history({minUsd:5})` vs
+ *     `transaction_history({})`) hit different cache entries.
+ */
+export class TurnReadCache {
+  private readonly store = new Map<string, { result: unknown; sourceToolUseId: string }>();
+
+  /**
+   * Build the cache key for a (toolName, input) pair. Stable across object
+   * key ordering so `{a:1,b:2}` and `{b:2,a:1}` map to the same entry.
+   */
+  static keyFor(toolName: string, input: unknown): string {
+    return `${toolName}:${stableStringify(input)}`;
+  }
+
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+
+  get(key: string): { result: unknown; sourceToolUseId: string } | undefined {
+    return this.store.get(key);
+  }
+
+  /**
+   * Populate the cache. Caller is responsible for ensuring the result was
+   * a successful read (no errors). Overwrites any prior entry for the same
+   * key — the most recent successful read wins, which is correct under our
+   * "writes invalidate the whole cache" invariant.
+   */
+  set(key: string, value: { result: unknown; sourceToolUseId: string }): void {
+    this.store.set(key, value);
+  }
+
+  /**
+   * Drop every entry. Called at turn end and after every successful write.
+   * Cheap and intentional — the cache is small (a handful of entries per
+   * turn at most) and clearing is the correct response to any state mutation.
+   */
+  clear(): void {
+    this.store.clear();
+  }
+
+  size(): number {
+    return this.store.size;
+  }
+}
+
+/**
+ * Stable JSON.stringify — sorts object keys recursively so semantically
+ * equal inputs produce equal cache keys. Mirrors the helper in
+ * `compact/microcompact.ts` so dedup keys agree across both layers.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return JSON.stringify(value.map(stableStringifyForObject));
+  return stableStringifyForObject(value);
+}
+
+function stableStringifyForObject(value: unknown): string {
+  if (value === null || value === undefined) return JSON.stringify(value);
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringifyForObject).join(',')}]`;
+  }
+  const sorted = Object.keys(value as Record<string, unknown>).sort();
+  const parts = sorted.map(
+    (k) => `${JSON.stringify(k)}:${stableStringifyForObject((value as Record<string, unknown>)[k])}`,
+  );
+  return `{${parts.join(',')}}`;
+}


### PR DESCRIPTION
## Problem

After v0.46.7 shipped intent-driven pre-dispatch, baseline testing showed duplicate cards rendering for direct read questions:

- "What's my balance?" → 2 BALANCE CHECK cards
- "Run a full health check" → 2 HEALTH CHECK cards (+ supplementary cards)
- "Show available MPP services" → 2 DISCOVER SERVICES cards (one full, one empty)

Two independent execution paths can each emit a `tool_result` event for the same tool in the same turn:

1. The deterministic dispatcher (host → `invokeReadTool` → SSE event)
2. The LLM (calls the tool itself → SSE event)

Coordinating them via prompt rules ("DO NOT re-call when you see a synthetic pair") had ~30% miss rate empirically — not acceptable for a production system.

## Fix

Engine-side intra-turn cache for read-only tool calls (`TurnReadCache`).

Within ONE user turn, calling the same read-only tool with the same args twice is now idempotent:

- The first call executes for real and caches the result.
- Any subsequent call (whether from `invokeReadTool`, the early dispatcher, or the post-LLM execution loop) returns the cached result and emits a `tool_result` event with `resultDeduped: true`, so hosts can skip rendering a duplicate card while the LLM still gets the data it needs to satisfy its `tool_use_id`.

## Cache lifecycle

| Event | Cache action |
|---|---|
| `invokeReadTool` succeeds | Populate |
| Early dispatcher executes a read | Populate |
| Agent loop executes a read | Populate |
| Same `(toolName, input)` called again | Hit → emit `resultDeduped: true` |
| Any write tool succeeds | Invalidate (state changed) |
| `pending_action` (turn paused) | Survive — resume continues same turn |
| User declines write | Clear (turn ended) |
| `turn_complete` | Clear (next turn starts fresh) |

## Why this is the right architectural fix

- **Deterministic** — code, not probability. 0% miss rate on identical (name, input) within a turn.
- **Generalizes beyond the dispatcher** — catches any LLM accidental double-call in a multi-step loop.
- **Correct freshness** — writes invalidate the cache, so post-write reads always see fresh state.
- **Simplifies the prompt** — no more "DO NOT re-call" rules fighting the model.

## Compatibility

- New event field `resultDeduped: true` on the existing `tool_result` event type (already declared in `types.ts` for microcompact). Hosts that ignore the field continue to render duplicates as before; the audric companion PR honors it.
- `cacheable: false` tools (balance_check, health_check, savings_info, transaction_history) still skip cross-turn microcompact dedup — the TurnReadCache only operates within a single turn.
- `EarlyToolDispatcher` constructor takes an optional `TurnReadCache` third argument — back-compat for any direct constructor callers.

## Tests

- 6 new `TurnReadCache` class tests (key stability across object key ordering, lifecycle).
- 6 new engine integration tests:
  - LLM calling same read tool twice in one turn dedups the second call
  - Different inputs to the same tool do NOT dedup
  - Host pre-dispatch via `invokeReadTool` causes subsequent LLM call to dedup
  - `invokeReadTool` is idempotent within a turn
  - Successful write invalidates the cache mid-turn
  - Cache resets between turns (turn N entries don't dedup turn N+1 calls)

All 370 tests pass.

## Test plan

- [x] Unit tests cover all entry points and lifecycle transitions
- [x] `pnpm --filter @t2000/engine test` — 370 passing
- [x] `pnpm --filter @t2000/engine build` — clean
- [x] `pnpm --filter @t2000/engine lint` — clean (0 errors, only pre-existing warnings)
- [ ] Audric companion PR consumes `resultDeduped` flag and skips duplicate card rendering

Made with [Cursor](https://cursor.com)