### PR TITLE
✅ fix(gateway): mock prisma in gateway.test.ts to unblock CI

### DIFF
--- a/apps/gateway/lib/gateway.test.ts
+++ b/apps/gateway/lib/gateway.test.ts
@@ -1,4 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+
+// `gateway.ts` imports `./log-payment`, which imports `./prisma`, which
+// imports the generated `@prisma/client/default` module. CI doesn't run
+// `prisma generate` for the gateway package before tests, so the
+// transitive resolution fails with `Cannot find module '.prisma/client/default'`.
+// `fetchWithRetry` itself is pure (no DB access) — mocking the prisma
+// module short-circuits the import chain. Mirrors the same pattern
+// `log-payment.test.ts` uses.
+vi.mock('./prisma', () => ({
+  prisma: {
+    mppPayment: { create: vi.fn() },
+  },
+}));
+
 import { fetchWithRetry } from './gateway';
 
 function mockResponse(status: number, body: unknown = {}): Response {


### PR DESCRIPTION
## Summary

Fixes pre-existing CI failure on every PR + main:

\`\`\`
Error: Cannot find module '.prisma/client/default'
\`\`\`

## Root cause

\`apps/gateway/lib/gateway.test.ts\` imports \`./gateway\` → \`./log-payment\` → \`./prisma\` → \`@prisma/client\`. CI doesn't run \`prisma generate\` for the gateway package before tests, so the transitive resolution fails.

The companion test \`log-payment.test.ts\` already sidesteps this with \`vi.mock('./prisma', ...)\`. Applying the same pattern to \`gateway.test.ts\` short-circuits the transitive import chain. \`fetchWithRetry\` is pure (no DB access) so mocking has no test-semantic impact.

## Surfaced via

S.266 engine canvas PR (#89) couldn't merge cleanly because of this pre-existing red. Confirmed on main commit \`0afe9fd0a\` — not introduced by S.266.

## Test plan

- [x] \`pnpm --filter gateway test\` — all 7 test files, 59 tests pass locally
- [ ] CI green on this PR

## Out of scope

The deeper fix (running \`prisma generate\` as part of gateway test setup) would let the test exercise real prisma typings if it ever needs to. But the gateway test today is purely about \`fetchWithRetry\`, so the mock is the minimal change.

Made with [Cursor](https://cursor.com)