### PR TITLE
fix(engine): honor permissionLevel:'auto' on write tools without an agent

### DIFF
--- a/packages/engine/src/__tests__/confirmation.test.ts
+++ b/packages/engine/src/__tests__/confirmation.test.ts
@@ -255,6 +255,38 @@ describe('Confirmation flow (pending_action + resumeWithToolResult)', () => {
     }
   });
 
+  it('regression: auto-approves write tools with permissionLevel: auto WITHOUT an agent', async () => {
+    // Repros the v0.46.14 audric bug where save_contact (and every other
+    // Prisma-backed audric tool such as savings_goal_create) silently
+    // failed because the engine forced confirmation for *all* write tools
+    // when no agent was present, ignoring the explicit `auto` opt-in.
+    // The audric server runs the engine without an agent — auto-tier
+    // tools that don't need on-chain signing must execute server-side.
+    const provider = createMockProvider([
+      [{ type: 'tool_call', id: 'tc-1', name: 'auto_action', input: {} }],
+      [{ type: 'text', text: 'Done' }],
+    ]);
+
+    const engine = new QueryEngine({
+      provider,
+      tools: [autoWriteTool],
+      systemPrompt: 'Test',
+      // NO agent — audric scenario.
+    });
+
+    const events = await collectEvents(engine.submitMessage('Do it'));
+
+    const pendingActions = events.filter((e) => e.type === 'pending_action');
+    expect(pendingActions).toHaveLength(0);
+
+    const results = events.filter((e) => e.type === 'tool_result');
+    expect(results).toHaveLength(1);
+    if (results[0].type === 'tool_result') {
+      expect(results[0].isError).toBe(false);
+      expect(results[0].result).toEqual({ done: true });
+    }
+  });
+
   it('handles mixed read + write: reads execute, write yields pending_action', async () => {
     const provider = createMockProvider([
       [

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -826,6 +826,17 @@ export class QueryEngine {
         const needsConfirmation = (() => {
           if (!tool || tool.isReadOnly) return false;
           if (tool.permissionLevel === 'explicit') return true;
+          // [v0.46.15] Honor `permissionLevel: 'auto'` on write tools even
+          // when no agent is present. These are custom tools (e.g. audric's
+          // server-owned save_contact / savings_goal_*) that persist via
+          // their own data layer (Prisma) and never need on-chain signing.
+          // They explicitly opted into auto by setting the permission
+          // level — gating them on `context.agent` here silently broke
+          // every audric Prisma-backed write tool. Tools that DO need
+          // an agent must NOT set permissionLevel: 'auto'.
+          if (tool.permissionLevel === 'auto' && !toolNameToOperation(call.name)) {
+            return false;
+          }
           // Without an agent, write tools can't execute server-side —
           // always require confirmation so the client handles execution.
           if (!context.agent && !tool.isReadOnly) return true;


### PR DESCRIPTION
## Summary

Production bug from tonight: every \`save_contact\` call in audric fails with the LLM apologizing about a \"platform-side issue\". Root cause is in the engine — and it's also been silently breaking every other Prisma-backed audric tool (\`savings_goal_create\`, \`savings_goal_update\`, \`savings_goal_archive\`) for as long as they've existed.

## The bug

Engine's needsConfirmation check has a hard rule:

\`\`\`ts
if (!context.agent && !tool.isReadOnly) return true; // confirm
\`\`\`

That made sense for the engine's built-in write tools (send/save/swap/etc.) which need an agent to sign on-chain. But it ignores \`permissionLevel: 'auto'\` — a tool can explicitly opt into server-side auto-execution, and audric uses this for tools that talk to Prisma instead of the chain.

End-to-end failure mode:
1. LLM calls \`save_contact\` with \`{name, address}\`.
2. Engine evaluates needsConfirmation → true (no agent + not read-only).
3. Engine emits \`pending_action\`.
4. Audric client checks \`shouldClientAutoApprove\` → false (\`save_contact\` isn't in \`NON_FINANCIAL_AUTO_APPROVE\` and has no operation mapping).
5. Either the PermissionCard renders (no UI for save_contact) or onValidateAction routes to executeToolAction, which throws \"Unknown tool: save_contact\".
6. LLM gets the error result and narrates a generic failure to the user.

## Fix

Honor \`permissionLevel: 'auto'\` for write tools that have no financial-operation mapping. Tools that DO map to a financial operation (send/swap/save/etc.) still go through the existing agent + tier checks, so on-chain writes can never silently auto-execute.

\`\`\`ts
if (tool.permissionLevel === 'auto' && !toolNameToOperation(call.name)) {
  return false;
}
if (!context.agent && !tool.isReadOnly) return true;
\`\`\`

## Test plan

- [x] \`pnpm --filter @t2000/engine test\` — 430 passed (was 429 + 1 new regression test)
- [x] New test exercises the no-agent + auto-tier path that the previous test was bypassing by passing \`agent: {}\`.
- [ ] Manual: in audric, \"save 0x... as Wallet1\" → executes server-side, contact persists across sessions, LLM doesn't apologize.


Made with [Cursor](https://cursor.com)