### PR TITLE
feat(engine): swap-preview guard requires swap_quote before swap_execute

### DIFF
--- a/packages/engine/src/__tests__/guard-swap-preview.test.ts
+++ b/packages/engine/src/__tests__/guard-swap-preview.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  runGuards,
+  createGuardRunnerState,
+  updateGuardStateAfterToolResult,
+  extractConversationText,
+  DEFAULT_GUARD_CONFIG,
+} from '../guards.js';
+import { buildTool } from '../tool.js';
+import type { PendingToolCall } from '../orchestration.js';
+
+/**
+ * Regression tests for the swap-preview guard.
+ *
+ * Failure mode being prevented: the LLM tells the user "$1 USDC will get
+ * you ~0.285 SUI" (from stale training memory — actual SUI price was
+ * $0.95, so they get ~1.05 SUI), then calls swap_execute. The user sees
+ * a wildly wrong estimate before the permission card renders. We block
+ * swap_execute unless a real swap_quote ran for the same (from, to,
+ * amount) within the recent window.
+ */
+
+const swapExecute = buildTool({
+  name: 'swap_execute',
+  description: 'swap',
+  inputSchema: z.object({
+    from: z.string(),
+    to: z.string(),
+    amount: z.number().positive(),
+    byAmountIn: z.boolean().optional(),
+  }),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: false,
+  flags: { mutating: true, requiresBalance: true },
+  preflight: (input) => {
+    if (input.from.toLowerCase() === input.to.toLowerCase()) {
+      return { valid: false, error: `Cannot swap ${input.from} to itself.` };
+    }
+    return { valid: true };
+  },
+  call: async () => ({ data: {} }),
+});
+
+const swapQuote = buildTool({
+  name: 'swap_quote',
+  description: 'quote',
+  inputSchema: z.object({
+    from: z.string(),
+    to: z.string(),
+    amount: z.number().positive(),
+  }),
+  jsonSchema: { type: 'object', properties: {} },
+  isReadOnly: true,
+  call: async () => ({ data: {} }),
+});
+
+function makeCall(input: Record<string, unknown>): PendingToolCall {
+  return { id: 'tool_use_1', name: 'swap_execute', input };
+}
+
+const EMPTY_CONV = extractConversationText([]);
+
+describe('guardSwapPreview (swap_execute requires recent swap_quote)', () => {
+  it('blocks swap_execute when no matching swap_quote ran', () => {
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('swap_preview');
+    expect(result.blockReason).toContain('swap_quote');
+    expect(result.blockReason).toContain('USDC');
+    expect(result.blockReason).toContain('SUI');
+  });
+
+  it('passes when a matching swap_quote was just recorded', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 1 },
+      { fromAmount: 1, toAmount: 1.05, route: 'cetus', priceImpact: 0.001 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('matches case-insensitively (sui vs SUI)', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'usdc', to: 'sui', amount: 1 },
+      { fromAmount: 1, toAmount: 1.05 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('accepts amounts within ±1% tolerance', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 100 },
+      { fromAmount: 100, toAmount: 105 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      // 100.5 is within 1% of 100
+      makeCall({ from: 'USDC', to: 'SUI', amount: 100.5 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('blocks amounts outside ±1% tolerance', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 100 },
+      { fromAmount: 100, toAmount: 105 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      // 102 is 2% above 100 → outside tolerance
+      makeCall({ from: 'USDC', to: 'SUI', amount: 102 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('swap_preview');
+  });
+
+  it('blocks if quote was for a different pair', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 1 },
+      { fromAmount: 1, toAmount: 1.05 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      // user pivoted to USDT but didn't re-quote
+      makeCall({ from: 'USDC', to: 'USDT', amount: 1 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('swap_preview');
+  });
+
+  it('does not run on non-swap_execute tools', () => {
+    const otherTool = buildTool({
+      name: 'send_transfer',
+      description: 'send',
+      inputSchema: z.object({ to: z.string(), amount: z.number(), asset: z.string().optional() }),
+      jsonSchema: { type: 'object', properties: {} },
+      isReadOnly: false,
+      flags: { mutating: true, requiresBalance: true },
+      call: async () => ({ data: {} }),
+    });
+
+    const result = runGuards(
+      otherTool,
+      // explicit asset to bypass asset_intent
+      { id: 'x', name: 'send_transfer', input: { to: '0xdead', amount: 1, asset: 'USDC' } },
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blockGate).not.toBe('swap_preview');
+  });
+
+  it('can be disabled via config.swapPreview = false', () => {
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      createGuardRunnerState(),
+      { ...DEFAULT_GUARD_CONFIG, swapPreview: false },
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(false);
+  });
+
+  it('does not record failed swap_quote calls', () => {
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 1 },
+      { error: 'no route' },
+      true, // isError=true → must NOT record
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('swap_preview');
+  });
+
+  it('allows multiple sequential quote→execute pairs in the same session', () => {
+    const state = createGuardRunnerState();
+
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'USDC', to: 'SUI', amount: 1 },
+      { fromAmount: 1, toAmount: 1.05 },
+      false,
+      state,
+    );
+    expect(
+      runGuards(
+        swapExecute,
+        makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+        state,
+        DEFAULT_GUARD_CONFIG,
+        EMPTY_CONV,
+      ).blocked,
+    ).toBe(false);
+
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      { from: 'SUI', to: 'USDT', amount: 0.5 },
+      { fromAmount: 0.5, toAmount: 0.47 },
+      false,
+      state,
+    );
+    expect(
+      runGuards(
+        swapExecute,
+        makeCall({ from: 'SUI', to: 'USDT', amount: 0.5 }),
+        state,
+        DEFAULT_GUARD_CONFIG,
+        EMPTY_CONV,
+      ).blocked,
+    ).toBe(false);
+  });
+
+  it('preflight (from===to) still wins over swap_preview', () => {
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'USDC', amount: 1 }),
+      createGuardRunnerState(),
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    // input_validation runs first and short-circuits
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('input_validation');
+  });
+});

--- a/packages/engine/src/guards.ts
+++ b/packages/engine/src/guards.ts
@@ -98,6 +98,17 @@ export interface GuardConfig {
    * tool would silently ship USDC. Default on.
    */
   assetIntent?: boolean;
+  /**
+   * Root-cause fix for "LLM hallucinates a stale training-data price
+   * (e.g. '$3.50/SUI') and shows the user a wildly wrong estimate before
+   * the swap card renders". When enabled (default), `swap_execute` is
+   * blocked unless a matching `swap_quote(from, to, amount)` ran in the
+   * recent past (60s window, ±1% amount tolerance). The block forces the
+   * LLM to fetch a real on-chain quote and cite its actual numbers, not
+   * a guess. Set to `false` only if the host has its own pre-execution
+   * quote requirement.
+   */
+  swapPreview?: boolean;
 }
 
 export const DEFAULT_GUARD_CONFIG: GuardConfig = {
@@ -113,6 +124,7 @@ export const DEFAULT_GUARD_CONFIG: GuardConfig = {
   inputValidation: true,
   addressSource: true,
   assetIntent: true,
+  swapPreview: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -169,6 +181,70 @@ export class RetryTracker {
     const prev = this.executed.get(this.key(toolName, input));
     if (!prev) return { blocked: false };
     return { blocked: true, previousResult: prev.result };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SwapQuoteTracker — records swap_quote calls so swapPreview can verify a
+// swap_execute was preceded by a real on-chain quote. Without this, the
+// LLM falls back to training-memory prices and gives the user wildly wrong
+// estimates (the "$3.50/SUI when SUI is $0.95" class of bugs).
+// ---------------------------------------------------------------------------
+
+interface RecordedSwapQuote {
+  from: string;
+  to: string;
+  amount: number;
+  ts: number;
+}
+
+export class SwapQuoteTracker {
+  /** Quotes recorded in the recent window. Trimmed lazily on every check. */
+  private quotes: RecordedSwapQuote[] = [];
+
+  /** Match window: 60s is generous enough for slow LLM turns but tight enough
+   * to invalidate stale quotes from earlier in the session. */
+  private readonly windowMs = 60_000;
+
+  /** Amount tolerance: ±1% (covers gas-padding, integer-rounding, and the
+   * rare case where the LLM rounds the input differently between quote and
+   * execute). Prices barely move in 60s so 1% is forgiving but meaningful. */
+  private readonly amountTolerance = 0.01;
+
+  /**
+   * Normalize a token identifier so symbol vs. coinType vs. case don't
+   * cause spurious mismatches. Lowercase + trim is sufficient because the
+   * SDK's resolver itself is case-insensitive on symbols.
+   */
+  private normalize(token: string): string {
+    return token.trim().toLowerCase();
+  }
+
+  record(input: { from: string; to: string; amount: number }): void {
+    const now = Date.now();
+    this.quotes.push({
+      from: this.normalize(input.from),
+      to: this.normalize(input.to),
+      amount: input.amount,
+      ts: now,
+    });
+    const cutoff = now - this.windowMs;
+    this.quotes = this.quotes.filter((q) => q.ts > cutoff);
+  }
+
+  hasMatchingQuote(input: { from: string; to: string; amount: number }): boolean {
+    const cutoff = Date.now() - this.windowMs;
+    const fromN = this.normalize(input.from);
+    const toN = this.normalize(input.to);
+    const target = input.amount;
+    return this.quotes.some(
+      (q) =>
+        q.ts > cutoff &&
+        q.from === fromN &&
+        q.to === toN &&
+        target > 0 &&
+        Math.abs(q.amount - target) / target <= this.amountTolerance,
+    );
   }
 }
 
@@ -471,6 +547,57 @@ function guardAssetIntent(
   };
 }
 
+// ---------------------------------------------------------------------------
+// guardSwapPreview — root-cause fix for "LLM hallucinates a stale price
+// (e.g. '$3.50/SUI' when SUI is $0.95) and shows the user a wildly wrong
+// estimate before the swap card renders". We require swap_execute to be
+// preceded by a real on-chain swap_quote so the LLM has authoritative
+// numbers (price impact, route, exact output) to cite.
+//
+// Match rule:
+//   - Same `from` and `to` token identifiers (case-insensitive).
+//   - `amount` within ±1% of the quoted amount.
+//   - swap_quote ran within the last 60s (current turn is well within).
+//
+// Anything else → block with a structured error so the LLM is forced to
+// call swap_quote first and re-issue swap_execute with the same params.
+// ---------------------------------------------------------------------------
+
+function guardSwapPreview(
+  tool: Tool,
+  call: PendingToolCall,
+  swapQuoteTracker: SwapQuoteTracker,
+): GuardResult {
+  if (tool.name !== 'swap_execute') {
+    return { verdict: 'pass', gate: 'swap_preview', tier: 'safety' };
+  }
+
+  const input = call.input as { from?: unknown; to?: unknown; amount?: unknown };
+  const from = typeof input.from === 'string' ? input.from : '';
+  const to = typeof input.to === 'string' ? input.to : '';
+  const amount = Number(input.amount ?? 0);
+
+  // If inputs are malformed, let `inputValidation`/`preflight` handle it —
+  // this guard is specifically about quote freshness, not input shape.
+  if (!from || !to || !(amount > 0)) {
+    return { verdict: 'pass', gate: 'swap_preview', tier: 'safety' };
+  }
+
+  if (swapQuoteTracker.hasMatchingQuote({ from, to, amount })) {
+    return { verdict: 'pass', gate: 'swap_preview', tier: 'safety' };
+  }
+
+  return {
+    verdict: 'block',
+    gate: 'swap_preview',
+    tier: 'safety',
+    message:
+      `swap_execute requires a recent matching swap_quote so the user sees an accurate preview. ` +
+      `Call swap_quote({ from: "${from}", to: "${to}", amount: ${amount} }) first, then re-issue swap_execute with the same params. ` +
+      `swap_quote is read-only and returns the real on-chain output, route, and price impact — never estimate from memory.`,
+  };
+}
+
 function guardAddressSource(
   tool: Tool,
   call: PendingToolCall,
@@ -560,6 +687,7 @@ export function guardStaleData(toolFlags: ToolFlags): GuardInjection | null {
 export interface GuardRunnerState {
   balanceTracker: BalanceTracker;
   retryTracker: RetryTracker;
+  swapQuoteTracker: SwapQuoteTracker;
   lastHealthFactor: number | null;
 }
 
@@ -567,6 +695,7 @@ export function createGuardRunnerState(): GuardRunnerState {
   return {
     balanceTracker: new BalanceTracker(),
     retryTracker: new RetryTracker(),
+    swapQuoteTracker: new SwapQuoteTracker(),
     lastHealthFactor: null,
   };
 }
@@ -653,6 +782,9 @@ export function runGuards(
   }
   if (config.assetIntent !== false) {
     results.push(guardAssetIntent(tool, call, conversationContext.recentUserText));
+  }
+  if (config.swapPreview !== false) {
+    results.push(guardSwapPreview(tool, call, state.swapQuoteTracker));
   }
   if (config.irreversibility !== false) {
     results.push(guardIrreversibility(tool, call, conversationContext.fullText));
@@ -750,6 +882,20 @@ export function updateGuardStateAfterToolResult(
     const hf = Number(r.healthFactor ?? r.health_factor ?? r.hf);
     if (!isNaN(hf) && hf > 0) {
       state.lastHealthFactor = hf;
+    }
+  }
+
+  // Record successful swap_quote calls so guardSwapPreview can verify a
+  // matching quote ran before swap_execute. We key off the *input* (not
+  // the result) so the LLM can use the same params for both calls and
+  // the match is unambiguous.
+  if (toolName === 'swap_quote' && input && typeof input === 'object') {
+    const i = input as { from?: unknown; to?: unknown; amount?: unknown };
+    const from = typeof i.from === 'string' ? i.from : '';
+    const to = typeof i.to === 'string' ? i.to : '';
+    const amount = Number(i.amount ?? 0);
+    if (from && to && amount > 0) {
+      state.swapQuoteTracker.record({ from, to, amount });
     }
   }
 


### PR DESCRIPTION
## Summary

Root-cause fix for the **\"\$3.50/SUI when SUI is \$0.95\" hallucination** class of bugs reported by users. Without an on-chain quote the LLM falls back to stale training memory and shows the user a wildly wrong estimate before the swap permission card renders.

## What's new

- **`SwapQuoteTracker`** records `swap_quote` inputs (60s window, ±1% amt tolerance, normalized symbol/coinType match).
- **`guardSwapPreview`** blocks `swap_execute` unless a matching quote is in the tracker. The block message tells the LLM exactly which quote call to issue.
- Wired into `runGuards` (safety tier, between `asset_intent` and `irreversibility`) and recorded in `updateGuardStateAfterToolResult` on successful `swap_quote`.
- Failed `swap_quote` calls do **not** record (isError check).
- Disable via `config.swapPreview = false` for hosts with their own pre-execution quote requirement.

## Test plan

- [x] 11 new unit tests (`guard-swap-preview.test.ts`):
  - missing quote blocks
  - matching quote passes
  - case-insensitive match
  - ±1% tolerance accepted, ±2% blocked
  - mismatched pair blocks
  - non-`swap_execute` pass-through
  - disabled via config
  - failed quote does NOT record
  - multiple sequential quote→execute pairs
  - `preflight` (from===to) still wins over `swap_preview`
- [x] Full engine suite: 427/427 pass
- [ ] Audric host updates to consume new engine + re-enable `swap_quote` tool + strengthen system prompt (separate PR in audric repo)


Made with [Cursor](https://cursor.com)