### PR TITLE
🐛 fix(serve): Next OPTIONS export so browser x402 preflight works

### DIFF
--- a/apps/docs/sell-to-agents/overview.mdx
+++ b/apps/docs/sell-to-agents/overview.mdx
@@ -13,11 +13,13 @@ Per call, ≤ $5, no protocol fee. Deliverable work above that is
 [escrow](/commerce/sell-services) instead.
 
 ```ts
-export const POST = serve
-  .route({ path: 'search' })
-  .paid('0.02')
-  .body(schema)
-  .handler(async ({ body }) => search(body));
+export const { POST, OPTIONS } = asNextRoute(
+  serve
+    .route({ path: 'search' })
+    .paid('0.02')
+    .body(schema)
+    .handler(async ({ body }) => search(body)),
+);
 ```
 
 ## Wrap an existing API
@@ -36,17 +38,26 @@ export const POST = serve
   </Step>
   <Step title="Wrap a route">
     ```ts app/api/search/route.ts
+    import { asNextRoute } from '@t2000/serve';
     import { z } from 'zod';
     import { serve } from '@/lib/serve';
 
     const input = z.object({ query: z.string().min(1) });
 
-    export const POST = serve
-      .route({ path: 'search', description: 'Web search, paid per call' })
-      .paid('0.02')
-      .body(input, z.toJSONSchema(input))
-      .handler(async ({ body }) => yourExistingLogic(body));
+    export const { POST, OPTIONS } = asNextRoute(
+      serve
+        .route({ path: 'search', description: 'Web search, paid per call' })
+        .paid('0.02')
+        .body(input, z.toJSONSchema(input))
+        .handler(async ({ body }) => yourExistingLogic(body)),
+    );
     ```
+
+    Next.js dispatches only the methods a `route.ts` exports — export
+    `OPTIONS` too (`asNextRoute` does it), or browser buyers fail CORS
+    preflight; serve's CORS handling alone isn't enough when only `POST`
+    is exported. Fetch runtimes (Bun / Deno / workers) mounting one
+    handler are fine as-is.
   </Step>
   <Step title="Serve discovery docs">
     ```ts
@@ -112,7 +123,8 @@ Every route is `(Request) => Promise<Response>`.
 <CodeGroup>
 
 ```ts Next.js
-export const POST = serve.route({ path: 'search' }).paid('0.02').handler(fn);
+export const { POST, OPTIONS } =
+  asNextRoute(serve.route({ path: 'search' }).paid('0.02').handler(fn));
 export const GET = serve.openapi();   // app/openapi.json/route.ts
 export const GET = serve.llms();      // app/llms.txt/route.ts
 ```

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -4,16 +4,24 @@ Merchant-side x402 router for Sui — wrap any API so agents can discover it and
 
 ```ts
 // app/api/search/route.ts (Next.js) — a complete paid endpoint
-import { createServeFromEnv } from '@t2000/serve';
+import { asNextRoute, createServeFromEnv } from '@t2000/serve';
 
 const serve = createServeFromEnv(); // reads T2000_PAY_TO from env
 
