### PR TITLE
fix(infra): add 02:00 UTC trigger to t2000-cron-daily-intel for v1.4.2 financial-context-snapshot

### DIFF
--- a/infra/setup-cron.sh
+++ b/infra/setup-cron.sh
@@ -18,11 +18,16 @@ set -euo pipefail
 #     definitions (`t2000-cron-hourly`, `t2000-cron-daily-chain`, and the
 #     legacy umbrella `t2000-cron`) were deleted from EventBridge + ECS in S.12.5.
 #
-# Only `t2000-cron-daily-intel` survives. It still runs at 07:00 + 19:00 UTC
-# to refresh:
-#   - Portfolio snapshots (silent context for the engine)
-#   - Episodic memory + financial profile inference
-#   - Behavioural-pattern *classifiers* (kept as pure functions feeding ChainFacts)
+# Only `t2000-cron-daily-intel` survives. It runs at 02:00, 07:00, and 19:00
+# UTC to refresh silent context for the engine:
+#   - 07:00 → portfolio snapshots + episodic chain memory
+#   - 19:00 → financial profile inference + memory extraction
+#   - 02:00 → financial-context snapshot (UserFinancialContext rows powering
+#             the `<financial_context>` engine prompt block — added in
+#             v1.4.2 / Spec Item 6, fans out via the audric internal API)
+# 02:00 deliberately runs 19h *after* the previous calendar day's 07:00
+# portfolio-snapshot so fin_ctx derives savings/debt/wallet deltas from the
+# freshest PortfolioSnapshot row for every active user.
 # All output is silent context fed to the LLM at chat time. Nothing is surfaced
 # to the user without them asking.
 #
@@ -166,8 +171,8 @@ create_or_update_schedule() {
 
 # Step 3: Create/update the daily-intel schedule (only surviving cron)
 echo ""
-echo "--- Schedule: Daily Intel (silent context refresh — hours 7,19 UTC) ---"
-create_or_update_schedule "t2000-cron-daily-intel" "cron(0 7,19 * * ? *)" "t2000-cron-daily-intel"
+echo "--- Schedule: Daily Intel (silent context refresh — hours 2,7,19 UTC) ---"
+create_or_update_schedule "t2000-cron-daily-intel" "cron(0 2,7,19 * * ? *)" "t2000-cron-daily-intel"
 
 echo ""
 echo "=== Done ==="


### PR DESCRIPTION
## Summary

The \`financial-context-snapshot\` job is wired in [\`apps/server/src/cron/index.ts\`](https://github.com/mission69b/t2000/blob/main/apps/server/src/cron/index.ts) (gated on \`HOUR_FIN_CTX = 2\`) but the EventBridge schedule was still \`cron(0 7,19 * * ? *)\` from the pre-v1.4.2 era — meaning the cron task container never woke up at 02:00 UTC and the new \`UserFinancialContext\` rows were never written.

Returning users would still get the \`<financial_context>\` engine block via the engine-factory fail-open path (Prisma miss → \`null\` → block skipped), but the daily refresh was silently not running.

## Changes

1. **\`infra/setup-cron.sh\`** schedule expression: \`cron(0 7,19 * * ? *)\` → \`cron(0 2,7,19 * * ? *)\`. A fresh \`setup-cron.sh\` invocation now provisions all three hours.
2. **Header docs** refreshed to document what each hour does:
   - \`07:00\` → portfolio snapshots + episodic chain memory
   - \`19:00\` → financial profile inference + memory extraction
   - \`02:00\` → financial-context snapshot (UserFinancialContext rows powering the \`<financial_context>\` engine prompt block)

## Live AWS state

Already applied out-of-band via \`aws scheduler update-schedule\`:

\`\`\`
$ aws scheduler get-schedule --name t2000-cron-daily-intel --group-name default
  Expression: cron(0 2,7,19 * * ? *)
  State:      ENABLED
\`\`\`

This PR aligns the repo with reality. **No code changes.**

## Why no ECS task definition change

BlockVision is consumed by audric (Vercel), not the cron container. The cron task just POSTs to \`/api/internal/financial-context-snapshot\` with \`AUDRIC_INTERNAL_KEY\`, which is already in the task definition. The new \`t2000/mainnet/blockvision-api-key\` secret exists in AWS for centralized rotation but is not wired into any ECS task — that's intentional.

## Test plan

- [x] Schedule expression verified live: \`cron(0 2,7,19 * * ? *)\`, ENABLED
- [ ] Watch CloudWatch \`/ecs/mission69b-mainnet → t2000-cron-daily-intel\` at next 02:00 UTC for the \`financial-context-snapshot\` log line
- [ ] Verify \`SELECT count(*) FROM "UserFinancialContext"\` is non-zero in audric Neon prod after the run
- [ ] Confirm a returning user sees the \`<financial_context>\` block on engine boot (server logs or LLM trace)

Refs: [t2000 v0.47.0](https://github.com/mission69b/t2000/releases/tag/v0.47.0), [audric#63](https://github.com/mission69b/audric/pull/63), [audric#64](https://github.com/mission69b/audric/pull/64).

Made with [Cursor](https://cursor.com)