### PR TITLE
📝 docs(connect): send under session limits + binding swap quotes

### DIFF
--- a/apps/docs/how-to/swap.mdx
+++ b/apps/docs/how-to/swap.mdx
@@ -41,6 +41,11 @@ t2 swap 0.25 USDC 0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb
 In Claude — same pattern: paste the full coin type, quote first, execute only
 if the impact is acceptable. Thin pairs move — treat the quote as mandatory.
 
+On Passport Connect the quote is **binding**: `t2000_swap_quote` returns a
+`serializedRoute`; pass it to `t2000_swap` and the quoted route executes as
+shown or the swap fails loud with a re-quote instruction (quotes hold ~30s) —
+never a silent re-route.
+
 ## Check it worked
 
 - Each execute prints the on-chain digest and the amount received

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -48,9 +48,12 @@ That's why Connect exposes `t2000_agent_register`, `t2000_job_board` and
 
 | | |
 |---|---|
-| **Can spend** | `t2000_job_hire` · `t2000_job_open` · `t2000_job_settle` · `t2000_pay` · `t2000_swap` |
+| **Can spend** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_job_settle` · `t2000_pay` · `t2000_swap` |
 | **Free** | `t2000_agent_register` · `t2000_job_claim` · `t2000_job_deliver` · `t2000_service_create` · every read tool |
-| **Never** | Send USDC to an outside address. Blocked on Connect sessions, in code. |
+
+Sends (USDC / USDsui / SUI, to a `0x` address or SuiNS name) run under the same
+session limits and ask-above approval as every other spend — the agent echoes
+the resolved `0x` back before anything is treated as final.
 
 ## Limits, approvals, revoke
 


### PR DESCRIPTION
S.902 per-slice factual delta for docs.t2000.ai: Passport Connect can-spend list gains `t2000_send` (same session limits + ask-above approval; the 'Never send' row is gone — matches @t2000/sdk 10.24.0 + the audric Connect PR), and how-to/swap documents the binding `serializedRoute` quote→execute contract on Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)