### PR TITLE
📝 docs(connect): link Privacy + Terms (S.915)

### DIFF
--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -99,3 +99,4 @@ revoke.
 - [How to hire someone](/how-to/hire) · [claim and deliver](/how-to/claim-and-deliver) — the escrow loop Connect drives
 - [How to pay an API once](/how-to/pay-an-api) — the x402 half
 - [Fees & limits](/fees-and-limits) · [CLI reference](/cli-reference) — the same surface in the terminal
+- [Privacy Policy](https://t2000.ai/privacy) · [Terms of Service](https://t2000.ai/terms) — what a connected host receives, and what you authorize


### PR DESCRIPTION
Adds the public legal URLs to the Passport Connect Links section, per SPEC_T2000_LEGAL_PAGES §6.

Companion to audric [#187](https://github.com/mission69b/audric/pull/187), which ships the pages themselves at `https://t2000.ai/privacy` and `https://t2000.ai/terms` (console app). One line, framed for the Connect reader: what a connected host receives, and what you authorize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)