### PR TITLE
✨ feat(sdk): resolve label@audric Passport handles (P3.1)

### DIFF
--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -16,9 +16,9 @@
 //   - PIN flow removed. Uses `withAgent` from `lib/with-agent.ts`.
 //
 // SuiNS resolution is delegated to the SDK's `T2000.resolveRecipient` —
-// 0x addresses and `.sui` names (including subnames like
-// `alice.audric.sui`) resolve without CLI-side handling. Bare `@handle`
-// forms are NOT resolvable.
+// 0x addresses, `.sui` names (including subnames like `alice.audric.sui`)
+// AND Passport handles (`alice@audric` → `alice.audric.sui`, P3.1/S.912)
+// resolve without CLI-side handling. Other `@namespace` forms stay invalid.
 
 import type { Command } from 'commander';
 import pc from 'picocolors';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -87,6 +87,7 @@ export {
   InvalidAddressError,
   SuinsNotRegisteredError,
   SuinsRpcError,
+  canonicalizeRecipientInput,
   looksLikeSuiNs,
   resolveSuinsViaRpc,
   resolveAddressToSuinsViaRpc,

--- a/packages/sdk/src/t2000.ts
+++ b/packages/sdk/src/t2000.ts
@@ -26,6 +26,7 @@ import { resolveSymbol, resolveCoinDecimals } from './token-registry.js';
 import {
   SUI_ADDRESS_REGEX,
   SuinsNotRegisteredError,
+  canonicalizeRecipientInput,
   looksLikeSuiNs,
   resolveSuinsViaRpc,
 } from './utils/suins.js';
@@ -570,7 +571,9 @@ export class T2000 extends EventEmitter<T2000Events> {
   async resolveRecipient(
     input: string,
   ): Promise<{ address: string; suinsName?: string }> {
-    const trimmed = input.trim();
+    // P3.1: canonicalize `label@audric` → `label.audric.sui` here too, so
+    // send previews return the canonical name — one path with the utils.
+    const trimmed = canonicalizeRecipientInput(input);
     if (SUI_ADDRESS_REGEX.test(trimmed)) {
       return { address: trimmed.toLowerCase() };
     }
@@ -594,7 +597,7 @@ export class T2000 extends EventEmitter<T2000Events> {
     }
     throw new T2000Error(
       'INVALID_ADDRESS',
-      `Cannot resolve recipient "${input}". Provide a 0x address or a .sui name.`,
+      `Cannot resolve recipient "${input}". Provide a 0x address, a .sui name, or a Passport handle (name@audric).`,
     );
   }
 

--- a/packages/sdk/src/utils/suins.test.ts
+++ b/packages/sdk/src/utils/suins.test.ts
@@ -22,6 +22,7 @@ import {
   SUI_ADDRESS_REGEX,
   SUI_ADDRESS_STRICT_REGEX,
   SUINS_NAME_REGEX,
+  canonicalizeRecipientInput,
   looksLikeSuiNs,
   resolveSuinsViaRpc,
   resolveAddressToSuinsViaRpc,
@@ -200,6 +201,50 @@ describe('utils/suins — SDK exports (S.279)', () => {
     it('throws SuinsNotRegisteredError when a well-formed name resolves to null', async () => {
       mockQuery.mockResolvedValueOnce({ data: { address: null } });
       await expect(normalizeAddressInput('ghost.sui')).rejects.toBeInstanceOf(SuinsNotRegisteredError);
+    });
+  });
+
+  // P3.1 / S.912 — Passport handles: `label@audric` ≡ `label.audric.sui`.
+  describe('canonicalizeRecipientInput (@audric handles)', () => {
+    it('maps label@audric to the canonical SuiNS name', () => {
+      expect(canonicalizeRecipientInput('funkii@audric')).toBe('funkii.audric.sui');
+    });
+
+    it('lowercases label AND namespace form', () => {
+      expect(canonicalizeRecipientInput('Funkii@Audric')).toBe('funkii.audric.sui');
+    });
+
+    it('leaves 0x addresses, .sui names, and garbage untouched (trim only)', () => {
+      expect(canonicalizeRecipientInput('  0xAbC1  ')).toBe('0xAbC1');
+      expect(canonicalizeRecipientInput('alex.sui')).toBe('alex.sui');
+      expect(canonicalizeRecipientInput('funkii')).toBe('funkii');
+      expect(canonicalizeRecipientInput('alice@other')).toBe('alice@other');
+    });
+
+    it('looksLikeSuiNs accepts @audric handles, rejects bare labels + other namespaces', () => {
+      expect(looksLikeSuiNs('alice@audric')).toBe(true);
+      expect(looksLikeSuiNs('alice')).toBe(false);
+      expect(looksLikeSuiNs('alice@other')).toBe(false);
+    });
+
+    it('normalizeAddressInput resolves the handle via the canonical name', async () => {
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce({ data: { address: { address: '0xABC' } } });
+      await expect(normalizeAddressInput('Funkii@Audric')).resolves.toEqual({
+        address: '0xabc',
+        suinsName: 'funkii.audric.sui',
+        raw: 'Funkii@Audric',
+      });
+      // The RPC saw the CANONICAL name — one resolution chain, no @ leaks.
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ variables: { name: 'funkii.audric.sui' } }),
+      );
+    });
+
+    it('unregistered handle → SuinsNotRegisteredError, never an invented address', async () => {
+      mockQuery.mockReset();
+      mockQuery.mockResolvedValueOnce({ data: { address: null } });
+      await expect(normalizeAddressInput('ghost@audric')).rejects.toBeInstanceOf(SuinsNotRegisteredError);
     });
   });
 });

