### PR TITLE
fix(engine,sdk): unblock swap_execute after early-dispatched quote + coerce Cetus priceImpact

### DIFF
--- a/packages/engine/src/__tests__/early-dispatcher.test.ts
+++ b/packages/engine/src/__tests__/early-dispatcher.test.ts
@@ -55,6 +55,15 @@ describe('EarlyToolDispatcher', () => {
     expect(dispatched).toBe(false);
   });
 
+  it('exposes original tool input by tool_use_id (needed for guard state recording)', () => {
+    const tool = makeTool();
+    const dispatcher = new EarlyToolDispatcher([tool], ctx);
+    dispatcher.tryDispatch(makeCall('t1', 'read_tool', { from: 'USDC', to: 'SUI', amount: 1 }));
+
+    expect(dispatcher.getInputById('t1')).toEqual({ from: 'USDC', to: 'SUI', amount: 1 });
+    expect(dispatcher.getInputById('missing')).toBeUndefined();
+  });
+
   it('collects results in dispatch order regardless of completion order', async () => {
     let resolveFirst!: (v: { data: unknown }) => void;
     let resolveSecond!: (v: { data: unknown }) => void;

--- a/packages/engine/src/__tests__/guard-swap-preview.test.ts
+++ b/packages/engine/src/__tests__/guard-swap-preview.test.ts
@@ -291,6 +291,34 @@ describe('guardSwapPreview (swap_execute requires recent swap_quote)', () => {
     ).toBe(false);
   });
 
+  it('regression: null input from early-dispatch path does NOT record a quote (must be passed through)', () => {
+    // Repros the v0.46.13 bug where EarlyToolDispatcher executed swap_quote
+    // but the engine called updateGuardStateAfterToolResult with `input: null`,
+    // so SwapQuoteTracker never saw the (from,to,amount) and every subsequent
+    // swap_execute was blocked. The fix is to forward the input from the
+    // dispatcher entry — this test guards against silently regressing again.
+    const state = createGuardRunnerState();
+    updateGuardStateAfterToolResult(
+      'swap_quote',
+      swapQuote,
+      null,
+      { fromAmount: 1, toAmount: 1.05, route: 'cetus', priceImpact: 0.001 },
+      false,
+      state,
+    );
+
+    const result = runGuards(
+      swapExecute,
+      makeCall({ from: 'USDC', to: 'SUI', amount: 1 }),
+      state,
+      DEFAULT_GUARD_CONFIG,
+      EMPTY_CONV,
+    );
+
+    expect(result.blocked).toBe(true);
+    expect(result.blockGate).toBe('swap_preview');
+  });
+
   it('preflight (from===to) still wins over swap_preview', () => {
     const result = runGuards(
       swapExecute,

--- a/packages/engine/src/early-dispatcher.ts
+++ b/packages/engine/src/early-dispatcher.ts
@@ -103,6 +103,16 @@ export class EarlyToolDispatcher {
   }
 
   /**
+   * Look up the original tool input by `tool_use_id`. Used by the engine to
+   * feed `updateGuardStateAfterToolResult` (which needs the call input to
+   * record swap_quote → swap_execute pairing, etc.) for tools that were
+   * dispatched here instead of going through the normal post-stream loop.
+   */
+  getInputById(toolUseId: string): unknown | undefined {
+    return this.entries.find((e) => e.call.id === toolUseId)?.call.input;
+  }
+
+  /**
    * Collect all results in original dispatch order.
    * Yields `tool_result` events as each promise resolves.
    */

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -710,8 +710,14 @@ export class QueryEngine {
               }
             }
             const tool = findTool(this.tools, earlyEvent.toolName);
+            // Pull the original input back off the dispatcher so guard state
+            // (e.g. SwapQuoteTracker) can key off it. Passing `null` here was
+            // a silent regression that made guardSwapPreview block every
+            // swap_execute even after a successful early-dispatched
+            // swap_quote.
+            const earlyInput = dispatcher.getInputById(earlyEvent.toolUseId) ?? null;
             updateGuardStateAfterToolResult(
-              earlyEvent.toolName, tool, null, earlyEvent.result, earlyEvent.isError, this.guardState,
+              earlyEvent.toolName, tool, earlyInput, earlyEvent.result, earlyEvent.isError, this.guardState,
             );
 
             let enrichedResult = earlyEvent.result;

--- a/packages/sdk/src/protocols/cetus-swap.ts
+++ b/packages/sdk/src/protocols/cetus-swap.ts
@@ -66,7 +66,7 @@ export async function findSwapRoute(params: {
       amountIn: routerData.amountIn.toString(),
       amountOut: routerData.amountOut.toString(),
       byAmountIn: params.byAmountIn,
-      priceImpact: routerData.deviationRatio,
+      priceImpact: normalizePriceImpact(routerData.deviationRatio),
       insufficientLiquidity: true,
     };
   }
@@ -81,9 +81,22 @@ export async function findSwapRoute(params: {
     amountIn: routerData.amountIn.toString(),
     amountOut: routerData.amountOut.toString(),
     byAmountIn: params.byAmountIn,
-    priceImpact: routerData.deviationRatio,
+    priceImpact: normalizePriceImpact(routerData.deviationRatio),
     insufficientLiquidity: false,
   };
+}
+
+/**
+ * Cetus' aggregator types `deviationRatio` as `number`, but in some routes
+ * the router actually returns a string ("0.001234"). The SDK type lies, so we
+ * always coerce to a finite number here (NaN/null/undefined → 0). Without
+ * this every downstream consumer that calls `priceImpact.toFixed(...)` will
+ * crash at runtime — including the Audric SwapQuoteCard, which takes the
+ * whole chat UI down through its error boundary.
+ */
+function normalizePriceImpact(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two compounding regressions that surfaced in production tonight: every swap was getting blocked by the swap-preview guard, and when the LLM did manage to render a quote card the chat UI crashed.

### Bug 1 — Engine: `swap_execute` always blocked after `swap_quote`

`swap_quote` is a read-only tool, so `EarlyToolDispatcher` runs it ahead of the LLM stream (concurrent with the model thinking). When the engine later called `updateGuardStateAfterToolResult`, it passed `input: null` for early-dispatched results. `SwapQuoteTracker.record(...)` reads `input.from / input.to / input.amount` — none of which exist on `null` — so no quote was ever recorded, and `guardSwapPreview` blocked every subsequent `swap_execute` with "no matching quote".

User-facing effect (from the report):

> The swap guard appears to not be recognizing the prior quote — let me retry...
> [3 retries, all blocked]

**Fix:** new `EarlyToolDispatcher.getInputById(toolUseId)` exposes the original call input. The engine looks it up before calling `updateGuardStateAfterToolResult`.

### Bug 2 — SDK: Cetus `deviationRatio` is sometimes a string, not a number

`@cetusprotocol/aggregator-sdk` types `deviationRatio` as `number` in some response shapes and `string` in others. Our `cetus-swap.ts` blindly assigned it to `priceImpact: number` so the runtime value lied to TypeScript. Downstream:

- `displayText` in `swap_quote` worked accidentally (`string * 100` coerces to a number, then `.toFixed` is fine).
- `SwapQuoteCard` and `TransactionReceiptCard` called `data.priceImpact.toFixed(2)` directly → `TypeError: t.priceImpact.toFixed is not a function` → React error boundary tore down the entire chat tree, browser reported "crashed".

**Fix:** `normalizePriceImpact()` in `cetus-swap.ts` coerces with `Number(...)` and falls back to `0` for NaN/null/undefined. Defensive coercion is also added to the audric cards in a follow-up PR so a future bad payload can never crash the UI.

## Test plan

- [x] `pnpm --filter @t2000/engine test` — 429 passed
- [x] `pnpm --filter @t2000/sdk test` — 391 passed
- [x] New regression test: `guard-swap-preview` proves a `null`-input record from the early-dispatch path does NOT register a quote, so the new wiring is the only way the guard passes.
- [x] New unit test: `early-dispatcher` covers `getInputById` lookup.
- [ ] Manual: swap $1 USDC → SUI then send the proceeds in one prompt — should pass guard on first try and render the quote card without crashing.


Made with [Cursor](https://cursor.com)