### PR TITLE
✨ origin-aware agent sell — --primary + multi-route output (SPEC_T2_X402_STORE_SURFACE slice D)

### DIFF
--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -317,12 +317,16 @@ Subcommands:
     .command('sell')
     .argument(
       '[endpoint]',
-      'Your x402 endpoint URL (https). Omit with --remove to clear the listing.',
+      'Your API origin (https://api.example.com — every paid route in its openapi.json gets listed) or one x402 route URL. Omit with --remove to clear the listing.',
     )
     .description(
-      'List your x402 endpoint on your public Agent ID profile. The endpoint is live-probed (must answer 402 with a Sui payment challenge), then set on-chain — sponsored, gasless. Same flow as the console\u2019s "Sell your API".',
+      'List your x402 API on your public Agent ID profile. An origin expands via {origin}/openapi.json — every paid route is live-probed (must answer 402 with a Sui payment challenge) and becomes a store card; a single 402 URL lists just that route. Then set on-chain — sponsored, gasless. Same flow as the console\u2019s "Sell your API".',
     )
     .option('--remove', 'Remove the listing instead')
+    .option(
+      '--primary <path>',
+      'Route to record as the on-chain primary endpoint (default: the cheapest paid route)',
+    )
     .option(
       '--category <category>',
       `Directory category for your listing: ${AGENT_CATEGORIES.join(' | ')} (required unless already set on your profile)`,
@@ -334,6 +338,7 @@ Subcommands:
         endpoint: string | undefined,
         opts: {
           remove?: boolean;
+          primary?: string;
           category?: string;
           key?: string;
           api?: string;
@@ -366,7 +371,11 @@ Subcommands:
           const prepRes = await fetch(`${base}/agent/endpoint/prepare`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ address, endpoint: target }),
+            body: JSON.stringify({
+              address,
+              endpoint: target,
+              ...(opts.primary ? { primary: opts.primary } : {}),
+            }),
           });
           const prep = (await prepRes.json().catch(() => ({}))) as {
             nonce?: string;
@@ -377,17 +386,39 @@ Subcommands:
               currency?: string | null;
               issues?: { message?: string; code?: string }[];
             } | null;
+            origin?: string | null;
+            primary?: { path?: string; url?: string } | null;
+            routes?: {
+              method?: string;
+              path?: string;
+              url?: string;
+              priceUsdc?: string | null;
+              summary?: string | null;
+              probeOk?: boolean;
+              issues?: { message?: string; code?: string }[];
+            }[];
+            issues?: { message?: string; code?: string }[];
             error?: { message?: string } | string;
           };
           if (!prepRes.ok) {
-            const issues = prep.probe?.issues ?? [];
             const msg =
               typeof prep.error === 'string'
                 ? prep.error
                 : (prep.error?.message ?? `HTTP ${prepRes.status}`);
-            const detail = issues
-              .map((i) => `  ✗ ${i.message ?? i.code}`)
-              .join('\n');
+            // Origin expands carry per-route findings; single probes the
+            // flat issue list. Show whichever came back.
+            const lines: string[] = (prep.probe?.issues ?? []).map(
+              (i) => `  ✗ ${i.message ?? i.code}`,
+            );
+            for (const r of prep.routes ?? []) {
+              if (r.probeOk === false) {
+                lines.push(`  ✗ ${r.method ?? 'POST'} ${r.path}`);
+                for (const i of r.issues ?? []) {
+                  lines.push(`      ${i.message ?? i.code}`);
+                }
+              }
+            }
+            const detail = lines.join('\n');
             throw new Error(detail ? `${msg}\n${detail}` : msg);
           }
           if (!(prep.nonce && prep.txBytes)) {
@@ -400,12 +431,16 @@ Subcommands:
             body: { nonce: prep.nonce, address, signature },
           });
 