--- a/packages/sdk/src/utils/suins.ts
+++ b/packages/sdk/src/utils/suins.ts
@@ -61,11 +61,38 @@ export const SUI_ADDRESS_STRICT_REGEX = /^0x[a-fA-F0-9]{64}$/i;
  */
 export const SUINS_NAME_REGEX = /^[a-z0-9-]+(\.[a-z0-9-]+)*\.sui$/;
 
+/**
+ * Passport display handle (P3.1 / S.912): `funkii@audric`. Product lock —
+ * humans hold `label@audric`; the on-chain SuiNS name is
+ * `label.audric.sui`. ONLY the `@audric` namespace maps (the parent we
+ * own); `label@other` stays invalid — we never loosen the SuiNS regex to
+ * accept `@` globally.
+ */
+const AUDRIC_HANDLE_RE = /^([a-z0-9-]+)@audric$/i;
+
+/**
+ * Canonicalize user paste BEFORE address/SuiNS shape checks:
+ * - `label@audric` → `label.audric.sui` (lowercased) — the literal parent
+ *   string deliberately matches `AUDRIC_PARENT_NAME` in
+ *   `protocols/suins-leaf.ts` (not imported: that module pulls the heavy
+ *   `@mysten/suins` client into every normalizer consumer).
+ * - everything else (0x, `.sui` names, garbage) passes through trimmed.
+ */
+export function canonicalizeRecipientInput(raw: string): string {
+  const trimmed = raw.trim();
+  const m = AUDRIC_HANDLE_RE.exec(trimmed);
+  if (m) {
+    return `${m[1].toLowerCase()}.audric.sui`;
+  }
+  return trimmed;
+}
+
 export class InvalidAddressError extends Error {
   constructor(public readonly raw: string) {
     super(
       `"${raw}" isn't a valid Sui address or SuiNS name. ` +
-        `Pass a 0x-prefixed hex address (e.g. 0x40cd…3e62) or a SuiNS name ending in .sui (e.g. alex.sui).`,
+        `Pass a 0x-prefixed hex address (e.g. 0x40cd…3e62), a SuiNS name ending in .sui (e.g. alex.sui), ` +
+        `or a Passport handle (e.g. alex@audric).`,
     );
     this.name = 'InvalidAddressError';
   }
@@ -95,7 +122,9 @@ export class SuinsRpcError extends Error {
  */
 export function looksLikeSuiNs(value: string): boolean {
   if (!value) return false;
-  return SUINS_NAME_REGEX.test(value.trim().toLowerCase());
+  // `label@audric` canonicalizes to `label.audric.sui` first (P3.1), so
+  // Passport handles count as names everywhere this predicate gates.
+  return SUINS_NAME_REGEX.test(canonicalizeRecipientInput(value).toLowerCase());
 }
 
 /**
@@ -111,7 +140,8 @@ export async function resolveSuinsViaRpc(
   rawName: string,
   ctx: { suiRpcUrl?: string; signal?: AbortSignal } = {},
 ): Promise<string | null> {
-  const name = rawName.trim().toLowerCase();
+  // Canonicalize first (P3.1) so call sites may pass `label@audric` directly.
+  const name = canonicalizeRecipientInput(rawName).toLowerCase();
   if (!SUINS_NAME_REGEX.test(name)) {
     throw new InvalidAddressError(rawName);
   }
@@ -225,7 +255,9 @@ export async function normalizeAddressInput(
   value: string,
   ctx: { suiRpcUrl?: string; signal?: AbortSignal } = {},
 ): Promise<NormalizedAddress> {
-  const trimmed = value.trim();
+  // P3.1: `label@audric` → `label.audric.sui` before shape checks. `raw`
+  // keeps the ORIGINAL paste; `suinsName` carries the canonical name.
+  const trimmed = canonicalizeRecipientInput(value);
   if (SUI_ADDRESS_REGEX.test(trimmed)) {
     return { address: trimmed.toLowerCase(), suinsName: null, raw: value };
   }


### PR DESCRIPTION
## P3.1 (S.912) — Resolve `label@audric` Passport handles via SDK SSOT

S.911 dogfood: `funkii.sui` + hex round-trip pass, but **`funkii@audric` failed format validation** before SuiNS ran. Product lock: humans hold `label@audric`; the on-chain name is `label.audric.sui` — both must resolve the same address. Root fix in the **one SDK normalizer**, not an MCP branch.

### The canonicalize helper (one site)
`canonicalizeRecipientInput(raw)` in `utils/suins.ts`: `label@audric` → `label.audric.sui` (lowercased); everything else passes through trimmed. **Only the `@audric` namespace maps** (the parent we own — the literal matches `AUDRIC_PARENT_NAME` in `suins-leaf.ts`, deliberately not imported: that module drags `@mysten/suins` into every normalizer consumer). `label@other` stays invalid; `SUINS_NAME_REGEX` is **not** loosened to accept `@` globally.

### Wired once into all four resolution sites
- `normalizeAddressInput` — `raw` keeps the original paste, `suinsName` carries the **canonical** `.audric.sui` form.
- `looksLikeSuiNs` — `alice@audric` → true; bare `alice` and `alice@other` stay false.
- `resolveSuinsViaRpc` — call sites may pass handles directly; the RPC only ever sees the canonical name.
- `T2000.resolveRecipient` — send previews return the canonical name (one path with the utils, no dual logic).

Error copy (`InvalidAddressError` + resolveRecipient) now names all three accepted forms: `0x…`, `name.sui`, `name@audric`. CLI `send.ts` header updated — its "bare `@handle` NOT resolvable" note is stale product as of this change.

### Verification
- New tests: canonicalize (case-insensitive, passthrough for 0x/`.sui`/garbage/`@other`), predicate acceptance matrix, `normalizeAddressInput('Funkii@Audric')` with the mock RPC **asserting the query saw `funkii.audric.sui`** and `raw` preserved, `ghost@audric` → `SuinsNotRegisteredError` (no invented address).
- SDK suite **545 tests green** · sdk + cli build · repo typecheck/lint clean (7 pre-existing warnings in unrelated test files).

### After merge
Release **patch** via the release workflow, then bump `@t2000/sdk` in audric (5 consumers) + soften the Connect `t2000_resolve` description to name `user@audric` — separate audric PR.

### Founder dogfood (once Connect has the SDK)
```
t2000_resolve funkii@audric    → same 0x as funkii.sui
t2000_resolve ghostzzzz@audric → honest fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
