### PR TITLE
✨ feat(serve): default activity report URL in createServeFromEnv

### DIFF
--- a/packages/serve/README.md
+++ b/packages/serve/README.md
@@ -51,7 +51,7 @@ npm install @t2000/serve
 |---|---|---|
 | `T2000_PAY_TO` | yes | Your Sui address — payments settle here (`t2 address` prints it) |
 | `T2000_NETWORK` | no | `mainnet` (default) or `testnet` |
-| `T2000_ACTIVITY_REPORT_URL` | no | Fire-and-forget `x402.paid` reports after each successful settle — set `https://t2000.ai/api/activity/x402` to appear on the [t2000.ai](https://t2000.ai/activity) activity tape. Chain-verified server-side; never affects buyer responses. Unset = no report. |
+| `T2000_ACTIVITY_REPORT_URL` | no | Fire-and-forget `x402.paid` reports after each successful settle (chain-verified server-side; never affects buyer responses). **Default-on for `createServeFromEnv`**: unset → `https://t2000.ai/api/activity/x402`, so your sold routes appear on the [t2000.ai](https://t2000.ai/activity) activity tape. Opt out with `false` \| `0` \| `off` \| `none`, or set a custom URL. Code-constructed `new Serve({...})` stays silent unless you pass `activityReportUrl`. |
 | `T2000_BASE_URL` | no | Public URL of the deployed app (used in challenges + discovery) |
 | `KV_REST_API_URL` / `KV_REST_API_TOKEN` | serverless: yes | Upstash-compatible KV for durable replay protection. Without it the store is in-memory (fine for one long-lived process, wrong for serverless). |
 

--- a/packages/serve/src/index.ts
+++ b/packages/serve/src/index.ts
@@ -21,7 +21,12 @@
 // private key and never pays gas. The handler runs BEFORE settlement, so a
 // failed handler never charges the buyer.
 
-export { createServe, createServeFromEnv, Serve } from './serve.js';
+export {
+  createServe,
+  createServeFromEnv,
+  DEFAULT_ACTIVITY_REPORT_URL,
+  Serve,
+} from './serve.js';
 export { asNextRoute } from './next.js';
 export { RouteBuilder } from './route.js';
 export { buildLlmsTxt, buildOpenApiDocument } from './discovery.js';

--- a/packages/serve/src/serve-env.test.ts
+++ b/packages/serve/src/serve-env.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createServe, createServeFromEnv, DEFAULT_ACTIVITY_REPORT_URL } from './serve.js';
+
+const PAY_TO = '0x' + 'ab'.repeat(32);
+
+// B2 default-on (createServeFromEnv ONLY): new template/env sellers appear
+// on the t2000.ai activity tape without a hidden env knack; explicit code
+// construction stays silent unless opted in.
+describe('createServeFromEnv — activity report URL resolution', () => {
+  it('defaults to the t2000.ai report URL when the env key is missing', () => {
+    const serve = createServeFromEnv({ T2000_PAY_TO: PAY_TO });
+    expect(serve.activityReportUrl).toBe(DEFAULT_ACTIVITY_REPORT_URL);
+    expect(DEFAULT_ACTIVITY_REPORT_URL).toBe('https://t2000.ai/api/activity/x402');
+  });
+
+  it('empty string (Vercel empty-env class) re-defaults, same as unset', () => {
+    const serve = createServeFromEnv({
+      T2000_PAY_TO: PAY_TO,
+      T2000_ACTIVITY_REPORT_URL: '  ',
+    });
+    expect(serve.activityReportUrl).toBe(DEFAULT_ACTIVITY_REPORT_URL);
+  });
+
+  it.each(['false', 'off', '0', 'none', 'FALSE', 'Off'])(
+    'opt-out token %s → no report',
+    (token) => {
+      const serve = createServeFromEnv({
+        T2000_PAY_TO: PAY_TO,
+        T2000_ACTIVITY_REPORT_URL: token,
+      });
+      expect(serve.activityReportUrl).toBeUndefined();
+    },
+  );
+
+  it('a custom URL is used verbatim', () => {
+    const serve = createServeFromEnv({
+      T2000_PAY_TO: PAY_TO,
+      T2000_ACTIVITY_REPORT_URL: 'https://example.test/report',
+    });
+    expect(serve.activityReportUrl).toBe('https://example.test/report');
+  });
+
+  it('code-constructed Serve without activityReportUrl stays silent', () => {
+    const serve = createServe({ payTo: PAY_TO });
+    expect(serve.activityReportUrl).toBeUndefined();
+  });
+});

--- a/packages/serve/src/serve.ts
+++ b/packages/serve/src/serve.ts
@@ -5,6 +5,13 @@ import { RouteBuilder, type RouteOptions, type RouteRuntime } from './route.js';
 import { UpstashDigestStore } from './store.js';
 import type { BuiltRoute, ServeConfig, ServeNetwork } from './types.js';
 
+/** The t2000.ai attributed-activity report endpoint — ONE canonical string
+ *  (matches the sdk's DEFAULT_ACTIVITY_REPORT_URL; tests assert equality). */
+export const DEFAULT_ACTIVITY_REPORT_URL = 'https://t2000.ai/api/activity/x402';
+
+/** Explicit opt-out tokens for T2000_ACTIVITY_REPORT_URL (case-insensitive). */
+const REPORT_OPT_OUT = new Set(['false', '0', 'off', 'none']);
+
 export class Serve {
   private readonly runtime: RouteRuntime;
   /** Every route built through this instance, keyed by path (discovery). */
@@ -15,6 +22,8 @@ export class Serve {
   readonly name?: string;
   readonly description?: string;
   readonly baseUrl?: string;
+  /** Where settled payments are reported (B2) — undefined = no report. */
+  readonly activityReportUrl?: string;
 
   constructor(config: ServeConfig) {
     if (!config.payTo || !isValidSuiAddress(config.payTo)) {
@@ -27,6 +36,7 @@ export class Serve {
     this.name = config.name;
     this.description = config.description;
     this.baseUrl = config.baseUrl?.replace(/\/$/, '');
+    this.activityReportUrl = config.activityReportUrl;
 
     const currency: Currency = this.network === 'testnet' ? USDC_TESTNET : USDC;
     this.runtime = {
@@ -36,7 +46,7 @@ export class Serve {
       store: config.store ?? new InMemoryDigestStore(),
       baseUrl: this.baseUrl,
       rpcUrl: config.rpcUrl,
-      activityReportUrl: config.activityReportUrl,
+      activityReportUrl: this.activityReportUrl,
     };
   }
 
@@ -134,10 +144,15 @@ export function createServe(config: ServeConfig): Serve {
  *   T2000_NAME        optional — service name for discovery docs
  *   T2000_DESCRIPTION optional — one-liner for discovery docs
  *   T2000_ACTIVITY_REPORT_URL
- *                     optional — fire-and-forget x402.paid reports after each
- *                     successful settle; set https://t2000.ai/api/activity/x402
- *                     to appear on the t2000.ai activity tape (chain-verified
- *                     server-side, never affects buyer responses)
+ *                     optional — where settled payments are reported
+ *                     (fire-and-forget x402.paid after each successful settle;
+ *                     chain-verified server-side, never affects buyer
+ *                     responses). DEFAULT-ON for FromEnv: unset →
+ *                     https://t2000.ai/api/activity/x402 so new sellers appear
+ *                     on the t2000.ai activity tape. Opt out with
+ *                     `false` | `0` | `off` | `none` (case-insensitive), or
+ *                     set a custom URL. (`new Serve({...})` without
+ *                     activityReportUrl stays silent — only FromEnv defaults.)
  *   KV_REST_API_URL / KV_REST_API_TOKEN
  *                     optional — enables the durable Upstash replay store
  *                     (REQUIRED in serverless production; without it replay
@@ -181,7 +196,16 @@ export function createServeFromEnv(env: Record<string, string | undefined> = pro
     baseUrl: read('T2000_BASE_URL'),
     name: read('T2000_NAME'),
     description: read('T2000_DESCRIPTION'),
-    activityReportUrl: read('T2000_ACTIVITY_REPORT_URL'),
+    activityReportUrl: resolveReportUrlFromEnv(read('T2000_ACTIVITY_REPORT_URL')),
     store,
   });
+}
+
+/** FromEnv activity-report resolution (B2 default-on): unset/empty →
+ *  the t2000.ai default; an explicit opt-out token → undefined (silent);
+ *  anything else is the seller's custom report URL. */
+function resolveReportUrlFromEnv(raw: string | undefined): string | undefined {
+  if (raw === undefined) return DEFAULT_ACTIVITY_REPORT_URL;
+  if (REPORT_OPT_OUT.has(raw.toLowerCase())) return undefined;
+  return raw;
 }

--- a/templates/serve-vercel/README.md
+++ b/templates/serve-vercel/README.md
@@ -24,6 +24,10 @@ demo handler for your real API and you're selling.
 3. Production on Vercel: add **Upstash for Redis** from the Storage tab
    (injects `KV_REST_API_URL`/`KV_REST_API_TOKEN` — durable replay protection).
 
+Settled calls show on [t2000.ai/activity](https://t2000.ai/activity) by
+default (chain-verified reports, never affecting buyer responses) — opt out
+with `T2000_ACTIVITY_REPORT_URL=false`.
+
 ## Test your live endpoint
 
 ```bash


### PR DESCRIPTION
## What (closes the clone-Deploy-button → invisible gap)
SDK/CLI already default-report; serve required a hidden env knack. Now **\`createServeFromEnv\` defaults \`T2000_ACTIVITY_REPORT_URL\` on** — new template/env sellers appear on [t2000.ai/activity](https://t2000.ai/activity) without knowing the var exists.

## Resolution (FromEnv only)
- **Unset / empty** (Vercel empty-env class) → \`DEFAULT_ACTIVITY_REPORT_URL\` = \`https://t2000.ai/api/activity/x402\` (exported; a test asserts equality with the one canonical string — no fork)
- **Opt-out tokens** \`false\` | \`0\` | \`off\` | \`none\` (case-insensitive) → no report
- **Any other value** → used verbatim as a custom URL
- **\`new Serve({payTo})\` stays silent** — code construction never defaults on (tests, air-gapped paths); \`Serve\` exposes a readonly \`activityReportUrl\` for inspection

Reporting semantics untouched: fire-and-forget after successful settle only, 1.5s timeout, chain-verified server-side, buyer 200 untouchable.

## Docs + template
- serve README env row + \`createServeFromEnv\` JSDoc: default-on + opt-out tokens
- \`templates/serve-vercel/.env.example\` — NEW (template had none): all four env groups incl. the report var with opt-out comment
- Template README: one line under Deploy — sold routes show on the tape by default, how to opt out

## Tests
New \`serve-env.test.ts\`: default when unset · empty re-defaults · all four opt-out tokens (+case variants) · custom URL verbatim · code-constructed Serve silent. 45 serve tests green; typecheck/lint/build clean.

## After merge
Founder: release **patch** (10.21.2) so template consumers pick it up. No funkii redeploy needed (env already set there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)