### PR TITLE
📝 docs: P1 purge — marketing copy teaches only the live product

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,11 +51,11 @@ if you have one.
   boundary is the filesystem ACL; see `ARCHITECTURE.md § Wallet + keys`.)
 - **Default-on spending limits** — per-tx + daily caps enforced inside the SDK,
   gating CLI **and** MCP writes.
-- **Payment verification** — HMAC-bound stateless challenges + on-chain USDC
-  verification; automated refund on upstream failure (no-charge-on-failure).
-- **Confidential inference** — fail-closed GPU-TEE attestation, TEE-signed
-  receipts, Sui-anchored hashes, client-side DCAP verification (`t2 verify`).
-- **Upstream API keys** — gateway env vars only; never exposed to callers.
+- **Payment verification** — challenge-bound signed payments, structurally
+  verified before settlement; the handler runs BEFORE money moves, so a
+  failing seller never charges the buyer (no-charge-on-failure).
+- **Confidential inference** — an Audric product (`api.audric.ai`):
+  fail-closed GPU-TEE attestation, TEE-signed receipts, Sui-anchored hashes.
 - **Automated scanning** — CodeQL + dependency audit in GitHub Actions.
 
 ## Audit Status

--- a/apps/web/app/data/t2k.ts
+++ b/apps/web/app/data/t2k.ts
@@ -38,9 +38,9 @@ export const T2K = {
     {
       n: "iii",
       name: "Capital Formation",
-      status: { label: "NEXT", tone: "next" },
-      desc: "Tokenize your agent — one-time, bound to its Agent ID, liquidity locked on-chain. Fees fund the agent's own wallet, backed by real receipts.",
-      chips: ["Tokenize", "Locked LP", "Fees → agent"],
+      status: { label: "HORIZON", tone: "horizon" },
+      desc: "Agents becoming financeable — ownership and liquidity against honest activity: settled USDC and Sui digests, never promised agent GDP. Shape defined later, deliberately.",
+      chips: ["Ownership", "Liquidity", "Receipts"],
       links: [],
     },
     {
@@ -55,8 +55,8 @@ export const T2K = {
       n: "v",
       name: "Law & Governance",
       status: { label: "SEEDED", tone: "seeded" },
-      desc: "Trust you can check: receipts on Sui, verifiable confidential inference, disputes bounded at creation. No platform custody, no platform judge.",
-      chips: ["Receipts", "TEE verify", "No custody"],
+      desc: "Trust you can check: receipts on Sui, disputes bounded at creation, verifiable confidential inference via Audric. No platform custody, no platform judge.",
+      chips: ["Receipts", "Bounded disputes", "No custody"],
       links: [],
     },
   ],
@@ -81,48 +81,50 @@ export interface StoryItem {
   total: string;
 }
 
-// Chained-prompt stories (payments page). x402-only — the NAVI/DeFi era
-// stories were retired with the product (S.444).
+// Chained-prompt stories (payments page). x402 + escrow — generic
+// marketplace verbs only: named third-party providers were the purged
+// proxy-mall catalog (2026-08-01), and catalog claims must come from the
+// live services board, never from copy.
 export const T2K_STORIES: StoryItem[] = [
   {
     n: "01",
     tag: "x402 · RESEARCH",
     title: "Morning market brief",
     prompt:
-      "Use t2 services. Pull SUI, ETH, BTC prices from CoinGecko, top 5 crypto headlines from NewsAPI, write me a 200-word brief.",
-    steps: ["coingecko · newsapi · anthropic"],
+      "Use t2 services. Find a research agent on the board and pay its brief endpoint for a 200-word morning market read on SUI.",
+    steps: ["t2 services · t2 pay"],
     done: "./brief.md",
-    total: "~$0.06 · 3 calls · 0 taps",
+    total: "one call · USDC per the 402 · 0 taps",
   },
   {
     n: "02",
-    tag: "x402 · CREATIVE",
-    title: "Concept → demo asset",
+    tag: "ESCROW · HIRE",
+    title: "Deliverable with a deadline",
     prompt:
-      "Use t2 services. Generate a hero image via fal.ai, write a 60-sec elevator pitch via Claude, synthesize it as MP3 via ElevenLabs.",
-    steps: ["fal.ai · anthropic · elevenlabs"],
-    done: "./hero.png · ./pitch.md · ./pitch.mp3",
-    total: "~$0.18 · 3 calls · 0 taps · ~18s",
+      "Hire an agent's listed service — USDC locks in escrow at hire, releases when it delivers, refunds if the deadline lapses.",
+    steps: ["t2 job hire · deliver · release"],
+    done: "Delivery on-chain · receipt-bound review.",
+    total: "escrowed · 5% at settlement",
   },
   {
     n: "03",
-    tag: "x402 · REACH",
-    title: "Mail mum a birthday card",
+    tag: "ESCROW · OPEN",
+    title: "Post it to the board",
     prompt:
-      "Use t2 services. It's my mum's birthday next Tuesday. Write her a warm note from me, render it as a card front via fal.ai, and put it in the mail to 123 Lochiel Road via Lob.",
-    steps: ["anthropic · fal.ai · lob"],
-    done: "Card queued · USPS delivery Tuesday.",
-    total: "~$2.08 · 3 calls · 0 taps",
+      "Post an Open job with a budget and deadline — the first active agent to claim it starts the clock; unclaimed money comes back fee-free.",
+    steps: ["t2 job open · claim · settle"],
+    done: "Claimed and delivered · escrow settled.",
+    total: "escrowed at post · refund on no claim",
   },
   {
     n: "04",
-    tag: "x402 · CODE",
-    title: "Write and run",
+    tag: "x402 · MACHINE",
+    title: "Agent pays agent",
     prompt:
-      "Use t2 services. Write a self-contained Python script that computes a 30-day EMA on sample SUI closes, then run it via Judge0 to verify.",
-    steps: ["anthropic · judge0"],
-    done: "Script verified · output matches expected.",
-    total: "~$0.04 · 2 calls · 0 taps · ~3s",
+      "Point any agent at a listed x402 endpoint — it gets the 402, signs a gasless USDC payment, retries, and keeps the receipt.",
+    steps: ["402 · sign · settle"],
+    done: "Response + on-chain receipt.",
+    total: "per-call · fee-free · gasless",
   },
 ];
 

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -43,14 +43,11 @@ client. Docs: https://docs.t2000.ai/passport-connect
 - Sell (services on your Agent ID — \`t2 service create\`, escrowed jobs,
   no server needed; or per-call x402 via \`t2 agent sell\`):
   https://docs.t2000.ai/sell-to-agents/overview
-- Services board (JSON): https://api.t2000.ai/v1/services · CLI: t2 browse
+- Services board (JSON): https://api.t2000.ai/v1/services · CLI: t2 services
 - Jobs read-model: https://api.t2000.ai/v1/jobs?seller=|buyer=
-- Private Inference (OpenAI-compatible, confidential tier): https://docs.t2000.ai/private-inference
-- Wire your coding tool (Claude Code, Codex, Continue, …): https://docs.t2000.ai/use-with-your-tools · CLI: t2 connect
-- Verify any confidential receipt in Audric: https://audric.ai
-- Live numbers: inference usage (tokens, model leaderboard) at
-
-  economy settlements at https://t2000.ai/activity
+- Private Inference (OpenAI-compatible, confidential tier + verify) is an
+  Audric product: https://audric.ai · API https://api.audric.ai
+- Live numbers: economy settlements at https://t2000.ai/activity
   (raw: https://t2000.ai/api/economy)
 
 ## Docs


### PR DESCRIPTION
## What (SPEC_T2_STALE_PURGE_AND_DOCS P1 — marketing/copy cluster; dictionary = P0 canon)

| File | deleted | rewritten | left (why) |
|---|---|---|---|
| \`apps/web/app/data/t2k.ts\` | named-provider example stories (fal.ai/ElevenLabs/Lob/Judge0/CoinGecko/NewsAPI — the purged proxy-mall catalog taught as payable) | **Capital layer card**: NEXT+"Tokenize your agent" → **HORIZON** + whitepaper-aligned vision copy (ownership/liquidity against honest receipts, shape later); **stories** → 4 honest marketplace verbs (pay a listed x402 route · escrow hire · Open post · agent-pays-agent) with a catalog-from-live-truth comment; **Law card** attributes confidential inference to Audric | Physical Labor / Law / Commerce cards (already aligned); PI product link already points at audric.ai |
| \`apps/web/app/llms.txt/route.ts\` | dangling "inference usage / model leaderboard" live-numbers line; dead \`docs.t2000.ai/private-inference\` + \`use-with-your-tools · t2 connect\` lines | PI line → "an Audric product: audric.ai · api.audric.ai"; \`t2 browse\` → \`t2 services\` | commerce/agents/services/jobs endpoints (accurate) |
| \`SECURITY.md\` | "Upstream API keys — gateway env vars" bullet (gateway gone); "\`t2 verify\` DCAP" as t2000 | payment bullet → settle-then-serve truth (handler before money, no-charge-on-failure); confidential bullet → "an Audric product (api.audric.ai)" | \`verifyReceipt\` line 31 (still a real SDK export) |

apps/web typechecks clean. Companion PR removes the Capital SDK builders.

## Residual greps (left, with why)
- **skills** (\`t2000-services\`/\`t2000-pay\`): explicit one-line History notes ("this skill used to list mpp.t2000.ai providers") — dictionary-allowed History
- **t2000-mcp / t2000-setup skills + docs stdio mentions**: kill-stdio migration truth, not primary-install teaching
- **apps/docs/changelog.mdx**: changelog = History by nature
- **packages/mcp internals**: deprecated/frozen package, published deprecation truth
- **\`.claude/skills/t2000-confidential-verify\`**: repo-agent rule depth → P4 (recommend delete there)
- **contracts/agent_capital**: on-chain Move stays (explicit exception)
- **\`extra.suimpp\` wire fields, \`payWithMpp\` name**: wire/polish exceptions per prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)