### PR TITLE
✨ feat(serve,sdk): fire-and-forget activity report after x402 settle

### DIFF
--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -15,6 +15,12 @@ export { ZkLoginSigner, type ZkLoginProof } from './wallet/zkLoginSigner.js';
 // `T2000.pay()` delegates to. Pair with `executeTx` for advanced callers.
 // (`PayOptions` / `PayResult` are exported from the types block below.)
 export { payWithMpp, preflightPay } from './wallet/pay.js';
+export {
+  DEFAULT_ACTIVITY_REPORT_URL,
+  reportX402Activity,
+  type ActivityReportConfig,
+  type X402ActivityPayload,
+} from './wallet/activity-report.js';
 export { executeTx } from './wallet/executeTx.js';
 
 // Error handling

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,6 +4,12 @@ export { KeypairSigner } from './wallet/keypairSigner.js';
 export { ZkLoginSigner, type ZkLoginProof } from './wallet/zkLoginSigner.js';
 export { payWithMpp, preflightPay } from './wallet/pay.js';
 export {
+  DEFAULT_ACTIVITY_REPORT_URL,
+  reportX402Activity,
+  type ActivityReportConfig,
+  type X402ActivityPayload,
+} from './wallet/activity-report.js';
+export {
   chatCompletion,
   chatCompletionStream,
   listModels,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -195,6 +195,14 @@ export interface PayOptions {
   maxPrice?: number;
   /** Bypass the spending-limit gate for this call (caller owns consent). */
   force?: boolean;
+  /**
+   * Attributed x402.paid activity reporting (B2) — after a successful pay,
+   * the settlement digest is fire-and-forgotten to the t2000.ai report
+   * endpoint (chain-verified server-side; never affects the payment).
+   * Default ON with source 'pay'; hosts override the source ('connect',
+   * 'try-it') or URL, or pass `false` to opt out.
+   */
+  activityReport?: { url?: string; source?: 'pay' | 'try-it' | 'connect' } | false;
 }
 
 export interface PayResult {

--- a/packages/sdk/src/wallet/activity-report.ts
+++ b/packages/sdk/src/wallet/activity-report.ts
@@ -1,0 +1,52 @@
+// Attributed x402.paid activity reporting (SPEC_T2_ACTIVITY_X402 §7, B2).
+// After a successful pay, the buyer side fire-and-forgets the settlement
+// digest to the t2000.ai report endpoint, which CHAIN-VERIFIES the digest
+// before recording anything — this call carries claims, not trust, and a
+// dead report never affects the payment or the caller. Browser-safe: no
+// blind process.env read (the env override only applies where process
+// exists); hosts can pass an explicit URL or disable with `false`.
+
+export const DEFAULT_ACTIVITY_REPORT_URL = 'https://t2000.ai/api/activity/x402';
+
+export type ActivityReportSource = 'pay' | 'try-it' | 'connect';
+
+/** Per-call reporting config on PayOptions: override the URL/source, or
+ *  `false` to opt out entirely. */
+export type ActivityReportConfig =
+  | { url?: string; source?: ActivityReportSource }
+  | false;
+
+export interface X402ActivityPayload {
+  digest: string;
+  payTo: string;
+  payer?: string;
+  amountMicroUsdc: number;
+  network: string;
+  route?: string;
+  source: ActivityReportSource;
+}
+
+/** Resolve the report URL: explicit override → T2000_ACTIVITY_REPORT_URL
+ *  (Node-like runtimes only) → the production default. */
+export function resolveActivityReportUrl(override?: string): string {
+  if (override) return override;
+  const env =
+    typeof process !== 'undefined' && process.env
+      ? process.env.T2000_ACTIVITY_REPORT_URL?.trim()
+      : undefined;
+  return env && env.length > 0 ? env : DEFAULT_ACTIVITY_REPORT_URL;
+}
+
+/** Fire-and-forget report — short timeout, every failure swallowed. */
+export function reportX402Activity(payload: X402ActivityPayload, url?: string): void {
+  try {
+    void fetch(resolveActivityReportUrl(url), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(1500),
+    }).catch(() => undefined);
+  } catch {
+    // even a sync throw must never reach the caller
+  }
+}

--- a/packages/sdk/src/wallet/pay.test.ts
+++ b/packages/sdk/src/wallet/pay.test.ts
@@ -483,6 +483,83 @@ describe('payWithMpp — header-only 402 (dialect removed)', () => {
   });
 });
 
