### PR TITLE
♻️ refactor(cli): remove agent-id SuiNS leaf product

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Agent ID"
-description: "On-chain identity for agents on Sui — an address, a @handle, an owner, and a public profile in the agent directory."
+description: "On-chain identity for agents on Sui — an address, a name, a #id, an owner, and a public profile in the agent directory."
 ---
 
-**Agent ID** gives every agent a portable, on-chain identity on Sui: a keypair-anchored address, an optional **`@handle`**, an optional human **owner**, and a public **profile** — discoverable in the **[agent directory](https://t2000.ai)**. The identity lives in the `agent_id::registry` Move package on mainnet, and everything here is **sponsored** — a brand-new agent holding 0 SUI can register itself.
+**Agent ID** gives every agent a portable, on-chain identity on Sui: a keypair-anchored address, a **name** and **#id**, an optional human **owner**, and a public **profile** — discoverable in the **[agent directory](https://t2000.ai)**. The identity lives in the `agent_id::registry` Move package on mainnet, and everything here is **sponsored** — a brand-new agent holding 0 SUI can register itself.
 
 <Note>
-  Identity is **address-anchored**, not name-anchored: the Sui address is the canonical id; handle and display name are layers on top. API keys are a separate spend-side concern — they come from the [console](/console), not from identity.
+  Identity is **address-anchored**, not name-anchored: the Sui address is the canonical id; the display name and #id are layers on top. API keys are a separate spend-side concern — they come from the [console](/console), not from identity.
 </Note>
 
 ---
@@ -31,19 +31,6 @@ Run t2 agent create --name "Atlas Research" --description "Market research on de
 Add `--owner <your-passport-address>` to propose yourself as owner — confirm in the [console](https://t2000.ai/manage), then edit the listing from the browser. The pieces also exist separately: `t2 init` registers a new wallet out of the box; `t2 agent register` covers an existing one; `t2 agent profile` names it later.
 
 **The agent registers itself — its key stays where it runs.** There is no browser create-form for agent keypairs by design (a keypair minted in a tab is how keys get lost). **Your Passport is an agent too** — tap **Create your Agent ID** on the [dashboard](https://t2000.ai/manage) to register your own address, consent-first, deactivate anytime.
-
----
-
-## Claim a handle
-
-`<label>.agent-id.sui`, shown as `@<label>` — resolves to your address via SuiNS. Optional, gasless:
-
-```bash
-t2 agent handle alice                # claim alice.agent-id.sui
-t2 agent handle alice --release      # give it up (change = release + re-claim)
-```
-
-Unique, first-come-first-served, enforced on-chain — a taken label fails cleanly (`409 handle_taken`), nothing charged or minted. Only the handle's current target can release it.
 
 ---
 

--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -108,7 +108,7 @@ agent.keypair;     // Ed25519Keypair (throws for zkLogin instances)
 ```
 
 <Note>
-**Agent identity** (register on-chain, claim a handle) lives in a separate package — **[`@t2000/id`](/agent-id)** — and the `t2 agent` CLI suite. This SDK (`@t2000/sdk`) is the wallet + payments layer; `@t2000/id` is the Agent ID layer.
+**Agent identity** (register on-chain, name + profile) lives in a separate package — **[`@t2000/id`](/agent-id)** — and the `t2 agent` CLI suite. This SDK (`@t2000/sdk`) is the wallet + payments layer; `@t2000/id` is the Agent ID layer.
 </Note>
 
 ---

--- a/apps/docs/agent-wallet.mdx
+++ b/apps/docs/agent-wallet.mdx
@@ -6,7 +6,7 @@ description: "One CLI + one skill set — hold + send USDC gasless, swap, pay an
 The **Agent Wallet** is `@t2000/cli` + `t2000-skills` — the terminal command surface for the whole stack:
 
 - **Money** (the core) — hold + send USDC/USDsui gasless, swap any Sui token, [pay any API](/how-to/pay-an-api) per call (`t2 send · swap · pay`)
-- **Identity** — register an [Agent ID](/agent-id), claim a handle, look up the directory (`t2 agent …`)
+- **Identity** — register an [Agent ID](/agent-id), set your name + profile, look up the directory (`t2 agent …`)
 - **Marketplace** — [hire](/how-to/hire) and [sell](/how-to/list-a-service) deliverable work through on-chain escrow (`t2 services · service · job`)
 
 The CLI is the human surface, the MCP server is the AI-client surface (same capabilities as tools), skills are the playbooks both share.
@@ -44,7 +44,7 @@ The core loop is four commands — everything else (swap, history, limits, ident
 |---|---|
 | `t2 init` | Create the wallet + a free on-chain Agent ID. `--import` restores a `suiprivkey1…` secret. |
 | `t2 fund` | Deposit address + QR. |
-| `t2 send <amount> <asset> <recipient>` | USDC / USDsui (gasless) or SUI. Recipient: `0x…` or SuiNS name (incl. subnames like `alice.agent-id.sui`). |
+| `t2 send <amount> <asset> <recipient>` | USDC / USDsui (gasless) or SUI. Recipient: `0x…` or SuiNS name (incl. subnames like `alice.audric.sui`). |
 | `t2 pay <url>` | Pay an x402 API — 402 challenge → USDC payment → response, automatic. |
 
 Every command takes `--json` (machine-parseable) and `--key <path>` (non-default wallet).

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -163,7 +163,7 @@ The highlights, newest first. For the exhaustive per-version log, see
 
   What remains is the whole product: the **wallet** (send · swap · receive),
   **x402 payments** (`t2 pay` against any paid API — the gateway catalog is
-  unchanged), and **Agent ID** (register, @handle, ownership, the public
+  unchanged), and **Agent ID** (register, ownership, the public
   directory at [t2000.ai](https://t2000.ai) — now also the home
   of [skills](https://t2000.ai/skills)). Registered agents that expose
   a paid endpoint implement x402 on it directly; any x402 client can pay it.
@@ -385,7 +385,7 @@ The highlights, newest first. For the exhaustive per-version log, see
 <Update label="Agent ID" description="June 2026">
   **On-chain identity for agents.** Give an agent a name humans and machines can trust.
 
-  - **Claim a handle** — `t2 agent handle` registers `<label>.agent-id.sui`.
+  - **Claim a handle** — registered `<label>.agent-id.sui` leaves (product retired 2026-08-04 — agents are name + #id + address; humans hold @audric).
   - **Own it** — register on-chain and link the agent to a human owner.
   - **Profile** — set a public name, image, website, and socials with `t2 agent profile`,
     all backed by the `@t2000/id` registry.

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -191,7 +191,6 @@ Registration is free and sponsored — no gas, no funding.
 | `t2 agent create` | Wallet + on-chain Agent ID + profile in one pass. `--owner <address>` proposes a human owner. |
 | `t2 agent register` | Register this wallet on-chain as an Agent ID. Idempotent. |
 | `t2 agent profile` | Set the public profile: `--name`, `--image <https-url>` (your pfp/avatar), `--description`, `--category`, `--website`, `--twitter`, `--github`. Any subset; signed by the agent key. |
-| `t2 agent handle <label>` | Claim `<label>.agent-id.sui` for this wallet. `--release` gives it up. |
 | `t2 agent sell <endpoint>` | List your x402 endpoint on your public profile — live-probed, gasless. `--category <cat>` sets your directory category (required once unless already set). `--remove` clears it. (Per-call machine path; selling deliverable work is `t2 service create` — [Services](#services-sell-deliverable-work).) |
 | `t2 agent link <owner>` | Propose an owner (two-sided — the owner confirms in the console). |
 | `t2 agent confirm <agent>` | Confirm ownership of an agent that proposed you. |

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -1,5 +1,7 @@
-// `t2 agent` — Agent ID (on-chain identity: register · handle · profile ·
-// ownership). Identity only: the `onboard`/`topup` wallet-credit commands
+// `t2 agent` — Agent ID (on-chain identity: register · profile · ownership).
+// The `handle` command (agent-id.sui SuiNS leaves) was removed 2026-08-04
+// (SPEC_T2_KILL_AGENT_ID_LEAF — humans hold @audric; agents are name + #id
+// + 0x). Identity only: the `onboard`/`topup` wallet-credit commands
 // were removed 2026-07-13 (PRODUCT.md one-path decision) and `tokenize` was
 // removed 2026-08-01 (SPEC_T2_CLEANUP_USDC_ONLY — the store is a USDC
 // economy; the SDK builders were deleted 2026-08-03 — on-chain
@@ -53,14 +55,13 @@ async function fetchJson(
 export function registerAgent(program: Command) {
   const group = program
     .command('agent')
-    .description('Agent ID — on-chain identity for this wallet (register · handle · profile · ownership)')
+    .description('Agent ID — on-chain identity for this wallet (register · profile · ownership)')
     .addHelpText(
       'after',
       `
 Subcommands:
   $ t2 agent create --name "Atlas Research"  Wallet + Agent ID + profile in one pass
   $ t2 agent register                        Existing wallet → on-chain Agent ID (gasless)
-  $ t2 agent handle alice                    Claim @alice
   $ t2 agent sell https://api.me.com/v1/x    Sell it as an x402 Service (live-probed, gasless)
 `,
     );
@@ -476,66 +477,6 @@ Subcommands:
             printKeyValue('Profile', `https://t2000.ai/${address}`);
           }
           printKeyValue('Tx', String(sub.digest));
-          printBlank();
-        } catch (error) {
-          handleError(error);
-        }
-      },
-    );
-
-  group
-    .command('handle')
-    .argument('<label>', 'Handle label (3–20 chars: lowercase a–z, 0–9, hyphens)')
-    .description(
-      'Claim <label>.agent-id.sui → this wallet (custody-minted, gasless). Use --release to give it up.',
-    )
-    .option('--release', 'Release (revoke) this handle instead of claiming it')
-    .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
-    .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(
-      async (
-        label: string,
-        opts: { release?: boolean; key?: string; api?: string },
-      ) => {
-        try {
-          const base = opts.api ?? DEFAULT_API_BASE;
-          const agent = await withAgent({ keyPath: opts.key });
-          const address = agent.address();
-
-          // Challenge → sign (bound to nonce + label, action-prefixed).
-          const challenge = await fetchJson(`${base}/agent/challenge`, {
-            method: 'POST',
-            body: { address },
-          });
-          const nonce = challenge.nonce as string | undefined;
-          if (!nonce) {
-            throw new Error('Failed to get a challenge nonce.');
-          }
-          const action = opts.release
-            ? 't2000-agent-handle-release'
-            : 't2000-agent-handle';
-          const message = new TextEncoder().encode(`${action}:${nonce}:${label}`);
-          const { signature } = await agent.keypair.signPersonalMessage(message);
-
-          const path = opts.release ? '/agent/handle/release' : '/agent/handle';
-          const res = await fetchJson(`${base}${path}`, {
-            method: 'POST',
-            body: { address, label, nonce, signature },
-          });
-
-          if (isJsonMode()) {
-            printJson({ address, ...res });
-            return;
-          }
-          printBlank();
-          if (opts.release) {
-            printSuccess(`Handle released: ${String(res.handle)}`);
-          } else {
-            printSuccess(`Handle claimed: ${String(res.display)}`);
-            printKeyValue('Handle', String(res.handle));
-          }
-          printKeyValue('Address', truncateAddress(address));
-          printKeyValue('Tx', String(res.digest));
           printBlank();
         } catch (error) {
           handleError(error);

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -17,8 +17,8 @@
 //
 // SuiNS resolution is delegated to the SDK's `T2000.resolveRecipient` —
 // 0x addresses and `.sui` names (including subnames like
-// `alice.audric.sui` / `alice.agent-id.sui`) resolve without CLI-side
-// handling. Bare `@handle` forms are NOT resolvable.
+// `alice.audric.sui`) resolve without CLI-side handling. Bare `@handle`
+// forms are NOT resolvable.
 
 import type { Command } from 'commander';
 import pc from 'picocolors';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -264,9 +264,6 @@ export type { CoinMeta } from './token-registry.js';
 // vSUI still exists in the codebase as a passive token (NAVI reward type
 // + Cetus swap target), but t2000 no longer exposes mint/redeem surfaces.
 export {
-  AGENT_ID_PARENT,
-  AGENT_ID_PARENT_NAME,
-  AGENT_ID_PARENT_NFT_ID,
   AUDRIC_PARENT,
   AUDRIC_PARENT_NAME,
   AUDRIC_PARENT_NFT_ID,

--- a/packages/sdk/src/protocols/suins-leaf.test.ts
+++ b/packages/sdk/src/protocols/suins-leaf.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, vi } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
 
 import {
-  AGENT_ID_PARENT,
-  AGENT_ID_PARENT_NAME,
   AUDRIC_PARENT_NAME,
   AUDRIC_PARENT_NFT_ID,
   buildAddLeafTx,
@@ -187,17 +185,18 @@ describe('suins-leaf', () => {
     });
   });
 
-  // [Agent ID Phase B, gate 2] The leaf machinery is parameterized by parent so
-  // the same builders serve a second namespace (`agent-id.sui`) without forking.
-  describe('parameterized parent (Agent ID)', () => {
-    const AGENT_PARENT: SuinsParent = {
-      name: 'agent-id.sui',
+  // The leaf machinery stays parameterized by parent (generic under
+  // `SuinsParent`); the retired agent-id parent is gone — a synthetic
+  // parent keeps the parameterization covered.
+  describe('parameterized parent', () => {
+    const OTHER_PARENT: SuinsParent = {
+      name: 'example.sui',
       nftId: '0xabc0000000000000000000000000000000000000000000000000000000000abc',
     };
 
     it('displayHandle / fullHandle accept a parent name', () => {
-      expect(displayHandle('bot', AGENT_ID_PARENT_NAME)).toBe('bot@agent-id');
-      expect(fullHandle('bot', AGENT_ID_PARENT_NAME)).toBe('bot.agent-id.sui');
+      expect(displayHandle('bot', OTHER_PARENT.name)).toBe('bot@example');
+      expect(fullHandle('bot', OTHER_PARENT.name)).toBe('bot.example.sui');
     });
 
     it('default parent is still audric (back-compat)', () => {
@@ -210,18 +209,13 @@ describe('suins-leaf', () => {
       buildAddLeafTx(fakeSuinsClient, {
         label: 'bot',
         targetAddress: VALID_TARGET,
-        parent: AGENT_PARENT,
+        parent: OTHER_PARENT,
       });
       expect(createLeafSubName).toHaveBeenCalledWith({
-        parentNft: AGENT_PARENT.nftId,
-        name: 'bot.agent-id.sui',
+        parentNft: OTHER_PARENT.nftId,
+        name: 'bot.example.sui',
         targetAddress: VALID_TARGET,
       });
-    });
-
-    it('agent-id parent has the registered NFT id', () => {
-      expect(AGENT_ID_PARENT.name).toBe('agent-id.sui');
-      expect(AGENT_ID_PARENT.nftId).toMatch(/^0x[0-9a-f]{64}$/);
     });
 
     it('throws when a parent NFT id is not configured', () => {

--- a/packages/sdk/src/protocols/suins-leaf.ts
+++ b/packages/sdk/src/protocols/suins-leaf.ts
@@ -49,9 +49,9 @@ export const AUDRIC_PARENT_NFT_ID =
  * A SuiNS parent under which leaf subnames are minted: the registered SLD name
  * + the on-chain `SuinsRegistration` NFT id the minting service must own/sign.
  *
- * Added 2026-06-29 (Agent ID Phase B, gate 2) to let the same leaf machinery
- * serve a SECOND namespace — `agent-id.sui` for Agent ID handles — without
- * forking it. Audric stays the default so every existing caller is unchanged.
+ * Added 2026-06-29 to keep the leaf machinery generic over the parent.
+ * Audric is the default (and, since the agent-id leaf product was retired
+ * 2026-08-04, the only product parent) — every existing caller is unchanged.
  */
 export interface SuinsParent {
   name: string;
@@ -64,21 +64,12 @@ export const AUDRIC_PARENT: SuinsParent = {
   nftId: AUDRIC_PARENT_NFT_ID,
 };
 
-/** The Agent ID parent (`<label>.agent-id.sui` → `@agent-id`). Distinct from
- *  audric.sui on purpose (infra/agent registry vs consumer brand).
- *
- *  Registered on SuiNS mainnet 2026-06-29; the `SuinsRegistration` NFT
- *  (`0xc8c1…d5d1f`) is held by the custody address
- *  `0x6988a92d…30e4532`, which signs leaf mints + pays their gas. Override via
- *  `AGENT_ID_PARENT_NFT_ID` for testnet/dev. */
-export const AGENT_ID_PARENT_NAME = 'agent-id.sui';
-export const AGENT_ID_PARENT_NFT_ID =
-  process.env.AGENT_ID_PARENT_NFT_ID ??
-  '0xc8c13f5b5a6d4c47c04877014794f65e67e2745d3bfa089b736eb54b0ebd5d1f';
-export const AGENT_ID_PARENT: SuinsParent = {
-  name: AGENT_ID_PARENT_NAME,
-  nftId: AGENT_ID_PARENT_NFT_ID,
-};
+// The agent-id.sui parent constants were REMOVED 2026-08-04
+// (SPEC_T2_KILL_AGENT_ID_LEAF): humans hold @audric only; agents are Agent
+// ID name + #id + 0x — no SuiNS leaf. The generic builders below stay
+// parameterized on `SuinsParent` for the Audric consumer parent. The parent
+// NFT (`0xc8c1…d5d1f`) sits unused on-chain; its custody address keeps its
+// separate gas-sponsor role.
 
 export interface BuildAddLeafParams {
   /** Bare label, e.g. `'alice'` — NOT the full `'alice.audric.sui'` path. */
@@ -271,9 +262,8 @@ export function displayHandle(
   label: string,
   parentName: string = AUDRIC_PARENT_NAME,
 ): string {
-  // Strip the trailing `.sui` TLD for the `@` display form.
-  // `displayHandle('alice')` → `'alice@audric'`; for Agent ID,
-  // `displayHandle('bot', AGENT_ID_PARENT_NAME)` → `'bot@agent-id'`.
+  // Strip the trailing `.sui` TLD for the `@` display form:
+  // `displayHandle('alice')` → `'alice@audric'`.
   const parentDisplay = parentName.replace(/\.sui$/, '');
   return `${label}@${parentDisplay}`;
 }

--- a/t2000-skills/skills/sui-grpc/SKILL.md
+++ b/t2000-skills/skills/sui-grpc/SKILL.md
@@ -60,7 +60,7 @@ const obj = await client.core.getObject({ objectId: '0x…' });
 const tx = await client.core.getTransaction({ digest: '…' });
 
 // SuiNS
-const { record } = await client.nameService.lookupName({ name: 'agent-id.sui' });
+const { record } = await client.nameService.lookupName({ name: 'audric.sui' });
 ```
 
 ## Rules

--- a/t2000-skills/skills/suins/SKILL.md
+++ b/t2000-skills/skills/suins/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 
 SuiNS is Sui's name service — `alice.sui` instead of `0x…`. Two reads cover almost every task:
 
-- **Lookup** — name → target address (`agent-id.sui` → `0x6988…4532`)
+- **Lookup** — name → target address (`audric.sui` → its treasury/custody `0x…`)
 - **Reverse lookup** — address → its default name
 
 ## Rules
@@ -39,8 +39,8 @@ const client = new SuiGrpcClient({
 });
 
 // name → address
-const { record } = await client.nameService.lookupName({ name: 'agent-id.sui' });
-console.log(record.targetAddress);   // 0x6988…4532
+const { record } = await client.nameService.lookupName({ name: 'audric.sui' });
+console.log(record.targetAddress);   // 0x…
 console.log(record.expirationTimestamp); // when the name expires
 
 // address → default name
@@ -48,22 +48,20 @@ const rev = await client.nameService.reverseLookupName({ address: '0x…' });
 console.log(rev.record?.name);
 ```
 
-Verified against mainnet: `agent-id.sui` → `0x6988a92d5695909b7baa4d996324a873fbbeec94eec445eab99cc08ed30e4532`.
-
 ## Resolve (JSON-RPC — works today, deactivated July 31, 2026 on mainnet)
 
 ```bash
 curl -s -X POST https://fullnode.mainnet.sui.io \
   -H "content-type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"suix_resolveNameServiceAddress","params":["agent-id.sui"]}'
-# → {"jsonrpc":"2.0","id":1,"result":"0x6988…4532"}
+  -d '{"jsonrpc":"2.0","id":1,"method":"suix_resolveNameServiceAddress","params":["audric.sui"]}'
+# → {"jsonrpc":"2.0","id":1,"result":"0x…"}
 ```
 
 Use only as a stopgap in environments without a gRPC client. Migrate before the cutoff.
 
 ## Registering and managing names
 
-Registration, renewals, and subnames are transactions — use [suins.io](https://suins.io) (browser) or the [`@mysten/suins` SDK](https://docs.suins.io/developer/sdk) (programmatic). The t2000 stack mints its own namespaces this way: `@handle` → `<label>.agent-id.sui` via `t2 agent handle <label>`.
+Registration, renewals, and subnames are transactions — use [suins.io](https://suins.io) (browser) or the [`@mysten/suins` SDK](https://docs.suins.io/developer/sdk) (programmatic). The Audric Passport mints `@handle` → `<label>.audric.sui` leaves this way; agents need no SuiNS name (Agent ID name + #id + address).
 
 ## Gotchas
 


### PR DESCRIPTION
## Phase C1 — kill the agent-id SuiNS leaf (t2000 half)

**SPEC:** `SPEC_T2_KILL_AGENT_ID_LEAF.md` (locked 2026-08-04). One handle story: humans hold **@audric**; agents are Agent ID **name + #id + 0x** — no SuiNS leaf. Companion audric PR removes the mint API + custody.

### Removed
- **CLI** — the `t2 agent handle` command (claim/`--release`), its help line and group description. `t2 agent` is now register · profile · ownership · sell.
- **SDK** — `AGENT_ID_PARENT`, `AGENT_ID_PARENT_NAME`, `AGENT_ID_PARENT_NFT_ID` + their barrel exports. The **generic** leaf machinery stays parameterized on `SuinsParent` (builders, `fullHandle`/`displayHandle`, `validateLabel`, `AUDRIC_PARENT`) — audric's live @audric identity surface consumes it, exactly the carve-out the SPEC allows. Test suite re-exampled onto a synthetic parent.
- **Docs** — agent-id.mdx loses the Claim-a-handle section (+ @handle intro/frontmatter); cli-reference row gone; agent-wallet/agent-sdk reworded; changelog entries kept as history, reworded past-tense.
- **Skills** — the suins skill no longer teaches the agent-id mint and its examples resolve `audric.sui` (the stale "verified" agent-id resolution line removed); sui-grpc example likewise.

### Kept (per SPEC)
- `@t2000/id` registry client untouched — register, name, #id, ownership all work leaf-free.
- Generic SuiNS resolution (`utils/suins`, `t2 send` name resolution) untouched.
- The parent NFT sits unused on-chain; its custody address keeps its separate gas-sponsor role (audric side).

### Acceptance
- [x] `t2 agent handle` gone from CLI + docs (**docs-consistency test enforces this** — it walks the command tree and fails on any doc/skill mention of a removed subcommand)
- [x] Agent register / sell / hire untouched
- [x] No half-dead command or orphan exports (repo grep clean; only historical changelog + removal-note comments remain)

### Verification
- sdk build + **530 tests pass**; cli build + **186 tests pass** (incl. docs-consistency + help-resolution suites); typecheck clean; lint = 7 pre-existing warnings in unrelated test files, 0 errors.

### Release note
Public surface changed (a CLI command + 3 published SDK exports removed) → per the founder default-down rule this ships as **one `minor`** after merge (`gh workflow run release.yml --field bump=minor`). Flag: `PRODUCT_ROADMAP.md` LIVE list still mentions SuiNS agent-id handles — founder-owned tracker, noted for your edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)