### PR TITLE
fix(server): retry + fail loud on notification-users fetch errors

### DIFF
--- a/apps/server/src/cron/scheduler.test.ts
+++ b/apps/server/src/cron/scheduler.test.ts
@@ -8,9 +8,11 @@ beforeEach(() => {
   vi.stubEnv('AUDRIC_INTERNAL_URL', 'https://test.audric.ai');
   vi.stubEnv('AUDRIC_INTERNAL_KEY', 'test-internal-key');
   globalThis.fetch = mockFetch;
+  vi.useFakeTimers({ shouldAdvanceTime: true });
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   globalThis.fetch = originalFetch;
   vi.unstubAllEnvs();
   vi.clearAllMocks();
@@ -36,21 +38,53 @@ describe('fetchNotificationUsers', () => {
     expect(opts.headers['x-internal-key']).toBe('test-internal-key');
   });
 
-  it('returns empty array on API failure', async () => {
-    mockFetch.mockResolvedValue({ ok: false, status: 500 });
-    const users = await fetchNotificationUsers();
-    expect(users).toEqual([]);
-  });
-
-  it('returns empty array on network error', async () => {
-    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
-    const users = await fetchNotificationUsers();
-    expect(users).toEqual([]);
-  });
-
-  it('returns empty array when API responds with no users field', async () => {
+  it('returns empty array when API responds 200 with no users field', async () => {
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
     const users = await fetchNotificationUsers();
     expect(users).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient 5xx and succeeds on a later attempt', async () => {
+    const mockUsers = [{ userId: 'u1', walletAddress: '0xaaa' }];
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: false, status: 502 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ users: mockUsers }) });
+
+    const users = await fetchNotificationUsers();
+    expect(users).toEqual(mockUsers);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting retries on persistent 5xx', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(fetchNotificationUsers()).rejects.toThrow(
+      /notification-users fetch failed after 3 attempts: HTTP 500/,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting retries on persistent network error', async () => {
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(fetchNotificationUsers()).rejects.toThrow(
+      /notification-users fetch failed after 3 attempts: ECONNREFUSED/,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('recovers from a single transient network blip on retry', async () => {
+    const mockUsers = [{ userId: 'u1', walletAddress: '0xaaa' }];
+
+    mockFetch
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ users: mockUsers }) });
+
+    const users = await fetchNotificationUsers();
+    expect(users).toEqual(mockUsers);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/server/src/cron/scheduler.ts
+++ b/apps/server/src/cron/scheduler.ts
@@ -8,6 +8,14 @@ function getInternalKey(): string {
   return process.env.AUDRIC_INTERNAL_KEY ?? '';
 }
 
+const MAX_ATTEMPTS = 3;
+const BASE_BACKOFF_MS = 1_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * Fetch eligible users from the audric internal API. Pure plumbing — the only
  * way the t2000 server (separate DB) can reach the audric DB to learn which
@@ -16,6 +24,18 @@ function getInternalKey(): string {
  * No timezone filtering — silent-infra crons run on fixed UTC hours and the
  * jobs themselves are idempotent.
  *
+ * Reliability: retries up to MAX_ATTEMPTS on 5xx / network errors with
+ * incremental backoff. Throws on persistent failure so `runCron` exits 1
+ * and the ECS task is reported as FAILED in EventBridge / CloudWatch — this
+ * replaces the previous silent `return []` which masked Audric/Neon
+ * cold-start outages as "0 eligible users" and dropped a full day of
+ * snapshots without any alarm. (Two real-world misses observed at
+ * 2026-04-21 07:00 UTC and 2026-04-24 07:00 UTC.)
+ *
+ * An empty `users` array in a 200 response is still a legitimate state
+ * (source-filtered queries can legitimately return zero eligible users) so
+ * we don't treat it as an error.
+ *
  * [SIMPLIFICATION DAY 5 — audit catch-up] Companion `reportNotifications`
  * was removed when the NotificationLog table + /api/internal/notification-log
  * endpoint were dropped. There is no notification audit log anymore — sent
@@ -23,24 +43,48 @@ function getInternalKey(): string {
  */
 export async function fetchNotificationUsers(): Promise<NotificationUser[]> {
   const url = `${getInternalUrl()}/api/internal/notification-users`;
+  let lastError: unknown;
 
-  try {
-    const res = await fetch(url, {
-      headers: {
-        'x-internal-key': getInternalKey(),
-        'Content-Type': 'application/json',
-      },
-    });
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          'x-internal-key': getInternalKey(),
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
 
-    if (!res.ok) {
-      console.error(`[cron] Failed to fetch notification users: ${res.status}`);
-      return [];
+      if (res.ok) {
+        const data = (await res.json()) as { users?: NotificationUser[] };
+        return data.users ?? [];
+      }
+
+      lastError = new Error(`HTTP ${res.status}`);
+      if (attempt < MAX_ATTEMPTS) {
+        const backoff = BASE_BACKOFF_MS * attempt;
+        console.warn(
+          `[cron] notification-users returned ${res.status} (attempt ${attempt}/${MAX_ATTEMPTS}) — retrying in ${backoff}ms`,
+        );
+        await sleep(backoff);
+        continue;
+      }
+    } catch (err) {
+      lastError = err;
+      if (attempt < MAX_ATTEMPTS) {
+        const backoff = BASE_BACKOFF_MS * attempt;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[cron] notification-users error (attempt ${attempt}/${MAX_ATTEMPTS}): ${msg} — retrying in ${backoff}ms`,
+        );
+        await sleep(backoff);
+        continue;
+      }
     }
-
-    const data = (await res.json()) as { users: NotificationUser[] };
-    return data.users ?? [];
-  } catch (err) {
-    console.error('[cron] Error fetching notification users:', err instanceof Error ? err.message : err);
-    return [];
   }
+
+  const reason = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `notification-users fetch failed after ${MAX_ATTEMPTS} attempts: ${reason}`,
+  );
 }


### PR DESCRIPTION
## Summary

The daily-intel cron has been silently dropping a full day of `PortfolioSnapshot` + `ChainMemory` rows whenever Audric's `/api/internal/notification-users` endpoint returns a 5xx (typically Neon cold-start / Vercel function timeout). Confirmed misses on **2026-04-21 07:00 UTC** and **2026-04-24 07:00 UTC** — ~17% observed failure rate on hour=7 runs in the past two weeks.

The miss is invisible because the existing code swallows the 5xx as `return []`, and `runCron()` then treats "0 users" as "exit cleanly". EventBridge reports the task as ✅ green, no alarm fires, no log line stands out, and the gap shows up days later when someone notices the missing snapshot row.

## Fix

`apps/server/src/cron/scheduler.ts`:
- Retry up to 3 attempts with incremental backoff (1s, 2s) on 5xx + network errors. Sized to absorb a Neon serverless cold-start (~10–20s on first wake).
- 30s `AbortSignal.timeout` per attempt so a hung TCP connection can't pin the cron task indefinitely.
- **Throw** on persistent failure instead of `return []`. The throw propagates to `runCron()`'s existing `.catch()` → `process.exit(1)` → ECS task marked FAILED → visible in CloudWatch and alertable via standard ECS metrics.

A 200 response with `{ users: [] }` is still legitimate (the source-filtered branches like `memory-extraction` can legitimately return zero eligible users), so we still return `[]` in that case.

## Test plan

- [x] `pnpm --filter @t2000/server typecheck` clean
- [x] `pnpm --filter @t2000/server test` — all 50 tests pass including 6 new/updated `fetchNotificationUsers` cases:
  - Fetches with the slimmed payload shape (existing)
  - Returns `[]` on 200 with no `users` field (existing — legitimate empty)
  - **Retries transient 5xx and succeeds on a later attempt** (new)
  - **Throws after exhausting retries on persistent 5xx** (replaces previous bug-enshrining test)
  - **Throws after exhausting retries on persistent network error** (replaces previous bug-enshrining test)
  - **Recovers from a single transient network blip on retry** (new)
- [ ] After merge: `deploy-server.yml` rebuilds the t2000-server image, ECS picks up the new image, next cron run uses retry behavior
- [ ] If a Neon cold-start cycle is observed in the next CloudWatch invocations, the warn-line should print and the cron should still complete successfully

## Deployment notes

`deploy-server.yml` triggers automatically on push to `main` with paths `apps/server/src/**`. The cron task definition uses the same `t2000-server:latest` image as the long-running service, so once the image is rebuilt, the next EventBridge-triggered cron will use the fixed code without any task definition update.

## Related

- Detailed root-cause investigation in transcript: gap days had cron logs `[cron] Failed to fetch notification users: 500` → `[cron] No users found — exiting` → exit 0 with EventBridge ✅
- Companion audric PR (mission69b/audric#65) addresses the missing `currentApy` + dead CSP host follow-ups.

Made with [Cursor](https://cursor.com)