### PR TITLE
feat(engine): send_transfer accepts asset + asset-intent guard

### DIFF
--- a/packages/engine/src/__tests__/guard-asset-intent.test.ts
+++ b/packages/engine/src/__tests__/guard-asset-intent.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  runGuards,
+  createGuardRunnerState,
+  extractConversationText,
+  DEFAULT_GUARD_CONFIG,
+} from '../guards.js';
+import { buildTool } from '../tool.js';
+import type { PendingToolCall } from '../orchestration.js';
+
+/**
+ * Regression tests for the asset-intent guard.
+ *
+ * Failure mode being prevented: the user asks "send my SUI to 0x...",
+ * the LLM calls send_transfer with no `asset` field, the tool defaults
+ * to USDC, and the wrong token is shipped. We block the call so the
+ * LLM is forced to re-issue with `asset: "SUI"`.
+ */
+
+const sendTransfer = buildTool({
+  name: 'send_transfer',
+  description: 'send',
+  inputSchema: z.object({
+    to: z.string(),
+    amount: z.number(),
+    asset: z.string().optional(),
+  }),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: false,
+  flags: { mutating: true, irreversible: true, requiresBalance: true },
+  call: async () => ({ data: {} }),
+});
+
+const KNOWN = '0x231455f0e9805bdd0945981463daf0346310a7b3b04a733b011cc791feb896cd';
+
+function makeCall(input: Record<string, unknown>): PendingToolCall {
+  return { id: 'tool_use_1', name: 'send_transfer', input };
+}
+
+function makeConvCtx(userText: string) {
+  return extractConversationText([
+    { role: 'user', content: [{ type: 'text', text: userText }] },
+  ]);
+}
+
+describe('guardAssetIntent (send_transfer asset safety)', () => {
+  it('blocks when user mentions SUI but call has no asset (defaults to USDC)', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1.0561 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`Swap $1 to SUI and send it to ${KNOWN}`),
+      undefined,
+      // satisfy address-source guard so we isolate the asset check
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('asset_intent');
+    expect(result.blockReason).toContain('SUI');
+  });
+
+  it('blocks when user mentions USDT but call has no asset', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 5 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`send 5 USDT to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('asset_intent');
+  });
+
+  it('passes when user explicitly says USDC', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`send 1 USDC to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('passes when call sets asset=SUI explicitly', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1.0561, asset: 'SUI' }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`Swap $1 to SUI and send it to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('passes when call sets asset=USDC explicitly even if user mentioned SUI', () => {
+    // Explicit USDC means the LLM committed to a token — the user can
+    // still cancel at the permission card. We only block the silent
+    // default.
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1, asset: 'USDC' }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`I'm comparing SUI prices, but send 1 USDC to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('does not match token names that appear inside other words', () => {
+    // "result" contains "sul" but not the standalone token "SUI"; the
+    // word boundary should keep this as a false positive.
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`pursuit suit suite for sushi`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('blocks lowercase token mentions', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx(`send my sui to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('asset_intent');
+  });
+
+  it('does not run on non-send_transfer tools', () => {
+    const otherTool = buildTool({
+      name: 'save_deposit',
+      description: 's',
+      inputSchema: z.object({ amount: z.number() }),
+      jsonSchema: { type: 'object', properties: {} },
+      isReadOnly: false,
+      flags: { mutating: true, requiresBalance: true },
+      call: async () => ({ data: {} }),
+    });
+
+    const result = runGuards(
+      otherTool,
+      { id: 'x', name: 'save_deposit', input: { amount: 5 } },
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      makeConvCtx('save 5 SUI worth'),
+    );
+
+    // save_deposit also has its own preflight that would reject SUI; we
+    // only assert asset_intent did not fire here.
+    expect(result.blockGate).not.toBe('asset_intent');
+  });
+
+  it('can be disabled via config.assetIntent = false', () => {
+    const result = runGuards(
+      sendTransfer,
+      makeCall({ to: KNOWN, amount: 1.0561 }),
+      createGuardRunnerState(),
+      { ...DEFAULT_GUARD_CONFIG, assetIntent: false },
+      makeConvCtx(`Swap $1 to SUI and send it to ${KNOWN}`),
+      undefined,
+      { contacts: [{ name: 'wallet', address: KNOWN }] },
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/packages/engine/src/guards.ts
+++ b/packages/engine/src/guards.ts
@@ -90,6 +90,14 @@ export interface GuardConfig {
    * upstream guard (e.g. an off-process verifier).
    */
   addressSource?: boolean;
+  /**
+   * Companion to `addressSource`: blocks send_transfer that defaults to
+   * USDC when the user's recent messages clearly named a non-USDC token
+   * (SUI, USDT, WAL, etc.). Without this, the LLM would call
+   * `send_transfer({ amount, to })` for a "send my SUI" request and the
+   * tool would silently ship USDC. Default on.
+   */
+  assetIntent?: boolean;
 }
 
 export const DEFAULT_GUARD_CONFIG: GuardConfig = {
@@ -104,6 +112,7 @@ export const DEFAULT_GUARD_CONFIG: GuardConfig = {
   retryProtection: true,
   inputValidation: true,
   addressSource: true,
+  assetIntent: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -395,6 +404,73 @@ function normalizeAddress(addr: string): string {
   return addr.trim().toLowerCase();
 }
 
+/**
+ * [send-safety v2] Bound the failure mode where the LLM was asked to
+ * send a non-USDC token (e.g. just-swapped SUI) but called send_transfer
+ * with no `asset` field. The tool defaults `asset` to USDC, so the user
+ * lost real money: "Done! Sent your SUI" while only USDC moved.
+ *
+ * Heuristic: if any of the supported NON-USDC tokens appears as a word
+ * in the user's recent messages AND the call has no `asset` (or asset
+ * is USDC while a different token is mentioned), block the call and
+ * force the LLM to re-issue with an explicit `asset`.
+ *
+ * Tokens are matched as standalone words (`\bSUI\b`, `\bWAL\b`, etc.)
+ * to avoid false positives on things like "USDC" or addresses that
+ * happen to contain the substring "sui".
+ */
+const NON_USDC_TOKEN_WORDS: ReadonlyArray<{ symbol: string; pattern: RegExp }> = [
+  // Patterns are anchored with \b on both sides. Case-insensitive.
+  { symbol: 'SUI', pattern: /\bSUI\b/i },
+  { symbol: 'USDT', pattern: /\bUSDT\b/i },
+  { symbol: 'USDe', pattern: /\bUSDe\b/i },
+  { symbol: 'USDsui', pattern: /\bUSDsui\b/i },
+  { symbol: 'WAL', pattern: /\bWAL\b/i },
+  { symbol: 'ETH', pattern: /\bETH\b/i },
+  { symbol: 'NAVX', pattern: /\bNAVX\b/i },
+  { symbol: 'GOLD', pattern: /\bGOLD\b/i },
+];
+
+function guardAssetIntent(
+  tool: Tool,
+  call: PendingToolCall,
+  userText: string,
+): GuardResult {
+  if (tool.name !== 'send_transfer') {
+    return { verdict: 'pass', gate: 'asset_intent', tier: 'safety' };
+  }
+
+  const input = call.input as Record<string, unknown>;
+  const assetWasSet = !(input.asset === undefined || input.asset === null || input.asset === '');
+
+  // If the LLM made any explicit asset choice, trust it — even if it's
+  // USDC. The danger we're guarding against is the *silent default* to
+  // USDC when the schema didn't expose `asset` at all (the original
+  // failure mode). Once the LLM has explicitly committed to a token,
+  // the user can verify and cancel at the permission card.
+  if (assetWasSet) {
+    return { verdict: 'pass', gate: 'asset_intent', tier: 'safety' };
+  }
+
+  // Asset was omitted. Block iff the user named a non-USDC token in
+  // their recent messages, since the omitted-asset path defaults to
+  // USDC and would silently ship the wrong token.
+  const mentioned = NON_USDC_TOKEN_WORDS.find((t) => t.pattern.test(userText));
+  if (!mentioned) {
+    return { verdict: 'pass', gate: 'asset_intent', tier: 'safety' };
+  }
+
+  return {
+    verdict: 'block',
+    gate: 'asset_intent',
+    tier: 'safety',
+    message:
+      `Asset mismatch: the user's recent messages mention "${mentioned.symbol}" but send_transfer was called without an \`asset\` field (defaults to USDC). ` +
+      `If the user asked you to send ${mentioned.symbol}, re-issue send_transfer with \`asset: "${mentioned.symbol}"\`. ` +
+      `If the user really meant USDC, set \`asset: "USDC"\` explicitly to confirm intent. Never default to USDC when the user named a different token.`,
+  };
+}
+
 function guardAddressSource(
   tool: Tool,
   call: PendingToolCall,
@@ -574,6 +650,9 @@ export function runGuards(
         identity?.walletAddress,
       ),
     );
+  }
+  if (config.assetIntent !== false) {
+    results.push(guardAssetIntent(tool, call, conversationContext.recentUserText));
   }
   if (config.irreversibility !== false) {
     results.push(guardIrreversibility(tool, call, conversationContext.fullText));

--- a/packages/engine/src/tools/transfer.ts
+++ b/packages/engine/src/tools/transfer.ts
@@ -1,14 +1,34 @@
 import { z } from 'zod';
+import { ALL_NAVI_ASSETS, SUPPORTED_ASSETS, type SupportedAsset } from '@t2000/sdk';
 import { buildTool } from '../tool.js';
 import { requireAgent } from './utils.js';
+
+/**
+ * Tokens send_transfer can move. Mirrors `SUPPORTED_ASSETS` so a new
+ * coin in the SDK constants is automatically settable here without
+ * touching the tool.
+ *
+ * The history of this tool: it was originally USDC-only (description
+ * literally said "Send USDC..."). When the LLM was asked to send a
+ * non-USDC token (e.g. just-swapped SUI), it would call send_transfer
+ * with the SUI amount, and the tool would silently ship USDC instead —
+ * the user lost real money. See the audric-send-safety-and-auth follow-up:
+ * "Done! Swapped 1 USDC for 1.0561 SUI and sent it all to Wallet 1." was
+ * the LLM's hallucinated success while only USDC actually moved.
+ */
+const ASSET_LIST = ALL_NAVI_ASSETS.map((a) => String(a)).join(', ');
 
 export const sendTransferTool = buildTool({
   name: 'send_transfer',
   description:
-    'Send USDC to another Sui address or contact name. Validates the address, checks balance, and executes the on-chain transfer. Returns tx hash, gas cost, and updated balance.',
+    `Send ANY supported token (${ASSET_LIST}) to another Sui address or contact name. Validates the address, checks balance, and executes the on-chain transfer. ` +
+    `MUST set the \`asset\` field to the token symbol you want to send (case-insensitive). If \`asset\` is omitted, USDC is assumed — only do this when the user explicitly asks for USDC. ` +
+    `When the user asks to send a token by name (SUI, USDT, etc.) or to send the proceeds of a just-completed swap, you MUST pass \`asset\` matching that token. ` +
+    `Returns tx hash, gas cost, and updated balance.`,
   inputSchema: z.object({
     to: z.string().min(1),
     amount: z.number().positive(),
+    asset: z.string().optional(),
     memo: z.string().optional(),
   }),
   jsonSchema: {
@@ -20,7 +40,11 @@ export const sendTransferTool = buildTool({
       },
       amount: {
         type: 'number',
-        description: 'Amount in USD to send',
+        description: 'Amount of the asset to send (denominated in the asset\u2019s own units, NOT USD). For USDC this is the USDC count; for SUI this is the SUI count.',
+      },
+      asset: {
+        type: 'string',
+        description: `Token symbol to send. One of: ${ASSET_LIST}. Defaults to USDC if omitted. REQUIRED whenever the user names a non-USDC token or you are forwarding the proceeds of a swap.`,
       },
       memo: {
         type: 'string',
@@ -43,18 +67,31 @@ export const sendTransferTool = buildTool({
     if (input.amount <= 0) {
       return { valid: false, error: 'Amount must be positive.' };
     }
+    if (input.asset !== undefined) {
+      const normalized = String(input.asset).toUpperCase();
+      if (!(normalized in SUPPORTED_ASSETS)) {
+        return {
+          valid: false,
+          error: `Unsupported asset "${input.asset}". send_transfer accepts: ${ASSET_LIST}.`,
+        };
+      }
+    }
     return { valid: true };
   },
 
   async call(input, context) {
     const agent = requireAgent(context);
-    const result = await agent.send({ to: input.to, amount: input.amount });
+    const asset = input.asset
+      ? (String(input.asset).toUpperCase() as SupportedAsset)
+      : 'USDC';
+    const result = await agent.send({ to: input.to, amount: input.amount, asset });
 
     return {
       data: {
         success: result.success,
         tx: result.tx,
         amount: result.amount,
+        asset,
         to: result.to,
         contactName: result.contactName,
         gasCost: result.gasCost,
@@ -62,7 +99,7 @@ export const sendTransferTool = buildTool({
         balance: result.balance,
         memo: input.memo ?? null,
       },
-      displayText: `Sent $${result.amount.toFixed(2)} to ${result.contactName ?? result.to.slice(0, 10)}… (tx: ${result.tx.slice(0, 8)}…)`,
+      displayText: `Sent ${result.amount} ${asset} to ${result.contactName ?? `${result.to.slice(0, 10)}…`} (tx: ${result.tx.slice(0, 8)}…)`,
     };
   },
 });


### PR DESCRIPTION
## Why

User reported a critical bug after the v0.46.11 send-safety release:

> Swap \$1 to SUI and send it to 0x321...
> > "Done! Swapped 1 USDC for 1.0561 SUI and sent it all to Wallet 1."

In reality only 1.056 USDC was sent (USDC dropped 101.21 → 100.15) and the swapped 1.0561 SUI is still sitting in the wallet. Same class of failure as the original lost-funds bug.

## Root cause

Two layers conspired:
1. \`send_transfer\` tool description was hardcoded \`"Send USDC..."\` and the schema had no \`asset\` field, even though the SDK supports any \`SUPPORTED_ASSETS\` member.
2. The LLM, having no \`asset\` to set, called \`send_transfer({ to, amount: 1.0561 })\` expecting it to send SUI. Tool defaulted to USDC, shipped USDC, returned \`success: true\`, and the LLM happily reported "sent the SUI".

## Changes

- **\`packages/engine/src/tools/transfer.ts\`** — add optional \`asset\` field validated against \`ALL_NAVI_ASSETS\`. Pass through to \`agent.send()\`. Update description + jsonSchema to make explicit that \`asset\` defaults to USDC and **must** be set when the user names a non-USDC token. Update \`displayText\` to include the actual asset symbol (was hardcoded "USDC").
- **\`packages/engine/src/guards.ts\`** — new \`guardAssetIntent\` (safety tier). Blocks \`send_transfer\` when (a) the call has no \`asset\` field AND (b) the user's recent messages name a non-USDC token (\`\\bSUI\\b\`, \`\\bUSDT\\b\`, etc.). Block message instructs the LLM to re-issue with \`asset: "<symbol>"\`, or to pass \`asset: "USDC"\` explicitly to confirm intent. New config flag \`assetIntent: true\` in \`DEFAULT_GUARD_CONFIG\`.
- **\`packages/engine/src/__tests__/guard-asset-intent.test.ts\`** — 9 new tests: SUI-after-swap regression, explicit \`USDC\` override path, word-boundary false positives ("pursuit suit suite for sushi" → no false alarm), case-insensitive matching, disable-via-config, no-fire on non-send_transfer tools.

## Why a guard, not just a system prompt rule

The audric system prompt already tells the LLM how to use \`asset\`. We've seen prompts ignored before (this is exactly how the original address-source bug surfaced). The engine guard makes the failure **loud** (block + structured message asking the LLM to retry) instead of **silent** (wrong token shipped, success returned).

The guard is intentionally permissive when \`asset\` is set explicitly — once the LLM has committed to a token, the user sees and confirms it on the permission card. We only block the silent USDC default.

## Tests

- 416/416 engine tests pass (35 files)
- New \`guard-asset-intent.test.ts\`: 9/9 pass
- Existing \`guard-address-source.test.ts\`: 11/11 pass (verified no regression)

## Followups in audric

- System prompt updated to instruct LLM about \`asset\` requirement, especially for swap-then-send flows
- PermissionCard inline "save as contact" field removed (was confusing users with auto-named "Wallet 1/2/3")
- New \`<ChunkedAddress>\` component renders chunked-hex with a copy button — copying yields raw \`0x...64-hex\` (no spaces leaked into clipboard, fixing user complaint about confirmation card display)

Made with [Cursor](https://cursor.com)