### PR TITLE
fix(engine): normalize SUI coin types for BlockVision price/list

### DIFF
--- a/packages/engine/src/__tests__/blockvision-prices.test.ts
+++ b/packages/engine/src/__tests__/blockvision-prices.test.ts
@@ -18,6 +18,10 @@ import {
 const ADDRESS = '0xdeadbeefcafe';
 const USDC_TYPE = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
 const SUI_TYPE = '0x2::sui::SUI';
+// [v0.47.1] BlockVision's `/coin/price/list` only returns SUI under its
+// fully-normalized 64-hex coin type. Tests must mock the long form to
+// faithfully exercise the normalization path.
+const SUI_TYPE_LONG = '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI';
 const NAVX_TYPE = '0xa99b8952d4f7d947ea77fe0ecdcc9e5fc0bcab2841d6e2a5aa00c3044e5544b5::navx::NAVX';
 
 const realFetch = globalThis.fetch;
@@ -286,13 +290,17 @@ describe('blockvision-prices — fetchAddressPortfolio', () => {
 
 describe('blockvision-prices — fetchTokenPrices', () => {
   it('6) hardcoded-stable shortcut — USDC/USDT resolve to $1.00 without hitting BlockVision', async () => {
+    // BlockVision echoes the LONG form of whatever coinType we sent. The
+    // engine normalizes inputs before the request and remaps the response
+    // back to the caller's input shape — so the test mock returns the long
+    // form, but the result must still be keyed by the caller's input.
     const fetchMock = vi.fn(async () =>
       mockJsonResponse({
         code: 200,
         message: 'OK',
         result: {
-          prices: { [SUI_TYPE]: '3.5' },
-          coin24HChange: { [SUI_TYPE]: '1.2345' },
+          prices: { [SUI_TYPE_LONG]: '3.5' },
+          coin24HChange: { [SUI_TYPE_LONG]: '1.2345' },
         },
       }),
     );
@@ -300,13 +308,82 @@ describe('blockvision-prices — fetchTokenPrices', () => {
 
     const prices = await fetchTokenPrices([USDC_TYPE, SUI_TYPE], 'test-key');
     expect(prices[USDC_TYPE]).toEqual({ price: 1 });
+    // Caller passed SUI_TYPE (short form) so the result is keyed by it,
+    // even though BlockVision returned the long form internally.
     expect(prices[SUI_TYPE]).toEqual({ price: 3.5, change24h: 1.2345 });
-    // Network call only happened for SUI (not for USDC, the stable).
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const calls = fetchMock.mock.calls as unknown as Array<[FetchInput]>;
     expect(calls.length).toBe(1);
     const url = urlOf(calls[0][0]);
-    expect(url).toContain(encodeURIComponent(SUI_TYPE));
+    // The URL contains the LONG form (what BlockVision actually accepts),
+    // not the short form the caller passed.
+    expect(url).toContain(encodeURIComponent(SUI_TYPE_LONG));
     expect(url).not.toContain(encodeURIComponent(USDC_TYPE));
+  });
+
+  // [v0.47.1] Three regression guards for the SUI short-form normalization
+  // fix. Pre-fix, BlockVision's `/coin/price/list` silently returned an
+  // empty `prices` map for `0x2::sui::SUI`, leaving the `token_prices`
+  // tool, `wallet-balance` route, and engine-factory price seeding all
+  // returning $0 for SUI even on Pro tier.
+
+  it('9) SUI short form ⇄ BlockVision long form: caller-keyed response, long-form URL', async () => {
+    const fetchMock = vi.fn(async (input: FetchInput) => {
+      const url = urlOf(input);
+      // Engine must send the LONG form — short form returns empty prices.
+      expect(url).toContain(encodeURIComponent(SUI_TYPE_LONG));
+      expect(url).not.toMatch(/tokenIds=0x2::sui::SUI(?:[^0-9a-zA-Z]|$)/);
+      return mockJsonResponse({
+        code: 200,
+        message: 'OK',
+        result: {
+          prices: { [SUI_TYPE_LONG]: '0.95256' },
+          coin24HChange: { [SUI_TYPE_LONG]: '-2.34' },
+        },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const prices = await fetchTokenPrices([SUI_TYPE], 'test-key');
+    // Result must be keyed by the SHORT form the caller passed.
+    expect(prices[SUI_TYPE]).toEqual({ price: 0.95256, change24h: -2.34 });
+    expect(prices[SUI_TYPE_LONG]).toBeUndefined();
+  });
+
+  it('10) SUI long form passed by caller — identity mapping, no double-fetch', async () => {
+    const fetchMock = vi.fn(async () =>
+      mockJsonResponse({
+        code: 200,
+        message: 'OK',
+        result: { prices: { [SUI_TYPE_LONG]: '0.95' } },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const prices = await fetchTokenPrices([SUI_TYPE_LONG], 'test-key');
+    expect(prices[SUI_TYPE_LONG]).toEqual({ price: 0.95 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('11) cache shared across short + long form on subsequent calls', async () => {
+    const fetchMock = vi.fn(async () =>
+      mockJsonResponse({
+        code: 200,
+        message: 'OK',
+        result: { prices: { [SUI_TYPE_LONG]: '0.95' } },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const a = await fetchTokenPrices([SUI_TYPE], 'test-key');
+    expect(a[SUI_TYPE]?.price).toBe(0.95);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call passes the LONG form. Cache stores by long form so this
+    // hits the cache rather than the network — proves the two forms are
+    // interchangeable from the cache's perspective.
+    const b = await fetchTokenPrices([SUI_TYPE_LONG], 'test-key');
+    expect(b[SUI_TYPE_LONG]?.price).toBe(0.95);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/engine/src/blockvision-prices.ts
+++ b/packages/engine/src/blockvision-prices.ts
@@ -27,7 +27,7 @@
 // callers can decide whether to badge "approximate" totals.
 // ---------------------------------------------------------------------------
 
-import { getDecimalsForCoinType, resolveSymbol } from '@t2000/sdk';
+import { getDecimalsForCoinType, resolveSymbol, normalizeCoinType } from '@t2000/sdk';
 import { fetchWalletCoins } from './sui-rpc.js';
 
 const BLOCKVISION_BASE = 'https://api.blockvision.org/v2/sui';
@@ -289,19 +289,24 @@ export async function fetchTokenPrices(
   const cacheValid = priceMapCache !== null && now - priceMapCache.ts < CACHE_TTL_MS;
   const cached = cacheValid ? priceMapCache!.prices : {};
 
+  // [v0.47.1] Cache + STABLE_USD_PRICES are keyed by long-form coin types
+  // (64-hex address). Caller inputs may be short-form (`0x2::sui::SUI`).
+  // Normalize for lookup, but preserve the caller's original string in
+  // the result map so consumers indexing by their input keys still work.
   const result: Record<string, { price: number; change24h?: number }> = {};
   const stillMissing: string[] = [];
-  for (const coinType of coinTypes) {
-    if (cached[coinType]) {
-      result[coinType] = cached[coinType];
+  for (const original of coinTypes) {
+    const norm = normalizeCoinType(original);
+    if (cached[norm]) {
+      result[original] = cached[norm];
       continue;
     }
-    const stable = STABLE_USD_PRICES[coinType];
+    const stable = STABLE_USD_PRICES[norm];
     if (typeof stable === 'number') {
-      result[coinType] = { price: stable };
+      result[original] = { price: stable };
       continue;
     }
-    stillMissing.push(coinType);
+    stillMissing.push(original);
   }
 
   if (stillMissing.length === 0) return result;
@@ -312,7 +317,12 @@ export async function fetchTokenPrices(
   const fetched = await fetchPricesFromBlockVision(stillMissing, apiKey);
   Object.assign(result, fetched);
 
-  const merged = { ...cached, ...fetched };
+  // Cache by long form so subsequent calls with either form hit the cache.
+  const cacheUpdates: Record<string, { price: number; change24h?: number }> = {};
+  for (const [original, value] of Object.entries(fetched)) {
+    cacheUpdates[normalizeCoinType(original)] = value;
+  }
+  const merged = { ...cached, ...cacheUpdates };
   priceMapCache = { prices: merged, ts: cacheValid ? priceMapCache!.ts : now };
 
   return result;
@@ -323,8 +333,21 @@ async function fetchPricesFromBlockVision(
   apiKey: string,
 ): Promise<Record<string, { price: number; change24h?: number }>> {
   const out: Record<string, { price: number; change24h?: number }> = {};
-  for (let i = 0; i < coinTypes.length; i += PRICE_LIST_CHUNK) {
-    const chunk = coinTypes.slice(i, i + PRICE_LIST_CHUNK);
+
+  // [v0.47.1] BlockVision's `/coin/price/list` requires fully-normalized
+  // 64-hex coin types — short forms like `0x2::sui::SUI` come back with
+  // `result.prices = {}` even on Pro. Normalize before sending; build a
+  // long→original map so callers who passed `0x2::sui::SUI` see exactly
+  // that key in the response (not the long form BlockVision echoes back).
+  const longToOriginal = new Map<string, string>();
+  for (const original of coinTypes) {
+    const long = normalizeCoinType(original);
+    if (!longToOriginal.has(long)) longToOriginal.set(long, original);
+  }
+  const longForms = Array.from(longToOriginal.keys());
+
+  for (let i = 0; i < longForms.length; i += PRICE_LIST_CHUNK) {
+    const chunk = longForms.slice(i, i + PRICE_LIST_CHUNK);
     const tokenIds = encodeURIComponent(chunk.join(','));
     const url = `${BLOCKVISION_BASE}/coin/price/list?tokenIds=${tokenIds}&show24hChange=true`;
     let res: Response;
@@ -353,11 +376,15 @@ async function fetchPricesFromBlockVision(
     if (json.code !== 200 || !json.result) continue;
     const prices = json.result.prices ?? {};
     const changes = json.result.coin24HChange ?? {};
-    for (const [coinType, priceStr] of Object.entries(prices)) {
+    for (const [returnedType, priceStr] of Object.entries(prices)) {
       const price = parseNumberOrNull(priceStr);
       if (price == null) continue;
-      const change24h = parseNumberOrNull(changes[coinType]);
-      out[coinType] = change24h == null ? { price } : { price, change24h };
+      // BlockVision echoes whatever long form we sent. Map back to the
+      // caller's input string, falling through to the returned key for
+      // safety if BlockVision ever normalizes differently than we do.
+      const original = longToOriginal.get(returnedType) ?? returnedType;
+      const change24h = parseNumberOrNull(changes[returnedType]);
+      out[original] = change24h == null ? { price } : { price, change24h };
     }
   }
   return out;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -61,7 +61,7 @@ export {
   assertAllowedAsset,
 } from './constants.js';
 export type { Operation } from './constants.js';
-export { validateAddress, truncateAddress } from './utils/sui.js';
+export { validateAddress, truncateAddress, normalizeCoinType } from './utils/sui.js';
 export {
   KNOWN_TARGETS,
   LABEL_PATTERNS,

--- a/packages/sdk/src/utils/sui.test.ts
+++ b/packages/sdk/src/utils/sui.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateAddress, truncateAddress } from './sui.js';
+import { validateAddress, truncateAddress, normalizeCoinType } from './sui.js';
 import { T2000Error } from '../errors.js';
 
 describe('sui utilities', () => {
@@ -61,6 +61,41 @@ describe('sui utilities', () => {
       expect(result.startsWith('0xabcd')).toBe(true);
       expect(result.endsWith('7890')).toBe(true);
       expect(result).toContain('...');
+    });
+  });
+
+  describe('normalizeCoinType', () => {
+    // Regression guards for the v0.47.1 BlockVision SUI fix. Pre-fix,
+    // BlockVision's `/coin/price/list` silently returned an empty
+    // `prices` map for `0x2::sui::SUI`, leaving `token_prices` and
+    // `wallet-balance?asset=SUI` returning $0.
+
+    it('normalizes the SUI native coin to its 64-hex long form', () => {
+      expect(normalizeCoinType('0x2::sui::SUI')).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI',
+      );
+    });
+
+    it('is idempotent on already-long coin types', () => {
+      const long =
+        '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+      expect(normalizeCoinType(long)).toBe(long);
+    });
+
+    it('preserves the module + name segments unchanged', () => {
+      expect(normalizeCoinType('0x6::clock::Clock')).toBe(
+        '0x0000000000000000000000000000000000000000000000000000000000000006::clock::Clock',
+      );
+    });
+
+    it('returns the input unchanged for non-coin-type strings (no triple ::)', () => {
+      expect(normalizeCoinType('0x2')).toBe('0x2');
+      expect(normalizeCoinType('not-a-coin')).toBe('not-a-coin');
+      expect(normalizeCoinType('')).toBe('');
+    });
+
+    it('returns the input unchanged when the address segment is malformed', () => {
+      expect(normalizeCoinType('foo::bar::Baz')).toBe('foo::bar::Baz');
     });
   });
 });

--- a/packages/sdk/src/utils/sui.ts
+++ b/packages/sdk/src/utils/sui.ts
@@ -28,3 +28,26 @@ export function truncateAddress(address: string): string {
   if (address.length <= 10) return address;
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }
+
+/**
+ * Normalize a Sui coin type to its canonical long-form 64-hex address.
+ * `0x2::sui::SUI` → `0x0000…0002::sui::SUI`. Idempotent on already-long
+ * forms. Returns the input unchanged if it doesn't look like a coin type
+ * (`<address>::<module>::<name>`) so callers can pass arbitrary strings
+ * without crashing.
+ *
+ * Why this exists: BlockVision's `/v2/sui/coin/price/list` endpoint
+ * silently returns an empty `prices` map for short-form coin types
+ * (notably `0x2::sui::SUI` — the native gas coin). Internal callers must
+ * pass the long form, but external callers (LLM tool args, cached
+ * coin-type strings, audit logs) commonly use the short form. Normalize
+ * before the network call, denormalize back to the caller's input shape
+ * after, and short/long become interchangeable.
+ */
+export function normalizeCoinType(coinType: string): string {
+  const parts = coinType.split('::');
+  if (parts.length !== 3) return coinType;
+  const [addr, mod, name] = parts;
+  if (!addr.startsWith('0x')) return coinType;
+  return `${normalizeSuiAddress(addr)}::${mod}::${name}`;
+}


### PR DESCRIPTION
## Summary

BlockVision's \`/v2/sui/coin/price/list\` silently returns an empty \`prices\` map for short-form coin types like \`0x2::sui::SUI\`, even on Pro tier. Only the fully-normalized 64-hex form (\`0x000…0002::sui::SUI\`) is recognized. Caught during v0.47.0 production verification: USDC priced correctly, SUI degraded silently.

## Impact (pre-fix)

- \`token_prices\` LLM tool: returned $0 for SUI
- \`/api/internal/wallet-balance?asset=SUI\`: returned 0 USD
- engine-factory prompt-time price seeding for SUI: nullable
- \`balance_check\` / \`portfolio_analysis\`: unaffected (use \`/account/coins\` endpoint which inlines SUI's price)

## Fix

- Added \`normalizeCoinType()\` to \`@t2000/sdk\` (pads the address segment via Mysten's \`normalizeSuiAddress\`; idempotent on long forms; pass-through on malformed input)
- Engine's \`fetchPricesFromBlockVision\` now normalizes inputs before the request and remaps response keys back to the caller's input shape so \`0x2::sui::SUI\` and \`0x000…0002::sui::SUI\` are interchangeable from the caller's perspective
- \`fetchTokenPrices\` keys its in-process cache + \`STABLE_USD_PRICES\` lookups by long form so subsequent calls with either shape hit the cache

## Tests

- 5 new SDK cases locking the \`normalizeCoinType\` contract (long form, idempotence, malformed input pass-through)
- 3 new engine cases:
  - #9: short form input → long form URL → caller-keyed response
  - #10: long form input → identity mapping
  - #11: cache shared across short + long forms (single network call)
- Existing test #6 updated to mock the long-form response real BlockVision returns

## Test plan

- [x] \`pnpm --filter @t2000/sdk test\` (396/396 pass)
- [x] \`pnpm --filter @t2000/engine test\` (442/442 pass)
- [x] \`pnpm --filter @t2000/engine typecheck\`
- [ ] After merge + release, verify \`/api/internal/wallet-balance?asset=SUI\` on prod returns non-zero USD for the sponsor wallet


Made with [Cursor](https://cursor.com)