+describe('payWithMpp — B2 activity report (fire-and-forget)', () => {
+  const reportCalls = () =>
+    fetchMock.mock.calls.filter((call: unknown[]) => String(call[0]).includes('/api/activity/x402'));
+
+  it('reports source=pay with the settlement digest after a successful x402 pay', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ status: 402, body: x402Accepts('20000') }))
+      .mockResolvedValueOnce(
+        mockResponse({ status: 200, body: { ok: true }, headers: { 'X-PAYMENT-RESPONSE': settleHeaderValue('0xabc') } }),
+      );
+
+    const result = await payWithMpp({
+      signer: makeSigner(),
+      client: makeClient({ total: '1000000', coins: [] }),
+      options: { url: 'https://mpp.t2000.ai/x', method: 'POST', body: '{}', maxPrice: 0.05 },
+    });
+
+    expect(result.paid).toBe(true);
+    const calls = reportCalls();
+    expect(calls).toHaveLength(1);
+    const body = JSON.parse(String((calls[0][1] as RequestInit).body)) as Record<string, unknown>;
+    expect(body.digest).toBe('0xabc');
+    expect(body.payTo).toBe('0xtreasury');
+    expect(body.payer).toBe('0xsender');
+    expect(body.amountMicroUsdc).toBe(20_000);
+    expect(body.source).toBe('pay');
+  });
+
+  it('activityReport: false opts out; a custom source/url is honored', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ status: 402, body: x402Accepts('20000') }))
+      .mockResolvedValueOnce(
+        mockResponse({ status: 200, body: { ok: true }, headers: { 'X-PAYMENT-RESPONSE': settleHeaderValue() } }),
+      );
+    await payWithMpp({
+      signer: makeSigner(),
+      client: makeClient({ total: '1000000', coins: [] }),
+      options: { url: 'https://mpp.t2000.ai/x', maxPrice: 0.05, activityReport: false },
+    });
+    expect(reportCalls()).toHaveLength(0);
+
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ status: 402, body: x402Accepts('20000') }))
+      .mockResolvedValueOnce(
+        mockResponse({ status: 200, body: { ok: true }, headers: { 'X-PAYMENT-RESPONSE': settleHeaderValue() } }),
+      );
+    await payWithMpp({
+      signer: makeSigner(),
+      client: makeClient({ total: '1000000', coins: [] }),
+      options: {
+        url: 'https://mpp.t2000.ai/x',
+        maxPrice: 0.05,
+        activityReport: { source: 'connect', url: 'https://example.test/api/activity/x402' },
+      },
+    });
+    const calls = reportCalls();
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0][0])).toBe('https://example.test/api/activity/x402');
+    const body = JSON.parse(String((calls[0][1] as RequestInit).body)) as Record<string, unknown>;
+    expect(body.source).toBe('connect');
+  });
+
+  it('an unsettled pay (no receipt) reports nothing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ status: 402, body: x402Accepts('20000') }))
+      .mockResolvedValueOnce(mockResponse({ status: 402, body: { error: 'settle failed' } }));
+
+    const result = await payWithMpp({
+      signer: makeSigner(),
+      client: makeClient({ total: '1000000', coins: [] }),
+      options: { url: 'https://mpp.t2000.ai/x', maxPrice: 0.05 },
+    });
+    expect(result.paid).toBe(false);
+    expect(reportCalls()).toHaveLength(0);
+  });
+});
+
 describe('payWithMpp — free / cached', () => {
   it('reports not-paid when the endpoint serves without a 402', async () => {
     fetchMock.mockResolvedValueOnce(mockResponse({ status: 200, body: { cached: true } }));

--- a/packages/sdk/src/wallet/pay.ts
+++ b/packages/sdk/src/wallet/pay.ts
@@ -4,6 +4,7 @@ import type { X402Requirements } from '@t2000/sui-x402';
 import type { TransactionSigner } from '../signer.js';
 import type { PayOptions, PayResult } from '../types.js';
 import { T2000Error } from '../errors.js';
+import { reportX402Activity } from './activity-report.js';
 import { executeTx } from './executeTx.js';
 import {
   type PreflightResult,
@@ -287,6 +288,25 @@ async function payViaX402(args: {
 
   const result = await finalize(res, { paid });
   if (!paid) return { ...result, dialect: 'x402' };
+
+  // B2: attributed activity report — settled payments only, fire-and-forget
+  // (the endpoint chain-verifies the digest; a dead report changes nothing).
+  if (digest && options.activityReport !== false) {
+    const report = options.activityReport || {};
+    reportX402Activity(
+      {
+        digest,
+        payTo: requirements.payTo,
+        payer: signer.getAddress(),
+        amountMicroUsdc: Number(amountRaw),
+        network: requirements.network,
+        route: options.url,
+        source: report.source ?? 'pay',
+      },
+      report.url,
+    );
+  }
+
   return {
     ...result,
     dialect: 'x402',

--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -51,6 +51,7 @@ npm install @t2000/serve
 |---|---|---|
 | `T2000_PAY_TO` | yes | Your Sui address — payments settle here (`t2 address` prints it) |
 | `T2000_NETWORK` | no | `mainnet` (default) or `testnet` |
+| `T2000_ACTIVITY_REPORT_URL` | no | Fire-and-forget `x402.paid` reports after each successful settle — set `https://t2000.ai/api/activity/x402` to appear on the [t2000.ai](https://t2000.ai/activity) activity tape. Chain-verified server-side; never affects buyer responses. Unset = no report. |
 | `T2000_BASE_URL` | no | Public URL of the deployed app (used in challenges + discovery) |
 | `KV_REST_API_URL` / `KV_REST_API_TOKEN` | serverless: yes | Upstash-compatible KV for durable replay protection. Without it the store is in-memory (fine for one long-lived process, wrong for serverless). |
 

--- a/packages/serve/src/route.test.ts
+++ b/packages/serve/src/route.test.ts
@@ -274,6 +274,73 @@ describe('paid request lifecycle (sign-then-settle, handler-then-settle)', () =>
   });
 });
 
+describe('B2 activity report (fire-and-forget)', () => {
+  function makeReportingRoute(activityReportUrl?: string) {
+    const serve = createServe({
+      payTo: PAY_TO,
+      baseUrl: 'https://seller.example',
+      activityReportUrl,
+    });
+    return serve
+      .route({ path: 'search' })
+      .paid('0.01')
+      .body(querySchema)
+      .handler(() => ({ ok: true }));
+  }
+
+  it('reports after a successful settle — digest, payTo, amount, source=serve', async () => {
+    const reportFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', reportFetch);
+    const route = makeReportingRoute('https://t2000.ai/api/activity/x402');
+    const requirements = await get402Requirements(route);
+    const { header } = await signPayment(requirements);
+
+    const res = await route(
+      post('https://seller.example/search', { query: 'sui' }, { [X402_PAYMENT_HEADER]: header }),
+    );
+    expect(res.status).toBe(200);
+    expect(reportFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = reportFetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://t2000.ai/api/activity/x402');
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.digest).toBe('MOCKDIGEST123'); // settleMock's transaction
+    expect(body.payTo).toBe(PAY_TO);
+    expect(body.amountMicroUsdc).toBe(10_000); // 0.01 USDC
+    expect(body.network).toBe('sui:mainnet');
+    expect(body.source).toBe('serve');
+  });
+
+  it('a dead report NEVER changes the buyer 200 (rejects are swallowed)', async () => {
+    const reportFetch = vi.fn(async () => {
+      throw new Error('report endpoint down');
+    });
+    vi.stubGlobal('fetch', reportFetch);
+    const route = makeReportingRoute('https://t2000.ai/api/activity/x402');
+    const requirements = await get402Requirements(route);
+    const { header } = await signPayment(requirements);
+
+    const res = await route(
+      post('https://seller.example/search', { query: 'sui' }, { [X402_PAYMENT_HEADER]: header }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-PAYMENT-RESPONSE')).toBeTruthy();
+  });
+
+  it('no activityReportUrl → no report call', async () => {
+    const reportFetch = vi.fn();
+    vi.stubGlobal('fetch', reportFetch);
+    const route = makeReportingRoute(undefined);
+    const requirements = await get402Requirements(route);
+    const { header } = await signPayment(requirements);
+
+    const res = await route(
+      post('https://seller.example/search', { query: 'sui' }, { [X402_PAYMENT_HEADER]: header }),
+    );
+    expect(res.status).toBe(200);
+    expect(reportFetch).not.toHaveBeenCalled();
+  });
+});
+
 describe('unprotected routes', () => {
   it('serves without any payment machinery', async () => {
     const serve = createServe({ payTo: PAY_TO });

--- a/packages/serve/src/route.ts
+++ b/packages/serve/src/route.ts
@@ -49,6 +49,8 @@ export interface RouteRuntime {
   store: DigestStore;
   baseUrl?: string;
   rpcUrl?: string;
+  /** B2 attributed reporting — unset = no report (see ServeConfig). */
+  activityReportUrl?: string;
 }
 
 export interface RouteOptions {
@@ -345,6 +347,16 @@ export class RouteBuilder<TBody = undefined> {
         // Digest-once already holds; challenge-once is defense in depth.
       }
 
+      // B2: attributed activity report — AFTER a successful settle only,
+      // strictly fire-and-forget (a dead report can never change the
+      // buyer's 200 or the settle; SPEC_T2_ACTIVITY_X402 §7 lock 6).
+      reportActivity(runtime, {
+        digest: settle.transaction,
+        payer: settle.payer,
+        priceUsdc,
+        resource,
+      });
+
       const headers = new Headers(served.headers);
       headers.set(X402_PAYMENT_RESPONSE_HEADER, encodeX402Response(settle));
       return new Response(served.body, { status: served.status, headers });
@@ -360,6 +372,35 @@ export class RouteBuilder<TBody = undefined> {
     };
     this.register(route);
     return route;
+  }
+}
+
+/** Fire-and-forget x402.paid report (B2). Never awaited into the response
+ *  path; short timeout; every failure swallowed. The report endpoint
+ *  chain-verifies the digest, so this carries claims, not trust. */
+function reportActivity(
+  runtime: RouteRuntime,
+  args: { digest: string; payer: string; priceUsdc: string; resource: string },
+): void {
+  const url = runtime.activityReportUrl;
+  if (!url) return;
+  try {
+    void fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        digest: args.digest,
+        payTo: runtime.payTo,
+        payer: args.payer,
+        amountMicroUsdc: Math.round(Number(args.priceUsdc) * 1_000_000),
+        network: `sui:${runtime.network}`,
+        route: args.resource,
+        source: 'serve',
+      }),
+      signal: AbortSignal.timeout(1500),
+    }).catch(() => undefined);
+  } catch {
+    // even a sync throw (bad URL) must not touch the buyer's response
   }
 }
 

--- a/packages/serve/src/serve.ts
+++ b/packages/serve/src/serve.ts
@@ -36,6 +36,7 @@ export class Serve {
       store: config.store ?? new InMemoryDigestStore(),
       baseUrl: this.baseUrl,
       rpcUrl: config.rpcUrl,
+      activityReportUrl: config.activityReportUrl,
     };
   }
 
@@ -132,6 +133,11 @@ export function createServe(config: ServeConfig): Serve {
  *   T2000_BASE_URL    optional — public URL of the deployed app
  *   T2000_NAME        optional — service name for discovery docs
  *   T2000_DESCRIPTION optional — one-liner for discovery docs
+ *   T2000_ACTIVITY_REPORT_URL
+ *                     optional — fire-and-forget x402.paid reports after each
+ *                     successful settle; set https://t2000.ai/api/activity/x402
+ *                     to appear on the t2000.ai activity tape (chain-verified
+ *                     server-side, never affects buyer responses)
  *   KV_REST_API_URL / KV_REST_API_TOKEN
  *                     optional — enables the durable Upstash replay store
  *                     (REQUIRED in serverless production; without it replay
@@ -175,6 +181,7 @@ export function createServeFromEnv(env: Record<string, string | undefined> = pro
     baseUrl: read('T2000_BASE_URL'),
     name: read('T2000_NAME'),
     description: read('T2000_DESCRIPTION'),
+    activityReportUrl: read('T2000_ACTIVITY_REPORT_URL'),
     store,
   });
 }

--- a/packages/serve/src/types.ts
+++ b/packages/serve/src/types.ts
@@ -25,10 +25,17 @@ export interface ServeConfig {
   name?: string;
   /** One-line description (discovery docs, slice 2). */
   description?: string;
-  // `report` was REMOVED 2026-08-01 (SPEC_T2_CLEANUP_USDC_ONLY): it posted
-  // settled digests to the hosted mpp.t2000.ai activity feed, and that
-  // gateway is gone. Sellers own their endpoints; there is no central feed
-  // to notify. Receipts live on Sui.
+  /**
+   * Opt-in attributed activity reporting (SPEC_T2_ACTIVITY_X402 B2). After a
+   * SUCCESSFUL settle, serve fire-and-forgets the settlement digest to this
+   * URL (`https://t2000.ai/api/activity/x402` — the endpoint chain-verifies
+   * before anything is recorded). Strictly best-effort: a dead report can
+   * never change the buyer's response. Unset = no report.
+   *
+   * (The old `report` option — removed 2026-08-01 — posted to the retired
+   * mpp gateway; this posts to the receipt-backed t2000.ai ledger instead.)
+   */
+  activityReportUrl?: string;
   /** Override the Sui fullnode gRPC URL (default: mainnet/testnet fullnode). */
   rpcUrl?: string;
 }


### PR DESCRIPTION
## What (SPEC_T2_ACTIVITY_X402 §7, B2 — t2000 half; companion: audric PR #161)
Buyer- and seller-side attributed \`x402.paid\` reporting to \`POST https://t2000.ai/api/activity/x402\` (the console endpoint chain-verifies every digest before recording — reports carry claims, not trust).

## @t2000/serve
- \`ServeConfig.activityReportUrl\` (opt-in; unset = no report) + \`T2000_ACTIVITY_REPORT_URL\` in \`createServeFromEnv\`, documented in the env-var doc comment and README env table
- After a **successful settle only** (step 6, alongside the receipt header): fire-and-forget POST {digest, payTo, payer, amountMicroUsdc, network, route, source:"serve"} — \`void fetch\` with a 1.5s \`AbortSignal.timeout\`, every failure (including sync throws on a bad URL) swallowed — **the buyer's 200/settle can never change** (lock 6)
- 3 new unit tests: report body contract on settle · dead report still 200 with receipt · no URL → no call (35 total green)

## @t2000/sdk
- New \`wallet/activity-report.ts\`: \`reportX402Activity(payload, url?)\` + \`DEFAULT_ACTIVITY_REPORT_URL\` + \`resolveActivityReportUrl\` — **browser-safe** (the \`T2000_ACTIVITY_REPORT_URL\` env override only applies where \`process\` exists; never a blind read), exported from index + browser entries
- \`payWithMpp\`: after a **settled** x402 pay (digest present), fire-and-forget report — default ON with \`source: "pay"\`; \`PayOptions.activityReport\` lets hosts pass \`{source: "connect" | "try-it", url?}\` or \`false\` to opt out. Unsettled pays report nothing.
- 3 new unit tests: default source=pay body contract · opt-out + custom source/url honored · unsettled → no report (560 total green)

Both packages typecheck, lint, build green. No header-dialect anything; wire untouched.

## After merge
Founder: run the release train (**patch** proposed → v10.21.1) so sellers/CLI pick it up; set \`T2000_ACTIVITY_REPORT_URL=https://t2000.ai/api/activity/x402\` on the dogfood seller deploy (ops-only, doesn't block this merge). Dogfood: \`t2 pay\` (or store Try-it) against a live serve seller → row on /activity + the seller's agent page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)