### PR TITLE
feat(sdk): route balance reads through transport-agnostic Core API (gRPC migration Stage 1)

### DIFF
--- a/packages/sdk/grpc-parity-probe.mjs
+++ b/packages/sdk/grpc-parity-probe.mjs
@@ -1,0 +1,144 @@
+// Stage 0 read-only parity + endpoint probe. Keyless, public mainnet, NO tx execution.
+// Confirms: (1) public fullnode serves gRPC-web, (2) Core API shape parity, (3) latency.
+import { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import { SuiGrpcClient } from '@mysten/sui/grpc';
+
+const URL = 'https://fullnode.mainnet.sui.io:443';
+const ADDR = '0x76d70cf9d3ab7f714a35adf8766a2cb25929cae92ab4de54ff4dea0482b05012'; // gateway recipient, active mainnet
+const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+const CLOCK = '0x6';
+
+const json = new SuiJsonRpcClient({ url: URL, network: 'mainnet' });
+const grpc = new SuiGrpcClient({ baseUrl: URL, network: 'mainnet' });
+
+const t = async (label, fn) => {
+  const s = performance.now();
+  try {
+    const r = await fn();
+    const ms = (performance.now() - s).toFixed(0);
+    console.log(`✅ ${label} (${ms}ms)`);
+    return r;
+  } catch (e) {
+    const ms = (performance.now() - s).toFixed(0);
+    console.log(`❌ ${label} (${ms}ms) → ${e?.message ?? e}`);
+    return null;
+  }
+};
+
+console.log('=== ENDPOINT: does public fullnode serve gRPC-web? ===');
+const gBal = await t('gRPC  core.getBalance', () => grpc.core.getBalance({ owner: ADDR, coinType: USDC }));
+if (gBal) console.log('   shape:', JSON.stringify(gBal));
+
+const jBalLegacy = await t('JSON  getBalance (legacy)', () => json.getBalance({ owner: ADDR, coinType: USDC }));
+if (jBalLegacy) console.log('   shape:', JSON.stringify(jBalLegacy));
+
+const jBalCore = await t('JSON  core.getBalance', () => json.core.getBalance({ owner: ADDR, coinType: USDC }));
+if (jBalCore) console.log('   shape:', JSON.stringify(jBalCore));
+
+console.log('\n=== listOwnedObjects / listCoins ===');
+const gObjs = await t('gRPC  core.listOwnedObjects', () => grpc.core.listOwnedObjects({ owner: ADDR }));
+if (gObjs) console.log('   keys:', Object.keys(gObjs), 'count:', gObjs.objects?.length);
+
+console.log('\n=== getObject (clock) — content shape ===');
+const gClock = await t('gRPC  core.getObject 0x6', () => grpc.core.getObject({ objectId: CLOCK }));
+if (gClock) console.log('   object keys:', Object.keys(gClock.object ?? {}));
+const gClockJson = await t('gRPC  core.getObject 0x6 +json', () => grpc.core.getObject({ objectId: CLOCK, include: { json: true } }));
+if (gClockJson) console.log('   json:', JSON.stringify(gClockJson.object?.json));
+
+console.log('\n=== BENCHMARK: 5x getBalance fan-out (portfolio-like) ===');
+const coins = [USDC, '0x2::sui::SUI', USDC, '0x2::sui::SUI', USDC];
+const benchJson = async () => Promise.all(coins.map((c) => json.core.getBalance({ owner: ADDR, coinType: c })));
+const benchGrpc = async () => Promise.all(coins.map((c) => grpc.core.getBalance({ owner: ADDR, coinType: c })));
+await t('warm gRPC', benchGrpc);
+await t('warm JSON', benchJson);
+for (let i = 0; i < 3; i++) {
+  await t(`  gRPC fan-out #${i + 1}`, benchGrpc);
+  await t(`  JSON fan-out #${i + 1}`, benchJson);
+}
+
+// [gRPC migration Stage 1] The real flip gate: run the REWRITTEN `queryBalance`
+// (now `client.core.*`) end-to-end on both transports and diff the full
+// BalanceResponse. This is what the canary must see identical before flipping
+// `T2000_TRANSPORT=grpc`. Imports from the built package, so run `pnpm build` first.
+console.log('\n=== STAGE 1 GATE: queryBalance() parity across transports + wallet shapes ===');
+const { queryBalance, resetSuiPriceCache, CETUS_USDC_SUI_POOL } = await import('./dist/index.js');
+
+// (a) Direct Cetus-pool getObject json-shape parity. `fetchSuiPrice` reads
+// `pool.object.json.current_sqrt_price`; if gRPC's json shape diverges, the
+// price path silently falls back. Check the source read shape head-on, on BOTH
+// transports, independent of any cache.
+console.log('\n--- Cetus pool getObject json shape (price source) ---');
+const jPool = await t('JSON  core.getObject pool +json', () => json.core.getObject({ objectId: CETUS_USDC_SUI_POOL, include: { json: true } }));
+const gPool = await t('gRPC  core.getObject pool +json', () => grpc.core.getObject({ objectId: CETUS_USDC_SUI_POOL, include: { json: true } }));
+const jSqrt = jPool?.object?.json?.current_sqrt_price;
+const gSqrt = gPool?.object?.json?.current_sqrt_price;
+console.log('   JSON current_sqrt_price:', jSqrt);
+console.log('   gRPC current_sqrt_price:', gSqrt);
+const poolShapeOk = jSqrt != null && gSqrt != null && String(jSqrt) === String(gSqrt);
+console.log(poolShapeOk ? '✅ pool json shape parity' : '❌ pool json shape mismatch — price path would fall back on one transport');
+
+// (b) queryBalance parity. Two fixes vs the earlier gate:
+//   1. resetSuiPriceCache() before EVERY call so each transport actually hits
+//      its own core.getObject (the module-level 60s price cache otherwise lets
+//      the 2nd transport reuse the 1st's price and skip getObject entirely).
+//   2. Do NOT strip usdEquiv/total. Compare them with a small relative tolerance
+//      for genuine sub-second price ticks — a blown json shape falls back to
+//      price=1.0 and shows up as a large gap, which this now catches.
+const PRICE_TOL = 0.02; // 2% — absorbs a real Cetus tick between reads, not a fallback
+const rel = (x, y) => (x === 0 && y === 0 ? 0 : Math.abs(x - y) / Math.max(Math.abs(x), Math.abs(y)));
+function compare(a, b) {
+  const structA = { ...a, gasReserve: { sui: a.gasReserve.sui }, total: undefined };
+  const structB = { ...b, gasReserve: { sui: b.gasReserve.sui }, total: undefined };
+  if (JSON.stringify(structA) !== JSON.stringify(structB)) return 'structural mismatch (stables / sui / available)';
+  if (rel(a.gasReserve.usdEquiv, b.gasReserve.usdEquiv) > PRICE_TOL)
+    return `usdEquiv drift ${a.gasReserve.usdEquiv} vs ${b.gasReserve.usdEquiv} (>${PRICE_TOL * 100}% — likely json-shape fallback on one transport)`;
+  if (rel(a.total, b.total) > PRICE_TOL) return `total drift ${a.total} vs ${b.total}`;
+  return null; // parity
+}
+// Reset, read — so this call computes price from its own transport's getObject.
+const read = (client, addr) => {
+  resetSuiPriceCache();
+  return queryBalance(client, addr);
+};
+
+const WALLETS = [
+  { label: 'gateway recipient (USDC + tiny SUI)', addr: ADDR },
+  { label: 'overlay fee wallet', addr: '0x5366efbf2b4fe5767fe2e78eb197aa5f5d138d88ac3333fbf3f80a1927da473a' },
+  { label: 'likely-empty / zero path', addr: `0x${'0'.repeat(60)}dead` },
+];
+
+let allParity = poolShapeOk;
+for (const w of WALLETS) {
+  console.log(`\n--- ${w.label} ---`);
+  // Both orders, to catch any order-dependent cache leak.
+  const jA = await t('JSON  queryBalance (order A)', () => read(json, w.addr));
+  const gA = await t('gRPC  queryBalance (order A)', () => read(grpc, w.addr));
+  const gB = await t('gRPC  queryBalance (order B)', () => read(grpc, w.addr));
+  const jB = await t('JSON  queryBalance (order B)', () => read(json, w.addr));
+  if (!jA || !gA || !gB || !jB) {
+    allParity = false;
+    console.log('❌ a read failed — cannot assert parity');
+    continue;
+  }
+  console.log('   JSON:', JSON.stringify(jA));
+  console.log('   gRPC:', JSON.stringify(gA));
+  const failA = compare(jA, gA); // JSON-first order
+  const failB = compare(jB, gB); // gRPC-first order
+  if (failA || failB) {
+    allParity = false;
+    console.log(`❌ PARITY MISMATCH — orderA: ${failA ?? 'ok'} | orderB: ${failB ?? 'ok'}`);
+  } else {
+    console.log('✅ PARITY (both orders; usdEquiv within tolerance, structure exact)');
+  }
+}
+
+console.log(
+  allParity
+    ? '\n✅ STAGE 1 GATE PASS — pool shape + queryBalance parity hold across transports, wallet shapes, and call orders.'
+    : '\n❌ STAGE 1 GATE FAIL — do not flip T2000_TRANSPORT until resolved.',
+);
+console.log('\ndone.');
+
+// Make the gate machine-checkable: a CI step or canary guard can gate on the
+// exit code. A logged ❌ with exit 0 reads as success to any automation.
+if (!allParity) process.exitCode = 1;

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -200,6 +200,12 @@ export const DEFAULT_RPC_URL = 'https://fullnode.mainnet.sui.io:443';
 // Reads stay JSON-RPC; only write paths that need gasless eligibility detection
 // build via gRPC. Override with T2000_GRPC_URL for local dev / testnet.
 export const DEFAULT_GRPC_URL = 'https://fullnode.mainnet.sui.io:443';
+// [gRPC migration Stage 1] Mainnet GraphQL endpoint for `getSuiGraphQLClient()`.
+// Only the history read (`queryTransactionBlocks`) has no Core/gRPC equivalent —
+// Stage 2 routes `history.ts` through GraphQL while every other read moves to
+// `client.core.*`. Stage 2 confirms this endpoint against the parity probe before
+// wiring; override with T2000_GRAPHQL_URL for local dev / testnet.
+export const DEFAULT_GRAPHQL_URL = 'https://sui-mainnet.mysten.app/graphql';
 export const DEFAULT_KEY_PATH = '~/.t2000/wallet.key';
 export const DEFAULT_CONFIG_PATH = '~/.t2000/config.json';
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -71,6 +71,7 @@ export {
   normalizeCoinType,
   getSuiClient,
   getSuiGrpcClient,
+  getSuiGraphQLClient,
   createSuiClient,
 } from './utils/sui.js';
 export {
@@ -135,6 +136,8 @@ export {
   getAddress,
 } from './wallet/keyManager.js';
 export { buildSendTx, addSendToTx } from './wallet/send.js';
+// Canonical SDK-level wallet balance reader (transport-agnostic via `.core`).
+export { queryBalance, resetSuiPriceCache } from './wallet/balance.js';
 export {
   fetchAllCoins,
   selectAndSplitCoin,

--- a/packages/sdk/src/t2000.ts
+++ b/packages/sdk/src/t2000.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from 'eventemitter3';
 import type { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import type { ClientWithCoreApi } from '@mysten/sui/client';
 import type { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
 import { Transaction, coinWithBalance, type TransactionObjectArgument } from '@mysten/sui/transactions';
 import { createPaymentTransactionUri } from '@mysten/payment-kit';
-import { getSuiClient, getSuiGrpcClient } from './utils/sui.js';
+import { getSuiClient, getSuiGrpcClient, getSuiReadClient } from './utils/sui.js';
 import {
   generateKeypair,
   keypairFromPrivateKey,
@@ -119,6 +120,11 @@ export class T2000 extends EventEmitter<T2000Events> {
   private readonly _signer: TransactionSigner;
   private readonly _keypair?: Ed25519Keypair;
   private readonly client: SuiJsonRpcClient;
+  // [gRPC migration Stage 1] Transport-agnostic READ client, selected by
+  // `T2000_TRANSPORT`. Defaults to `this.client` (JSON-RPC); flips to gRPC when
+  // `T2000_TRANSPORT=grpc`. Only the balance read path uses it today — writes
+  // and execution stay on `this.client` until Stage 4.
+  private readonly readClient: ClientWithCoreApi;
   private readonly _address: string;
   private readonly registry: ProtocolRegistry;
   readonly enforcer: SafeguardEnforcer;
@@ -145,6 +151,7 @@ export class T2000 extends EventEmitter<T2000Events> {
       this._address = getAddress(kp);
     }
     this.client = client;
+    this.readClient = getSuiReadClient(client);
     this.registry = registry ?? T2000.createDefaultRegistry(client);
     this.enforcer = new SafeguardEnforcer(configDir);
     this.enforcer.load();
@@ -654,7 +661,7 @@ export class T2000 extends EventEmitter<T2000Events> {
   }
 
   async balance(): Promise<BalanceResponse> {
-    const bal = await queryBalance(this.client, this._address);
+    const bal = await queryBalance(this.readClient, this._address);
 
     let chainTotal = bal.available + bal.gasReserve.usdEquiv;
 
@@ -1072,7 +1079,7 @@ export class T2000 extends EventEmitter<T2000Events> {
       .reduce((sum, p) => sum + p.amount, 0);
 
     if (savingsTotal < shortfall * 0.95) {
-      const bal = await queryBalance(this.client, this._address);
+      const bal = await queryBalance(this.readClient, this._address);
       throw new T2000Error(
         'INSUFFICIENT_BALANCE',
         `Insufficient funds. Available: $${bal.available.toFixed(2)}, savings: $${savingsTotal.toFixed(2)}, requested shortfall: $${shortfall.toFixed(2)}`,

--- a/packages/sdk/src/utils/sui.test.ts
+++ b/packages/sdk/src/utils/sui.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeCoinType,
   getSuiClient,
   getSuiGrpcClient,
+  getSuiReadClient,
 } from './sui.js';
 import { DEFAULT_GRPC_URL, DEFAULT_RPC_URL } from '../constants.js';
 import { T2000Error } from '../errors.js';
@@ -172,6 +173,46 @@ describe('sui utilities', () => {
       delete process.env.T2000_GRPC_URL;
       const fromDefault = getSuiGrpcClient();
       expect(getSuiGrpcClient(DEFAULT_GRPC_URL)).toBe(fromDefault);
+    });
+  });
+
+  describe('getSuiReadClient — transport flag (gRPC migration Stage 1)', () => {
+    // The env flag `T2000_TRANSPORT` is the single seam the read path flips on.
+    // Default / unrecognized → JSON-RPC (fail-safe to the live transport);
+    // `grpc` → the gRPC client. Both expose `.core`, so balance.ts is identical
+    // either way — these tests lock the SELECTION, not the read shapes.
+    const originalTransport = process.env.T2000_TRANSPORT;
+
+    afterEach(() => {
+      if (originalTransport === undefined) delete process.env.T2000_TRANSPORT;
+      else process.env.T2000_TRANSPORT = originalTransport;
+    });
+
+    it('returns the passed JSON-RPC client when the flag is unset', () => {
+      delete process.env.T2000_TRANSPORT;
+      const jsonRpc = getSuiClient(DEFAULT_RPC_URL);
+      expect(getSuiReadClient(jsonRpc)).toBe(jsonRpc);
+    });
+
+    it('returns the passed JSON-RPC client for an unrecognized flag value', () => {
+      process.env.T2000_TRANSPORT = 'carrier-pigeon';
+      const jsonRpc = getSuiClient(DEFAULT_RPC_URL);
+      expect(getSuiReadClient(jsonRpc)).toBe(jsonRpc);
+    });
+
+    it('returns the gRPC client when T2000_TRANSPORT=grpc (case/space-insensitive)', () => {
+      process.env.T2000_TRANSPORT = '  GRPC  ';
+      const jsonRpc = getSuiClient(DEFAULT_RPC_URL);
+      const read = getSuiReadClient(jsonRpc);
+      expect(read).not.toBe(jsonRpc);
+      expect(read).toBe(getSuiGrpcClient(DEFAULT_GRPC_URL));
+    });
+
+    it('honors an explicit grpcUrl on the grpc branch', () => {
+      process.env.T2000_TRANSPORT = 'grpc';
+      const jsonRpc = getSuiClient(DEFAULT_RPC_URL);
+      const custom = 'https://read.example/grpc';
+      expect(getSuiReadClient(jsonRpc, custom)).toBe(getSuiGrpcClient(custom));
     });
   });
 });

--- a/packages/sdk/src/utils/sui.ts
+++ b/packages/sdk/src/utils/sui.ts
@@ -1,7 +1,9 @@
 import { SuiJsonRpcClient, getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
 import { SuiGrpcClient } from '@mysten/sui/grpc';
+import { SuiGraphQLClient } from '@mysten/sui/graphql';
+import type { ClientWithCoreApi } from '@mysten/sui/client';
 import { isValidSuiAddress, normalizeSuiAddress } from '@mysten/sui/utils';
-import { DEFAULT_GRPC_URL, DEFAULT_RPC_URL } from '../constants.js';
+import { DEFAULT_GRAPHQL_URL, DEFAULT_GRPC_URL, DEFAULT_RPC_URL } from '../constants.js';
 import { T2000Error } from '../errors.js';
 
 /**
@@ -26,6 +28,16 @@ function resolveGrpcUrl(grpcUrl?: string): string {
   const envUrl = process.env.T2000_GRPC_URL?.trim();
   if (envUrl) return envUrl;
   return DEFAULT_GRPC_URL;
+}
+
+/**
+ * Same shape as `resolveRpcUrl` for the GraphQL endpoint.
+ */
+function resolveGraphqlUrl(graphqlUrl?: string): string {
+  if (graphqlUrl) return graphqlUrl;
+  const envUrl = process.env.T2000_GRAPHQL_URL?.trim();
+  if (envUrl) return envUrl;
+  return DEFAULT_GRAPHQL_URL;
 }
 
 /**
@@ -84,6 +96,78 @@ export function getSuiGrpcClient(grpcUrl?: string): SuiGrpcClient {
   const client = new SuiGrpcClient({ baseUrl, network: 'mainnet' });
   grpcClientCache.set(baseUrl, client);
   return client;
+}
+
+/**
+ * GraphQL client cache, keyed by URL. Same rationale as the JSON-RPC / gRPC
+ * caches: different URLs must produce different clients.
+ */
+const graphqlClientCache = new Map<string, SuiGraphQLClient>();
+
+/**
+ * Cached `SuiGraphQLClient` for the transaction-history read.
+ *
+ * [gRPC migration Stage 1 — stub; wired in Stage 2]
+ *
+ * Why this exists: every portfolio read except history has a Core/gRPC
+ * equivalent and moves to `client.core.*` (Stage 1+). The history read
+ * (legacy `queryTransactionBlocks`) has NO Core/gRPC method, so when Mysten
+ * deactivates the public JSON-RPC fullnode (2026-07-31) it must go through
+ * GraphQL instead. This client is the home for that path. Stage 2 rewrites
+ * `history.ts` to query through `getSuiGraphQLClient()` and validates it
+ * against the parity probe; until then this is an unused, ready entry point.
+ *
+ * Override the endpoint with the `T2000_GRAPHQL_URL` env var or the
+ * `graphqlUrl` arg. Cache is keyed by URL so multiple endpoints can co-exist.
+ */
+export function getSuiGraphQLClient(graphqlUrl?: string): SuiGraphQLClient {
+  const url = resolveGraphqlUrl(graphqlUrl);
+  const cached = graphqlClientCache.get(url);
+  if (cached) return cached;
+  const client = new SuiGraphQLClient({ url, network: 'mainnet' });
+  graphqlClientCache.set(url, client);
+  return client;
+}
+
+/**
+ * Resolve the active read transport from `T2000_TRANSPORT` (`grpc` | `jsonrpc`).
+ * Default is `jsonrpc` so the flip is opt-in per the migration plan; an
+ * unrecognized value also falls back to `jsonrpc` (fail-safe to the live
+ * transport rather than the not-yet-soaked one).
+ */
+function resolveReadTransport(): 'grpc' | 'jsonrpc' {
+  return process.env.T2000_TRANSPORT?.trim().toLowerCase() === 'grpc' ? 'grpc' : 'jsonrpc';
+}
+
+/**
+ * Transport-agnostic READ client, selected by `T2000_TRANSPORT`.
+ *
+ * [gRPC migration Stage 1 — SPEC_FULL_GRPC_MIGRATION §Stage 1]
+ *
+ * Both `SuiJsonRpcClient` and `SuiGrpcClient` expose `.core` (the unified
+ * `CoreClient`), so callers that read only through `client.core.*` (today:
+ * `balance.ts`) work identically on either transport. This selector is the
+ * single seam the env flag flips: `T2000_TRANSPORT=grpc` routes reads over
+ * gRPC, anything else stays on JSON-RPC. Writes/execution are NOT affected —
+ * they keep their own `SuiJsonRpcClient` until Stage 4.
+ *
+ * Returned as `ClientWithCoreApi` so callers can only reach the parity-safe
+ * `.core` surface, not transport-specific methods.
+ *
+ * On the `jsonrpc` branch we reuse the caller's existing JSON-RPC client (it
+ * already carries the resolved/overridden RPC URL) rather than re-resolving a
+ * fresh one — so a custom `rpcUrl` keeps working when the flag is off.
+ *
+ * NOTE: a custom `rpcUrl` does NOT carry over to the gRPC branch — when
+ * `T2000_TRANSPORT=grpc`, the gRPC endpoint comes from the `grpcUrl` arg, then
+ * `T2000_GRPC_URL`, then `DEFAULT_GRPC_URL`. A caller pointing reads at a
+ * non-default fullnode must set `T2000_GRPC_URL` (or pass `grpcUrl`) to match.
+ */
+export function getSuiReadClient(
+  jsonRpcClient: SuiJsonRpcClient,
+  grpcUrl?: string,
+): ClientWithCoreApi {
+  return resolveReadTransport() === 'grpc' ? getSuiGrpcClient(grpcUrl) : jsonRpcClient;
 }
 
 export function validateAddress(address: string): string {

--- a/packages/sdk/src/wallet/balance.test.ts
+++ b/packages/sdk/src/wallet/balance.test.ts
@@ -1,0 +1,103 @@
+/**
+ * queryBalance — Core API shape coverage (gRPC migration Stage 1).
+ *
+ * balance.ts was rewritten off the legacy JSON-RPC `client.getBalance` /
+ * `client.getObject` onto the transport-agnostic `client.core.*`. These tests
+ * lock in the Core API response shapes so the eventual JSON-RPC → gRPC flip is
+ * a no-op:
+ *   - `core.getBalance` → `{ balance: { balance, coinType, coinBalance, addressBalance } }`
+ *     (was `{ totalBalance }`)
+ *   - `core.getObject({ include: { json: true } })` → `{ object: { json } }`
+ *     (was `{ data: { content: { fields } } }`)
+ * Both transports' `.core` return these shapes, so a single mock covers both.
+ */
+import type { ClientWithCoreApi } from '@mysten/sui/client';
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_ASSETS } from '../constants.js';
+import { queryBalance } from './balance.js';
+
+const OWNER = `0x${'a'.repeat(64)}`;
+
+// sqrt_price = 2 * 2^64 → raw_price = 4 → SUI price = 1000 / 4 = 250 USD.
+// (A deliberately round, in-band value; the impl's guard accepts 0.01–1000.)
+const SQRT_PRICE_FOR_250 = (2n ** 65n).toString();
+
+function mockCoreClient(opts: {
+  balances?: Record<string, string>; // coinType → Core `.balance.balance`
+  sqrtPrice?: string | null;
+  rejectCoinTypes?: string[];
+}): ClientWithCoreApi {
+  const balances = opts.balances ?? {};
+  return {
+    core: {
+      getBalance: async ({ owner, coinType }: { owner: string; coinType: string }) => {
+        if (opts.rejectCoinTypes?.includes(coinType)) {
+          throw new Error(`mock rpc failure for ${coinType}`);
+        }
+        const balance = balances[coinType] ?? '0';
+        return { balance: { coinType, balance, coinBalance: balance, addressBalance: '0', owner } };
+      },
+      getObject: async () => ({
+        object: {
+          json: opts.sqrtPrice == null ? null : { current_sqrt_price: opts.sqrtPrice },
+        },
+      }),
+    },
+  } as unknown as ClientWithCoreApi;
+}
+
+describe('queryBalance — Core API shapes', () => {
+  it('reads stable balances off `.balance.balance` and sums them (SUI = 0)', async () => {
+    const client = mockCoreClient({
+      balances: {
+        [SUPPORTED_ASSETS.USDC.type]: '5000000', // 5 USDC
+        [SUPPORTED_ASSETS.USDsui.type]: '2000000', // 2 USDsui
+        [SUPPORTED_ASSETS.SUI.type]: '0',
+      },
+      sqrtPrice: SQRT_PRICE_FOR_250,
+    });
+
+    const r = await queryBalance(client, OWNER);
+
+    expect(r.stables.USDC).toBe(5);
+    expect(r.stables.USDsui).toBe(2);
+    expect(r.available).toBe(7);
+    expect(r.gasReserve.sui).toBe(0);
+    expect(r.gasReserve.usdEquiv).toBe(0);
+    expect(r.total).toBe(7);
+  });
+
+  it('derives the SUI gas-reserve USD value from the Cetus pool `json` field', async () => {
+    const client = mockCoreClient({
+      balances: {
+        [SUPPORTED_ASSETS.USDC.type]: '10000000', // 10 USDC
+        [SUPPORTED_ASSETS.USDsui.type]: '0',
+        [SUPPORTED_ASSETS.SUI.type]: '3000000000', // 3 SUI (9 decimals)
+      },
+      sqrtPrice: SQRT_PRICE_FOR_250,
+    });
+
+    const r = await queryBalance(client, OWNER);
+
+    expect(r.gasReserve.sui).toBe(3);
+    expect(r.gasReserve.usdEquiv).toBeCloseTo(750, 6); // 3 SUI × $250
+    expect(r.total).toBeCloseTo(760, 6); // 10 USDC + $750
+  });
+
+  it('degrades a failed per-coin balance read to 0 (the `.catch` path)', async () => {
+    const client = mockCoreClient({
+      balances: {
+        [SUPPORTED_ASSETS.USDsui.type]: '1000000', // 1 USDsui
+        [SUPPORTED_ASSETS.SUI.type]: '0',
+      },
+      rejectCoinTypes: [SUPPORTED_ASSETS.USDC.type],
+      sqrtPrice: SQRT_PRICE_FOR_250,
+    });
+
+    const r = await queryBalance(client, OWNER);
+
+    expect(r.stables.USDC).toBe(0);
+    expect(r.stables.USDsui).toBe(1);
+    expect(r.available).toBe(1);
+  });
+});

--- a/packages/sdk/src/wallet/balance.ts
+++ b/packages/sdk/src/wallet/balance.ts
@@ -1,4 +1,4 @@
-import type { SuiJsonRpcClient } from '@mysten/sui/jsonRpc';
+import type { ClientWithCoreApi } from '@mysten/sui/client';
 import { SUPPORTED_ASSETS, STABLE_ASSETS, MIST_PER_SUI, CETUS_USDC_SUI_POOL } from '../constants.js';
 import type { StableAsset } from '../constants.js';
 import type { BalanceResponse } from '../types.js';
@@ -7,6 +7,20 @@ const SUI_PRICE_FALLBACK = 1.0;
 let _cachedSuiPrice = 0;
 let _priceLastFetched = 0;
 const PRICE_CACHE_TTL_MS = 60_000;
+
+/**
+ * Reset the module-level SUI price cache.
+ *
+ * Test/probe seam (mirrors the engine's `resetXCacheStore` injectors). Without
+ * it, a parity probe that calls `queryBalance` on JSON-RPC then gRPC reuses the
+ * price the first call cached and the second transport NEVER hits
+ * `core.getObject` — so a broken gRPC pool-read shape would go undetected.
+ * Reset between transports to force each to exercise its own `getObject` path.
+ */
+export function resetSuiPriceCache(): void {
+  _cachedSuiPrice = 0;
+  _priceLastFetched = 0;
+}
 
 /**
  * Fetch SUI price in USD from the Cetus USDC/SUI pool's sqrt_price.
@@ -21,20 +35,26 @@ const PRICE_CACHE_TTL_MS = 60_000;
  *
  * Equivalently: 1000 / raw_price
  */
-async function fetchSuiPrice(client: SuiJsonRpcClient): Promise<number> {
+async function fetchSuiPrice(client: ClientWithCoreApi): Promise<number> {
   const now = Date.now();
   if (_cachedSuiPrice > 0 && now - _priceLastFetched < PRICE_CACHE_TTL_MS) {
     return _cachedSuiPrice;
   }
 
   try {
-    const pool = await client.getObject({
-      id: CETUS_USDC_SUI_POOL,
-      options: { showContent: true },
+    // [gRPC migration Stage 1] Read the pool via the transport-agnostic Core
+    // API (`client.core.*`). On JSON-RPC this returns the same data as the
+    // legacy `getObject`, so the rewrite soaks behavior-identically before the
+    // transport flip. We request `json` here; Stage 2 hardens this pool read to
+    // decode BCS `content` instead (the SDK warns `json` shape can vary across
+    // transports). The cached/fallback price below already absorbs any drift.
+    const pool = await client.core.getObject({
+      objectId: CETUS_USDC_SUI_POOL,
+      include: { json: true },
     });
 
-    if (pool.data?.content?.dataType === 'moveObject') {
-      const fields = pool.data.content.fields as Record<string, unknown>;
+    const fields = pool.object.json;
+    if (fields) {
       const currentSqrtPrice = BigInt(String(fields.current_sqrt_price ?? '0'));
 
       if (currentSqrtPrice > 0n) {
@@ -56,17 +76,21 @@ async function fetchSuiPrice(client: SuiJsonRpcClient): Promise<number> {
 }
 
 export async function queryBalance(
-  client: SuiJsonRpcClient,
+  client: ClientWithCoreApi,
   address: string,
 ): Promise<BalanceResponse> {
+  // [gRPC migration Stage 1] `client.core.getBalance` replaces the legacy
+  // `client.getBalance`. Shape drift: `.totalBalance` → `.balance.balance`
+  // (the Core total = coinBalance + addressBalance, runtime-confirmed). Both
+  // transports' `.core` return this shape, so this soaks on JSON-RPC today.
   const stableBalancePromises = STABLE_ASSETS.map((asset) =>
-    client.getBalance({ owner: address, coinType: SUPPORTED_ASSETS[asset].type })
-      .then((b) => ({ asset, amount: Number(b.totalBalance) / 10 ** SUPPORTED_ASSETS[asset].decimals }))
+    client.core.getBalance({ owner: address, coinType: SUPPORTED_ASSETS[asset].type })
+      .then((b) => ({ asset, amount: Number(b.balance.balance) / 10 ** SUPPORTED_ASSETS[asset].decimals }))
       .catch(() => ({ asset, amount: 0 })),
   );
 
   const [suiBalance, suiPriceUsd, ...stableResults] = await Promise.all([
-    client.getBalance({ owner: address, coinType: SUPPORTED_ASSETS.SUI.type }),
+    client.core.getBalance({ owner: address, coinType: SUPPORTED_ASSETS.SUI.type }),
     fetchSuiPrice(client),
     ...stableBalancePromises,
   ]);
@@ -78,7 +102,7 @@ export async function queryBalance(
     totalStables += amount;
   }
 
-  const suiAmount = Number(suiBalance.totalBalance) / Number(MIST_PER_SUI);
+  const suiAmount = Number(suiBalance.balance.balance) / Number(MIST_PER_SUI);
   const savings = 0; // Merged from NAVI in T2000.balance()
   const usdEquiv = suiAmount * suiPriceUsd;
   const total = totalStables + savings + usdEquiv;


### PR DESCRIPTION
## What

gRPC migration **Stage 1** (`SPEC_FULL_GRPC_MIGRATION`). Mysten deactivates the public Sui JSON-RPC fullnode on **2026-07-31**. Both `SuiJsonRpcClient` and `SuiGrpcClient` expose the same `.core` `CoreClient`, so this routes the **balance read path** onto `client.core.*`. It soaks on JSON-RPC today and flips to gRPC via a single env flag — a near-no-op.

Scope is deliberately one read path. Writes, execution, and history are untouched (Stages 2 and 4).

## Changes

- **`balance.ts`** — `fetchSuiPrice` + `queryBalance` use `client.core.getBalance` / `getObject` (shape drift: `.totalBalance` → `.balance.balance`; `.data.content.fields` → `.object.json`). Param widened to the transport-agnostic `ClientWithCoreApi`. Adds `resetSuiPriceCache()` (test/probe seam for the module-level price cache).
- **`utils/sui.ts`** — `getSuiReadClient()` flip seam keyed on `T2000_TRANSPORT` (default `jsonrpc`, fail-safe on unrecognized values). A custom `rpcUrl` does **not** carry to the gRPC branch, so a non-default fullnode needs `T2000_GRPC_URL` (documented inline). Adds `getSuiGraphQLClient()` stub for Stage 2 `history.ts` + `DEFAULT_GRAPHQL_URL`.
- **`t2000.ts`** — new `readClient` field routes the two `queryBalance` call sites; writes/execution stay on `this.client` (JSON-RPC) until Stage 4.
- **`index.ts`** — export `queryBalance` (canonical SDK balance reader), `resetSuiPriceCache`, `getSuiGraphQLClient`.
- **Tests** — `balance.test.ts` (Core response shapes) + `getSuiReadClient` transport-selector tests in `sui.test.ts`.
- **`grpc-parity-probe.mjs`** — Stage 1 gate: parity across both transports, multiple wallet shapes, and both call orders. Resets the price cache before each read so each transport exercises its own `core.getObject`; compares the full `BalanceResponse` (usdEquiv within a small tolerance, not stripped); checks the Cetus pool json shape head-on; non-zero exit on failure for CI/canary gating.

## How to flip

Off by default. Set `T2000_TRANSPORT=grpc` to route balance reads over gRPC; unset to roll back instantly (no redeploy).

## Verification

- `pnpm --filter @t2000/sdk typecheck` — clean
- `pnpm --filter @t2000/engine typecheck` — clean
- SDK tests — **639 passed**
- SDK build (CJS/ESM/DTS) — success
- SDK lint — 0 errors
- Live mainnet parity probe — **PASS** across 3 wallet shapes × both call orders; pool json shape byte-identical across transports

## Reviewed

Two independent Codex review rounds: a price-cache gate blind-spot (gRPC `getObject` skipped via shared cache) and a probe exit-code gap were both found and fixed; no outstanding code issues.

## Not in this PR (ops)

Production soak / canary — deploy + flip `T2000_TRANSPORT=grpc` on a canary surface, watch parity + latency, then widen.

> Note: live benchmark showed gRPC **not** faster than JSON-RPC on a getBalance fan-out (periodic ~220ms spikes vs steady ~45ms). Doesn't block Stage 1 (reads default to JSON-RPC); re-validate at Stage 3.