### PR TITLE
🐛 fix(sdk): recognize long-form SUI in history classifier (correct principal asset)

### DIFF
--- a/packages/sdk/src/wallet/classify.test.ts
+++ b/packages/sdk/src/wallet/classify.test.ts
@@ -452,3 +452,26 @@ describe('extractAllUserLegs (multi-leg / bundle awareness)', () => {
     expect(legs.every((l) => l.asset === 'USDC' || l.asset === 'SUI')).toBe(true);
   });
 });
+
+describe('extractTransferDetails — long-form SUI gas exclusion (GraphQL transport)', () => {
+  // GraphQL history feeds SUI's coin type fully-expanded; the classifier must
+  // still recognize it as SUI (gas noise) and not let it become the principal.
+  const LONG_SUI = '0x0000000000000000000000000000000000000000000000000000000000000002::sui::SUI';
+
+  it('keeps a smaller stablecoin transfer as the principal over a larger long-form SUI gas delta', () => {
+    const { asset, amount, direction } = extractTransferDetails(
+      [
+        // larger-raw SUI movement (9 decimals) — must be excluded as gas
+        bc(ADDR, LONG_SUI, '-5000000000'),
+        // the real transfer: 1 USDC inflow (6 decimals), smaller raw
+        bc(ADDR, USDC_TYPE, '1000000'),
+      ],
+      ADDR,
+    );
+    // Without the canonical SUI check the long-form SUI (abs 5e9 > 1e6) wins as
+    // principal → asset 'SUI', amount 5, direction 'out'. Correct is USDC/1/in.
+    expect(asset).toBe('USDC');
+    expect(amount).toBe(1);
+    expect(direction).toBe('in');
+  });
+});

--- a/packages/sdk/src/wallet/classify.ts
+++ b/packages/sdk/src/wallet/classify.ts
@@ -9,7 +9,28 @@
  * already producing fine-grained labels.
  */
 
+import { normalizeStructTag } from '@mysten/sui/utils';
 import { getDecimalsForCoinType, resolveSymbol, SUI_TYPE } from '../token-registry.js';
+
+/**
+ * Canonical SUI coin-type check. SUI's gas coin is referenced as the short
+ * `0x2::sui::SUI` by JSON-RPC balance changes but as the fully-expanded
+ * `0x000…0002::sui::SUI` by the GraphQL transport — a raw `=== SUI_TYPE` string
+ * compare lets the GraphQL gas delta pass as a "non-SUI" change, so it can be
+ * mis-picked as the transaction's principal asset/amount (and corrupt the
+ * lending direction). Compare normalized struct tags so SUI is detected
+ * regardless of address form (without false-matching an impostor
+ * `0xother::sui::SUI`, since the package address is part of the normalized tag).
+ * Per `token-data-architecture.mdc`: never equality-compare raw coin-type strings.
+ */
+const NORMALIZED_SUI_TYPE = normalizeStructTag(SUI_TYPE);
+function isSuiCoinType(coinType: string): boolean {
+  try {
+    return normalizeStructTag(coinType) === NORMALIZED_SUI_TYPE;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Coarse action bucket — one of `'send' | 'lending' | 'swap' |
@@ -165,12 +186,12 @@ export function refineLendingLabel(
   if (labelMatchedSpecific) return currentLabel;
 
   const userNonSuiOutflow = changes.find(
-    (c) => resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) < 0n,
+    (c) => resolveOwner(c.owner) === address && !isSuiCoinType(c.coinType) && BigInt(c.amount) < 0n,
   );
   if (userNonSuiOutflow) return 'deposit';
 
   const userNonSuiInflow = changes.find(
-    (c) => resolveOwner(c.owner) === address && c.coinType !== SUI_TYPE && BigInt(c.amount) > 0n,
+    (c) => resolveOwner(c.owner) === address && !isSuiCoinType(c.coinType) && BigInt(c.amount) > 0n,
   );
   if (userNonSuiInflow) return 'withdraw';
 
@@ -244,7 +265,7 @@ export function extractTransferDetails(
   const userChanges = changes.filter((c) => resolveOwner(c.owner) === sender);
   if (userChanges.length === 0) return {};
 
-  const userNonSui = userChanges.filter((c) => c.coinType !== SUI_TYPE);
+  const userNonSui = userChanges.filter((c) => !isSuiCoinType(c.coinType));
   const pool = userNonSui.length > 0 ? userNonSui : userChanges;
 
   let primary = pool[0];


### PR DESCRIPTION
## Problem

Transaction history mis-identifies the principal asset/amount of a tx.

History reads now use the Sui **GraphQL** transport, which returns SUI's coin type **fully expanded** (`0x000…0002::sui::SUI`). But the shared classifier (`wallet/classify.ts`) excludes SUI gas by strict-comparing the **short** `0x2::sui::SUI`:

- `extractTransferDetails` (line ~248) — `userNonSui = filter(coinType !== SUI_TYPE)` → runs on **every** history tx
- `refineLendingLabel` (lines ~168/173) — same compare

So the long-form SUI delta passes through as a "non-SUI" change. `extractTransferDetails` then picks the largest-by-raw-units change as the principal — and since SUI is 9 decimals vs stablecoins' 6, a normal gas spend (~0.001–0.005 SUI) often out-magnitudes a small stablecoin transfer.

**Impact (display-only, no funds at risk):** a "$1 USDC send" renders in history as **"−0.003 SUI"** — wrong asset, amount, and direction. Hits a common everyday case (small stablecoin sends/swaps). Surfaces in `t2 history` and any SDK consumer reading history. JSON-RPC emitted short-form SUI, so this only appeared after the GraphQL migration.

## Fix

Compare **canonical struct tags** instead of raw strings — new `isSuiCoinType(coinType)` using `normalizeStructTag`, replacing the three `coinType !== SUI_TYPE` checks. Form-insensitive (detects SUI in either address form) without false-matching an impostor `0xother::sui::SUI` (the package address is part of the normalized tag). Aligns with `token-data-architecture.mdc` (never raw-string-compare coin types).

## Verification

- **Regression test** (`classify.test.ts`): a larger-raw long-form SUI gas delta + a smaller USDC inflow must resolve to `USDC` / `1` / `in`. **Fails without the fix** (`SUI` / `5` / `out`), passes with it — confirmed by running before/after.
- Full SDK suite: **424 tests pass**, typecheck clean, lint 0 errors.

## Notes

Found while reconciling an (abandoned, now-superseded) gRPC read-migration branch against current main — this is the one real bug that survived; it's live on `v5.6.0`.