### PR TITLE
📝 docs: P4 purge — agent context teaches the live map

### DIFF
--- a/.claude/skills/t2000-design-system/SKILL.md
+++ b/.claude/skills/t2000-design-system/SKILL.md
@@ -45,7 +45,7 @@ description: >-
 - Apps read the **semantic** tokens (`--bg` / `--bg-elevated` / `--border`), NOT
   the raw `--ds-gray-*` primitives (those are the palette source).
 - **Per-app accent** is the one knob: `:root { --t2k-accent: <brand> }` — emerald
-  (verify), teal (mpp), blue (t2000.ai). shadcn apps map the house values into
+  blue (t2000.ai). shadcn apps map the house values into
   their own token slots (`--background`/`--card`/`--border`…) because shadcn's
   names collide with the canonical's `--border`/`--font-*`/`--radius-*`
   (importing the file would cycle) — so copy the values in.
@@ -55,7 +55,7 @@ description: >-
 | Surface | State |
 |---|---|
 | t2000.ai (`apps/web`) | ✅ copy-in `tokens.css` + the 2026-07 designer chrome (`app/styles/{tokens,type,page,responsive,theme}.css`); legacy `geist-ds.css` deleted; a temporary raw-primitive shim in each `globals.css` covers pre-redesign components until their port |
-| agents.t2000.ai (`audric/apps/console`) | ⏳ flips to the near-black house theme (founder decision 2026-07-06) by setting the console's shadcn slots to house values; Tailwind + shadcn architecture unchanged |
+| t2000.ai marketplace + console (`audric/apps/console`) | ✅ near-black house theme (Ember Steel) — shadcn slots on house values; Tailwind + shadcn architecture unchanged |
 | suimpp.dev (separate repo) | ⏳ still on published npm `@t2000/ui` until it migrates to copy-in |
 | audric.ai (`audric/apps/web-v3`) | ➖ consumer flagship — keeps its OWN theme, the ONE surface outside the family look |
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ every surface.
 
 ---
 
-## Packages (npm, lockstep version — 7)
+## Packages (npm, lockstep version — 6)
 
 | Package | What it is |
 |---|---|
@@ -73,9 +73,8 @@ every surface.
 | `@t2000/serve` | Merchant-side x402 router — wrap any API: `.route().paid().body().handler()`, settle-then-serve, discovery docs, `asNextRoute` for Next.js, optional activity report (default-on from env) |
 | `@t2000/sui-x402` | **The x402 dialect SSOT** — scheme `exact` requirements/verify/settle, digest replay store. (npm name note: `@t2000/x402` is an unpublish tombstone.) |
 | `@t2000/discovery` | x402 endpoint probe (accepts[] + WWW-Authenticate) + OpenAPI paid-route extraction — the listing gate + catalog contract |
-| `@t2000/mcp` | **DEPRECATED** — the retired local stdio server; kept published, no updates. Connect (`mcp.t2000.ai/mcp`) is the MCP surface. |
 