+          const primaryUrl = prep.primary?.url ?? target;
           if (isJsonMode()) {
             printJson({
               address,
-              endpoint: opts.remove ? null : target,
+              endpoint: opts.remove ? null : primaryUrl,
               listed: !opts.remove,
               probe: prep.probe ?? null,
+              origin: prep.origin ?? null,
+              primary: prep.primary ?? null,
+              routes: prep.routes ?? [],
               digest: sub.digest,
             });
             return;
@@ -414,12 +449,29 @@ Subcommands:
           if (opts.remove) {
             printSuccess('Listing removed.');
           } else {
-            printSuccess('Listed — your endpoint is live on your public profile.');
-            if (prep.probe?.amount) {
-              printKeyValue('Price', `${prep.probe.amount} USDC per call`);
+            const routes = prep.routes ?? [];
+            if (routes.length > 1) {
+              printSuccess(
+                `Listed — ${routes.length} paid routes are live on your public profile.`,
+              );
+              for (const r of routes) {
+                const mark = r.path === prep.primary?.path ? '  (primary)' : '';
+                const price = r.priceUsdc ? `${r.priceUsdc} USDC` : '?';
+                printKeyValue(
+                  `  ${r.method ?? 'POST'} ${r.path}`,
+                  `${price}${mark}`,
+                );
+              }
+            } else {
+              printSuccess(
+                'Listed — your endpoint is live on your public profile.',
+              );
+              if (prep.probe?.amount) {
+                printKeyValue('Price', `${prep.probe.amount} USDC per call`);
+              }
             }
-            printKeyValue('Endpoint', target);
-            printInfo(`Buyers pay it with: t2 pay ${target}`);
+            printKeyValue('Endpoint', primaryUrl);
+            printInfo(`Buyers pay it with: t2 pay ${primaryUrl}`);
             printKeyValue('Profile', `https://t2000.ai/${address}`);
           }
           printKeyValue('Tx', String(sub.digest));

--- a/packages/mcp/src/tools/write.ts
+++ b/packages/mcp/src/tools/write.ts
@@ -149,12 +149,13 @@ Responses that return media (image or audio URLs) should be surfaced to the user
 
   server.tool(
     't2000_agent_sell',
-    "Sell this agent's x402 API endpoint as a Service on its public Agent ID, so buyers can pay it per call in USDC. The endpoint is LIVE-PROBED server-side first (must answer 402 with a valid Sui payment challenge — probe failures are returned per-check), then one sponsored (gasless) signature sets it on-chain. The Service appears on t2000.ai and api.t2000.ai/v1/agents/{address} immediately, and buyers find it with t2000_services. Requires an on-chain Agent ID (`t2 agent register`). Set remove: true to clear the listing. Mirrors `t2 agent sell <endpoint>`. This does NOT spend funds.",
+    "Sell this agent's x402 API as Services on its public Agent ID, so buyers can pay it per call in USDC. Pass the API ORIGIN (https://api.example.com) to list every paid route in its openapi.json, or one route URL to list just that route. Every listed route is LIVE-PROBED server-side first (must answer 402 with a valid Sui payment challenge — probe failures are returned per-route), then one sponsored (gasless) signature sets the primary route on-chain. The routes appear on t2000.ai and api.t2000.ai/v1/agents/{address} immediately, and buyers find them with t2000_services. Requires an on-chain Agent ID (`t2 agent register`). Set remove: true to clear the listing. Mirrors `t2 agent sell <url>`. This does NOT spend funds.",
     {
-      endpoint: z.string().optional().describe('Your x402 endpoint URL (https). Omit only with remove: true.'),
+      endpoint: z.string().optional().describe('Your API origin (expands every paid route in its openapi.json) or one x402 route URL (https). Omit only with remove: true.'),
       remove: z.boolean().optional().describe('Remove the listing instead of setting one (default: false)'),
+      primary: z.string().optional().describe('Route path to record as the on-chain primary endpoint, e.g. "/palette" (default: the cheapest paid route)'),
     },
-    async ({ endpoint, remove }) => {
+    async ({ endpoint, remove, primary }) => {
       try {
         if (!(remove || endpoint)) {
           throw new Error('Provide the x402 endpoint URL (or remove: true to clear the listing).');
@@ -166,7 +167,11 @@ Responses that return media (image or audio URLs) should be surfaced to the user
         const prepRes = await fetch(`${base}/agent/endpoint/prepare`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ address, endpoint: target }),
+          body: JSON.stringify({
+            address,
+            endpoint: target,
+            ...(primary ? { primary } : {}),
+          }),
         });
         const prep = (await prepRes.json().catch(() => ({}))) as {
           nonce?: string;
@@ -177,15 +182,37 @@ Responses that return media (image or audio URLs) should be surfaced to the user
             currency?: string | null;
             issues?: { message?: string; code?: string }[];
           } | null;
+          origin?: string | null;
+          primary?: { path?: string; url?: string } | null;
+          routes?: {
+            method?: string;
+            path?: string;
+            url?: string;
+            priceUsdc?: string | null;
+            summary?: string | null;
+            probeOk?: boolean;
+            issues?: { message?: string; code?: string }[];
+          }[];
           error?: { message?: string } | string;
         };
         if (!prepRes.ok) {
           const msg = typeof prep.error === 'string' ? prep.error : (prep.error?.message ?? `HTTP ${prepRes.status}`);
-          // Surface the probe's per-check findings so the agent can fix its endpoint.
+          // Surface the probe's per-check findings (per-route on origin
+          // expands) so the agent can fix its endpoint.
           return {
             content: [{
               type: 'text' as const,
-              text: JSON.stringify({ ok: false, error: msg, probeIssues: prep.probe?.issues ?? [] }),
+              text: JSON.stringify({
+                ok: false,
+                error: msg,
+                probeIssues: prep.probe?.issues ?? [],
+                routes: (prep.routes ?? []).map((r) => ({
+                  method: r.method,
+                  path: r.path,
+                  probeOk: r.probeOk,
+                  issues: r.issues ?? [],
+                })),
+              }),
             }],
             isError: true,
           };
@@ -212,8 +239,19 @@ Responses that return media (image or audio URLs) should be surfaced to the user
             text: JSON.stringify({
               ok: true,
               listed: !remove,
-              endpoint: remove ? null : target,
+              endpoint: remove ? null : (prep.primary?.url ?? target),
               pricePerCall: prep.probe?.amount ? `${prep.probe.amount} ${prep.probe.currency ?? 'USDC'}` : undefined,
+              origin: prep.origin ?? undefined,
+              routes: remove
+                ? undefined
+                : (prep.routes ?? []).map((r) => ({
+                    method: r.method,
+                    path: r.path,
+                    url: r.url,
+                    priceUsdc: r.priceUsdc,
+                    summary: r.summary,
+                    primary: r.path === prep.primary?.path || undefined,
+                  })),
               profile: `https://t2000.ai/${address}`,
               digest: sub.digest,
             }),

--- a/packages/serve/src/route.test.ts
+++ b/packages/serve/src/route.test.ts
@@ -108,6 +108,15 @@ describe('402 challenge (unpaid)', () => {
     expect(entry?.resource).toBe('https://seller.example/search');
   });
 
+  it('also sets the MPP WWW-Authenticate header (dual-dialect, pre-0.2.2 probes)', async () => {
+    const route = makeRoute();
+    const res = await route(post('https://seller.example/search', {}));
+    const header = res.headers.get('www-authenticate');
+    expect(header).toContain('Payment realm="seller.example"');
+    expect(header).toContain(`recipient="${PAY_TO}"`);
+    expect(header).toContain('amount="0.01"'); // decimal — the header dialect's unit
+  });
+
   it('fires the 402 BEFORE body validation — the probe POSTs {} and must see the challenge', async () => {
     const route = makeRoute();
     const res = await route(post('https://seller.example/search', { wrong: 'shape' }));

--- a/packages/serve/src/route.ts
+++ b/packages/serve/src/route.ts
@@ -380,11 +380,27 @@ async function respond402(
       chain,
       currentEpoch: epoch,
     });
-    return json(402, {
-      x402Version: X402_VERSION,
-      error: args.error ?? 'Payment required',
-      accepts: [requirements],
-    });
+    // Belt-and-suspenders for pre-0.2.2 discovery clients and dual-dialect
+    // consumers: mirror the challenge into the MPP WWW-Authenticate shape.
+    // The accepts[] body stays the authoritative envelope — the header carries
+    // the same recipient/currency and the DECIMAL amount that dialect uses.
+    const host = (() => {
+      try {
+        return new URL(args.resource).hostname;
+      } catch {
+        return undefined;
+      }
+    })();
+    const wwwAuth = `Payment realm="${host ?? 'x402'}", recipient="${runtime.payTo}", currency="${runtime.currency}", amount="${args.priceUsdc}"`;
+    return json(
+      402,
+      {
+        x402Version: X402_VERSION,
+        error: args.error ?? 'Payment required',
+        accepts: [requirements],
+      },
+      { 'WWW-Authenticate': wwwAuth },
+    );
   } catch (err) {
     // Chain info unreachable — a 402 without the envelope is unpayable, so
     // be honest about the outage instead of serving a dead challenge.


### PR DESCRIPTION
## What

Client half of SPEC_T2_X402_STORE_SURFACE (server expand ships in audric [#136](https://github.com/mission69b/audric/pull/136)):

- **cli** `t2 agent sell` — accepts an API **origin** (or a single 402 URL, unchanged), new `--primary <path>`, prints the expanded route list (price + primary mark) and per-route probe findings on failure; on-chain endpoint output follows the server-picked primary URL
- **mcp** `t2000_agent_sell` — same widening for stdio: `primary` param, `routes` in the success payload, per-route `probeIssues` on failure

No probing moved client-side — both remain thin callers of `/v1/agent/endpoint/prepare|submit`, so old CLI builds keep working against the new API (legacy `probe` response shape preserved).

## Verified

- cli: tsc clean, eslint 0 errors, 217 tests green
- mcp: tsc clean, eslint 0 errors, 92 tests green
- Pay-rail regression on a full route URL: $0.01 to market-scout `/haiku` settled live (receipt `8XfaCDdxmsoVBogAwTCsRHhYD72fPXosiqSgsTqkXsny`)

## Founder dogfood (after audric deploy + next release)

```
t2 agent sell https://funkii-ai.vercel.app
```
→ lists 3 routes, `/palette` primary, profile shows 3 cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)