-export const POST = serve
-  .route({ path: 'search' })
-  .paid('0.01') // USDC per call
-  .body(searchSchema) // zod v4 / valibot / arktype / anything Standard-Schema
-  .handler(async ({ body }) => search(body));
+export const { POST, OPTIONS } = asNextRoute(
+  serve
+    .route({ path: 'search' })
+    .paid('0.01') // USDC per call
+    .body(searchSchema) // zod v4 / valibot / arktype / anything Standard-Schema
+    .handler(async ({ body }) => search(body)),
+);
 ```
+
+Next.js dispatches only the methods a `route.ts` exports — you must export
+`OPTIONS` too (`asNextRoute` does it), or browser buyers fail CORS preflight;
+serve's own CORS handling can't run on a request Next never delivers. Fetch
+runtimes that mount one handler (Bun / Deno / workers) don't need this —
+OPTIONS already reaches the same handler.
 
 That route now answers x402 payment challenges, validates inputs, verifies and
 settles payments on Sui, and is sellable as a Service on your Agent ID

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -2,13 +2,19 @@
 //
 // Wrap any API so agents can discover it and pay per call in USDC:
 //
-//   import { createServeFromEnv } from '@t2000/serve';
+//   import { asNextRoute, createServeFromEnv } from '@t2000/serve';
 //   const serve = createServeFromEnv();
-//   export const POST = serve
-//     .route({ path: 'search' })
-//     .paid('0.01')
-//     .body(searchSchema)
-//     .handler(async ({ body }) => search(body));
+//   export const { POST, OPTIONS } = asNextRoute(
+//     serve
+//       .route({ path: 'search' })
+//       .paid('0.01')
+//       .body(searchSchema)
+//       .handler(async ({ body }) => search(body)),
+//   );
+//
+// Next.js dispatches only the methods route.ts EXPORTS — export OPTIONS too
+// (asNextRoute does it) or browser buyers fail CORS preflight; serve's own
+// CORS handling can't run on a request Next never delivers.
 //
 // Sign-then-settle (SUIMPP_X402_SCHEME v0.3): the buyer signs a gasless USDC
 // payment, THIS package verifies + submits it — the seller never holds a
@@ -16,6 +22,7 @@
 // failed handler never charges the buyer.
 
 export { createServe, createServeFromEnv, Serve } from './serve.js';
+export { asNextRoute } from './next.js';
 export { RouteBuilder } from './route.js';
 export { buildLlmsTxt, buildOpenApiDocument } from './discovery.js';
 export { InMemoryDigestStore, UpstashDigestStore } from './store.js';

--- a/packages/serve/src/next.test.ts
+++ b/packages/serve/src/next.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { asNextRoute } from './next.js';
+import { createServe } from './serve.js';
+import { InMemoryDigestStore } from './store.js';
+
+const PAY_TO = '0x' + 'ab'.repeat(32);
+
+describe('asNextRoute', () => {
+  const serve = createServe({
+    payTo: PAY_TO,
+    network: 'mainnet',
+    store: new InMemoryDigestStore(),
+  });
+  const route = serve
+    .route({ path: 'haiku' })
+    .paid('0.01')
+    .handler(() => ({ ok: true }));
+
+  it('OPTIONS export IS the POST export — one handler, both methods', () => {
+    const exports = asNextRoute(route);
+    expect(exports.POST).toBe(route);
+    expect(exports.OPTIONS).toBe(route);
+  });
+
+  it('the OPTIONS export answers a preflight with CORS headers', async () => {
+    const { OPTIONS } = asNextRoute(route);
+    const res = await OPTIONS(
+      new Request('https://seller.example/haiku', { method: 'OPTIONS' }),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('access-control-allow-headers')).toContain(
+      'X-PAYMENT',
+    );
+  });
+});

--- a/packages/serve/src/next.ts
+++ b/packages/serve/src/next.ts
@@ -1,0 +1,23 @@
+import type { BuiltRoute } from './types.js';
+
+/**
+ * Export a built route the way Next.js App Router needs it.
+ *
+ * Next dispatches ONLY the methods a route.ts exports — serve's own CORS
+ * handling (OPTIONS → 204 with the ACAO headers) never runs if the file
+ * exports just `POST`: the browser preflight gets Next's bare 204 with no
+ * CORS headers, and every browser buyer (Passport, the store's Try it)
+ * fails while CLI/server buyers — who never preflight — work fine. Fetch
+ * runtimes mounted via a single handler (`serve.fetch`-style) don't have
+ * this hole; it is a Next export contract, not a serve one.
+ *
+ *   export const { POST, OPTIONS } = asNextRoute(
+ *     serve.route({ path: 'haiku' }).paid('0.01').handler(fn),
+ *   );
+ */
+export function asNextRoute(route: BuiltRoute): {
+  POST: BuiltRoute;
+  OPTIONS: BuiltRoute;
+} {
+  return { POST: route, OPTIONS: route };
+}

--- a/templates/serve-vercel/README.md
+++ b/templates/serve-vercel/README.md
@@ -52,17 +52,23 @@ Your API becomes a Service on your Agent ID, with a store page on
 
 ```ts
 // app/your-route/route.ts
+import { asNextRoute } from '@t2000/serve';
 import { z } from 'zod';
 import { serve } from '../../lib/serve';
 
 const input = z.object({ q: z.string() });
 