-All 7 release in lockstep via `release.yml` → `publish.yml` (never publish
+All 6 release in lockstep via `release.yml` → `publish.yml` (never publish
 manually; the dialect + discovery publish steps hard-fail). The x402 protocol
 also stays published as `@suimpp/{mpp,discovery}` mirrors from the suimpp repo
 — one line of history, not part of this stack's runtime.
@@ -270,6 +269,7 @@ NAVI/DeFi (2026-06), the hosted mpp proxy gateway + catalog and the Capital
 storefront (2026-08-01, `SPEC_T2_CLEANUP_USDC_ONLY`), Private Inference on
 `api.t2000.ai` and `verify.t2000.ai` as t2000 surfaces (retired 2026-08-01,
 `SPEC_PI_TO_AUDRIC` — both live on with Audric), the local stdio MCP server
-(2026-08-02, `SPEC_T2_KILL_STDIO`), and the MPP header payment dialect in the
+(retired 2026-08-02, `SPEC_T2_KILL_STDIO`; the `@t2000/mcp` package left the
+monorepo + lockstep 2026-08-03), and the MPP header payment dialect in the
 SDK (2026-08-03). Their rationale and internals live in git history and the
 internal build tracker; nothing in this document describes them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ t2000/
 ├── packages/sdk     ← @t2000/sdk (npm)
 ├── packages/id      ← @t2000/id (npm)    ← Agent ID — agent_id::registry client (added 2026-06-29)
 ├── packages/serve   ← @t2000/serve (npm) ← Merchant-side x402 router — wrap any API for agent payments (added 2026-07-20)
-├── packages/x402    ← @t2000/sui-x402 (npm) ← The x402 payment dialect for Sui — absorbed from @suimpp/mpp 2026-08-03 (B1; stack is 7 packages)
+├── packages/x402    ← @t2000/sui-x402 (npm) ← The x402 payment dialect for Sui — absorbed from @suimpp/mpp 2026-08-03 (B1)
 ├── packages/discovery ← @t2000/discovery (npm) ← x402 endpoint probe + OpenAPI extract — absorbed from @suimpp/discovery 2026-08-03
 ├── packages/store   ← @t2000/store (PLANNED, H1 — Agent Store: commerce engine, Move+Seal+Walrus)
 ├── packages/models  ← @t2000/models (PLANNED, H2 — Agent Models: OpenAI-compatible gateway to self-hosted Qwen + resold frontier)
@@ -34,7 +34,7 @@ t2000/
 
 ### Two brand layers
 
-**t2000** = infra. Names the underlying capabilities (SDK, CLI, MCP, x402 gateway, contracts). Used in technical docs, package names, READMEs, dev-facing surfaces. (The `@t2000/engine` harness package was retired 2026-06-14.)
+**t2000** = infra + the agent economy. Names the marketplace (t2000.ai), Passport Connect (mcp.t2000.ai), and the stack (SDK, CLI, serve, the sui-x402 dialect, Agent ID, contracts). Used in technical docs, package names, READMEs, dev-facing surfaces. (The `@t2000/engine` harness package was retired 2026-06-14.)
 
 **Audric** = consumer. The product a user touches at audric.ai.
 
@@ -199,7 +199,7 @@ Read `REPO_LAYOUT.md` once at session start for "where does X go?"
 
 | Document | What it covers | Read before |
 |----------|---------------|-------------|
-| `PRODUCT.md` | **The product map SSOT** — 2 products (Private Inference · x402 gateway), one customer + one path each; wallet/Agent ID = substrate, not products; `t2 agent onboard` deprecated | Any product/positioning/onboarding work |
+| `PRODUCT.md` | **The product map SSOT** — the USDC agent economy: A2A Marketplace (t2000.ai) + Passport Connect (mcp.t2000.ai); Private Inference = Audric (api.audric.ai); wallet/Agent ID = substrate, not products | Any product/positioning/onboarding work |
 | [`docs.t2000.ai`](https://docs.t2000.ai) | Live docs SSOT — product naming, CLI surface, SDK API, MCP tools (Mintlify, auto-deployed from `apps/docs/`) | Documentation or marketing |
 | `T2000_WHITEPAPER.md` | Public whitepaper — the layer map (Identity/Wallet · Commerce · Physical Labor horizon · Law & Governance); peer of PRODUCT/ARCHITECTURE at root | Vision/positioning work |
 | `ARCHITECTURE.md` | Current-state technical map — the two rails' request lifecycles, wallet/gas/limits, Agent ID, MCP/skills, auth, data stores, CI (rewritten 2026-07-13) | API or integration work |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pnpm build
 pnpm typecheck && pnpm lint && pnpm test
 ```
 
-Releases happen via the `release.yml` GitHub Actions workflow (bumps all seven packages in lockstep). See [`CLAUDE.md`](CLAUDE.md) for the release process and engineering principles.
+Releases happen via the `release.yml` GitHub Actions workflow (bumps all six packages in lockstep). See [`CLAUDE.md`](CLAUDE.md) for the release process and engineering principles.
 
 ## Security
 


### PR DESCRIPTION
## What (PURGE-DOCTRINE P4 — t2000 half; audric PR is the twin)
Any agent loading project instructions now gets the live product map, not the pre-split fiction.

| Location | was | now |
|---|---|---|
| CLAUDE.md Key Documents PRODUCT row | "2 products (Private Inference · x402 gateway)" | the USDC agent economy: A2A Marketplace + Passport Connect; PI = Audric |
| CLAUDE.md brand line | "SDK, CLI, MCP, x402 gateway, contracts" | marketplace + Connect + stack (SDK · CLI · serve · sui-x402 dialect · Agent ID · contracts) |
| CLAUDE.md tree line | "(B1; stack is 7 packages)" | count removed (Critical Rule 1 holds the canonical 6) |
| ARCHITECTURE packages table | live \`@t2000/mcp\` DEPRECATED row after the package was deleted | **row deleted**; header 7→6; History gains the one-line monorepo-exit date |
| README | "seven packages in lockstep" | six |
| design-system skill | \`agents.t2000.ai\` row (⏳ theme flip) + verify/mpp accent list | t2000.ai marketplace + console (✅ Ember Steel); dead accents dropped |

Verified zero: confidential-verify index entries (gone since #126), stdio-primary installs, Capital/engine/DeFi rule reintroductions. \`.claude/rules/packages.md\` already correct. REPO_LAYOUT whitepaper allowlist row confirmed. Residual greps = retirement one-liners only (CLAUDE Rule 1, packages.md, ARCH History) + \`.claude/settings.local.json\` (untracked local permission history, not agent teaching).

Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)