### PR TITLE
✨ feat(sdk): shared digest→created-object resolver (S.906 SSOT)

### DIFF
--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -25,6 +25,7 @@ import {
   postOpenJob,
   MAX_JOB_USDC,
   type OpenJobRow,
+  resolveCreatedObjectId,
 } from '@t2000/sdk';
 import { parseDuration } from './job.js';
 import { withAgent } from '../lib/with-agent.js';
@@ -80,25 +81,13 @@ function fmtLeft(ms: number | null): string {
   return `${Math.max(1, Math.floor(left / 60_000))}m`;
 }
 
-/** Best-effort: pull the created object id (Opening or Job) off a digest. */
-async function resolveCreated(
+/** Best-effort: pull the created object id (Opening or Job) off a digest —
+ *  the shared SDK walk (S.906 SSOT). */
+function resolveCreated(
   digest: string,
   marker: '::opening::Opening<' | '::escrow::Job<',
 ): Promise<string | undefined> {
-  try {
-    const client = getSuiClient();
-    const result = await client.core.waitForTransaction({
-      digest,
-      include: { objectTypes: true },
-      timeout: 15_000,
-    });
-    const txn =
-      result.$kind === 'Transaction' ? result.Transaction : result.FailedTransaction;
-    const types = txn.objectTypes ?? {};
-    return Object.keys(types).find((id) => types[id]?.includes(marker));
-  } catch {
-    return undefined; // the digest alone is still a receipt
-  }
+  return resolveCreatedObjectId(getSuiClient(), digest, marker);
 }
 
 /** Adds the Open-door verbs onto the `t2 job` group. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -194,6 +194,12 @@ export {
   refundOpenJob,
 } from './open-jobs.js';
 export type { OpenJobFilter, OpenJobRow } from './open-jobs.js';
+// Digest → created-object resolution (S.906 SSOT — CLI + console + Connect).
+export {
+  ESCROW_JOB_TYPE_MARKER,
+  OPENING_TYPE_MARKER,
+  resolveCreatedObjectId,
+} from './utils/resolve-created.js';
 export {
   fetchAllCoins,
   selectAndSplitCoin,

--- a/packages/sdk/src/utils/resolve-created.test.ts
+++ b/packages/sdk/src/utils/resolve-created.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  ESCROW_JOB_TYPE_MARKER,
+  OPENING_TYPE_MARKER,
+  resolveCreatedObjectId,
+} from './resolve-created.js';
+
+// S.906 SSOT — the one digest→object walk shared by CLI, console and the
+// Connect MCP. Best-effort: never throws, undefined on timeout/absence.
+
+function clientWith(objectTypes: Record<string, string>, kind = 'Transaction') {
+  return {
+    core: {
+      waitForTransaction: vi.fn(async () => ({
+        $kind: kind,
+        [kind]: { objectTypes },
+      })),
+    },
+  } as unknown as Parameters<typeof resolveCreatedObjectId>[0];
+}
+
+describe('resolveCreatedObjectId', () => {
+  it('finds the Opening by marker', async () => {
+    const client = clientWith({
+      '0xaaa': '0xpkg::opening::Opening<0xc::usdc::USDC>',
+      '0xbbb': '0x2::coin::Coin<0x2::sui::SUI>',
+    });
+    await expect(
+      resolveCreatedObjectId(client, '0xdigest', OPENING_TYPE_MARKER),
+    ).resolves.toBe('0xaaa');
+  });
+
+  it('finds the escrow Job by marker', async () => {
+    const client = clientWith({
+      '0xjob': '0xpkg::escrow::Job<0xc::usdc::USDC>',
+    });
+    await expect(
+      resolveCreatedObjectId(client, '0xdigest', ESCROW_JOB_TYPE_MARKER),
+    ).resolves.toBe('0xjob');
+  });
+
+  it('returns undefined when no object matches', async () => {
+    const client = clientWith({ '0xbbb': '0x2::coin::Coin<0x2::sui::SUI>' });
+    await expect(
+      resolveCreatedObjectId(client, '0xdigest', OPENING_TYPE_MARKER),
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws — a timeout resolves to undefined (digest still a receipt)', async () => {
+    const client = {
+      core: {
+        waitForTransaction: vi.fn(async () => {
+          throw new Error('timeout');
+        }),
+      },
+    } as unknown as Parameters<typeof resolveCreatedObjectId>[0];
+    await expect(
+      resolveCreatedObjectId(client, '0xdigest', OPENING_TYPE_MARKER),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/sdk/src/utils/resolve-created.ts
+++ b/packages/sdk/src/utils/resolve-created.ts
@@ -1,0 +1,40 @@
+import type { SuiGrpcClient } from '@mysten/sui/grpc';
+
+// Digest → created-object resolution (S.906 SSOT). Three consumers used to
+// hand-copy this walk — the CLI's `t2 job open`, audric's hire-submit route
+// and the Connect MCP's `t2000_job_open` — so the marker walk lives HERE
+// once. Best-effort by design: a slow indexer returns `undefined` and the
+// digest alone is still a receipt (callers must never block a successful
+// escrow post on resolution).
+
+/** The shared `Opening` object minted by an Open post. */
+export const OPENING_TYPE_MARKER = '::opening::Opening<';
+/** The escrow `Job` object minted by a hire or an Open claim. */
+export const ESCROW_JOB_TYPE_MARKER = '::escrow::Job<';
+
+/**
+ * Pull the id of an object a transaction created/touched whose type contains
+ * `marker`. Waits for the tx (default 15s, the CLI's long-standing budget)
+ * and scans `objectTypes`. Returns `undefined` on timeout or absence —
+ * never throws.
+ */
+export async function resolveCreatedObjectId(
+  client: SuiGrpcClient,
+  digest: string,
+  marker: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<string | undefined> {
+  try {
+    const result = await client.core.waitForTransaction({
+      digest,
+      include: { objectTypes: true },
+      timeout: opts.timeoutMs ?? 15_000,
+    });
+    const txn =
+      result.$kind === 'Transaction' ? result.Transaction : result.FailedTransaction;
+    const types = txn.objectTypes ?? {};
+    return Object.keys(types).find((id) => types[id]?.includes(marker));
+  } catch {
+    return undefined; // the digest alone is still a receipt
+  }
+}


### PR DESCRIPTION
S.906 single-source-of-truth extraction: `resolveCreatedObjectId(client, digest, marker)` + `OPENING_TYPE_MARKER` / `ESCROW_JOB_TYPE_MARKER` in @t2000/sdk — the waitForTransaction+objectTypes walk previously hand-copied in the CLI's `t2 job open` and audric's hire-submit, now needed a third time by Connect's `t2000_job_open`. Best-effort contract: never throws, `undefined` on timeout — a successful escrow post is never blocked on a slow index. CLI refactored onto the helper (behavior identical; markers unchanged). 4 new tests; sdk 539 + cli 186 green. Ships as one **minor** (new public export) — audric consumes it in the companion S.905/S.906 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)