-export const POST = serve
-  .route({ path: 'your-route', description: 'What it does' })
-  .paid('0.05')
-  .body(input, z.toJSONSchema(input))
-  .handler(async ({ body }) => yourExistingLogic(body));
+export const { POST, OPTIONS } = asNextRoute(
+  serve
+    .route({ path: 'your-route', description: 'What it does' })
+    .paid('0.05')
+    .body(input, z.toJSONSchema(input))
+    .handler(async ({ body }) => yourExistingLogic(body)),
+);
 ```
+
+Export `OPTIONS` too (`asNextRoute` does it) — Next only dispatches exported
+methods, and without it browser buyers fail CORS preflight.
 
 Then add `import '../your-route/route'` to `app/openapi.json/route.ts` and
 `app/llms.txt/route.ts` so it appears in the discovery docs.

--- a/templates/serve-vercel/app/haiku/route.ts
+++ b/templates/serve-vercel/app/haiku/route.ts
@@ -1,3 +1,4 @@
+import { asNextRoute } from '@t2000/serve';
 import { z } from 'zod';
 import { serve } from '../../lib/serve';
 
@@ -13,12 +14,17 @@ const LINES: Array<(t: string) => string> = [
   () => 'the escrow settles',
 ];
 
-export const POST = serve
-  .route({ path: 'haiku', description: 'A haiku about your topic, paid per call' })
-  .paid('0.01')
-  .body(haikuInput, z.toJSONSchema(haikuInput))
-  .handler(({ body, payer }) => ({
-    haiku: LINES.map((line) => line(body.topic)),
-    topic: body.topic,
-    paidBy: payer,
-  }));
+// asNextRoute exports OPTIONS alongside POST — Next only dispatches the
+// methods a route.ts exports, and without OPTIONS the browser CORS
+// preflight never reaches serve (browser buyers fail; CLI still works).
+export const { POST, OPTIONS } = asNextRoute(
+  serve
+    .route({ path: 'haiku', description: 'A haiku about your topic, paid per call' })
+    .paid('0.01')
+    .body(haikuInput, z.toJSONSchema(haikuInput))
+    .handler(({ body, payer }) => ({
+      haiku: LINES.map((line) => line(body.topic)),
+      topic: body.topic,
+      paidBy: payer,
+    })),
+);


### PR DESCRIPTION
## Root cause
serve handles \`OPTIONS → withCors(204)\` inside the route handler and sets ACAO on paid responses — but **Next.js App Router only dispatches methods a route.ts exports**. Every example (template, README, docs) exported only \`POST\`, so browser preflight never reached serve: Next answered a bare 204 with no CORS headers. CLI buyers never preflight, so \`t2 pay\` worked while browser Passport / store **Try it** failed with a false "no CORS" error. Serve's unit tests call the handler directly with OPTIONS, so they stayed green past the export hole.

## Fix (SSOT, not one-off seller apps)
- **\`asNextRoute(route)\`** — new tiny helper returning \`{ POST: route, OPTIONS: route }\`; exported from the package with the why documented at the definition and in the index header example.
- **templates/serve-vercel/app/haiku/route.ts** → \`export const { POST, OPTIONS } = asNextRoute(…)\` — clone-and-ship is now correct.
- **Docs sweep**: serve README, template README, and every Next example in \`apps/docs/sell-to-agents\` show the helper, each with the one-sentence rule: *Next dispatches only exported methods — export OPTIONS too; serve's CORS alone isn't enough when only POST is exported.* Fetch runtimes (Bun/Deno/workers) mounting one handler are explicitly called out as fine.
- **Tests**: \`next.test.ts\` — the OPTIONS export IS the POST function, and an OPTIONS request through it answers 204 with ACAO \`*\` + \`X-PAYMENT\` in allow-headers (the preflight contract, exercised through the export).

Sweep: no \`export const POST\` without OPTIONS/asNextRoute anywhere in templates/docs/README. serve 32 tests + typecheck + lint + build green.

Out of scope per prompt: funkii-ai (already has OPTIONS live), sdk/mppx, Activity B2, release (founder runs it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)