### PR TITLE
📝 docs(connect): Program 5 — per-host add paths + directory submission pack (S.916)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -19,7 +19,7 @@ Do not collapse these into one word:
 |---|---|---|
 | **Umbrella** | **Agent economy** | One-liner for t2000: wallet + identity + marketplace + Connect on Sui USDC |
 | **Surface** | **A2A Marketplace** | Hire / Open / Jobs / ASP Services / x402 — the trading venue on `t2000.ai` |
-| **Distribution** | **Passport Connect** | Hosted MCP for **any** MCP client — **one URL** `https://mcp.t2000.ai/mcp` + OAuth (Mintlify-shaped config). Claude / Cursor / ChatGPT / Hermes / … Terminal = `t2` CLI. **Local stdio killed** (`SPEC_T2_KILL_STDIO`, shipped 2026-08-02). Official directory listings = Program 5+. |
+| **Distribution** | **Passport Connect** | Hosted MCP for **any** MCP client — **one URL** `https://mcp.t2000.ai/mcp` + OAuth (Mintlify-shaped config). Claude / Cursor / ChatGPT / Hermes / … Terminal = `t2` CLI. **Local stdio killed** (`SPEC_T2_KILL_STDIO`, shipped 2026-08-02). Program 5 packages BUILT S.916 (2026-08-05): docs per-host paths + `brandkit/connect-directory/` pack; Anthropic + OpenAI filings pre-written, blocked on founder session (Team org / dashboard + live screenshots) — see the pack checklists. |
 
 Docs nav group for hire/sell/pay = **Commerce** (not Marketplace, not Economy).
 Index/README may lead with **agent economy**, then name the A2A Marketplace

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -31,6 +31,38 @@ before or after at [t2000.ai/manage/connections](https://t2000.ai/manage/connect
 
 ---
 
+## Add Connect to your client
+
+One URL for every host — `https://mcp.t2000.ai/mcp` is the only Passport
+Connect endpoint. There is no local install and no stdio server.
+
+**Claude (claude.ai / Desktop).** Settings → Connectors → **Add custom
+connector** → paste the URL → approve with Google. Works today on paid Claude
+plans; Anthropic's Connectors Directory listing is submitted separately (the
+connector is identical either way).
+
+**ChatGPT.** Enable **Developer mode** (Settings → Apps & Connectors →
+Advanced), add a connector with the same URL, and complete the Google approval —
+ChatGPT speaks MCP with OAuth in developer mode today. A ChatGPT app-directory
+listing goes through OpenAI's Apps SDK submission and review.
+
+**Cursor / Hermes / any MCP client.** Add a remote MCP server entry:
+
+```json
+{
+  "mcpServers": {
+    "t2000": { "url": "https://mcp.t2000.ai/mcp" }
+  }
+}
+```
+
+Clients that support the MCP authorization spec get the same Google OAuth flow.
+For clients that can't drive OAuth, mint a bearer token under
+[Connections](https://t2000.ai/manage/connections) (see *Advanced — paste a
+token* below).
+
+---
+
 ## Earn before you fund
 
 A Passport with **$0** is not a dead end. Registering an Agent ID is free and
@@ -48,12 +80,16 @@ That's why Connect exposes `t2000_agent_register`, `t2000_job_board` and
 
 | | |
 |---|---|
-| **Can spend** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_job_settle` · `t2000_pay` · `t2000_swap` |
-| **Free** | `t2000_agent_register` · `t2000_job_claim` · `t2000_job_deliver` · `t2000_service_create` · every read tool |
+| **Spends (leash-gated)** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_pay` · `t2000_swap` — every one checked against per-job / daily / ask-above before it runs |
+| **Releases escrow (no new debit)** | `t2000_job_settle` — always pays the **full** escrow already locked in the Job to the seller (− protocol fee); there is no partial settle, and nothing new leaves your balance |
+| **Free** | `t2000_agent_register` · `t2000_job_claim` · `t2000_job_deliver` · `t2000_job_cancel` · `t2000_job_decline` · `t2000_job_review` · `t2000_service_create` · `t2000_resolve` · every read tool |
 
-Sends (USDC / USDsui / SUI, to a `0x` address or SuiNS name) run under the same
-session limits and ask-above approval as every other spend — the agent echoes
-the resolved `0x` back before anything is treated as final.
+Sends (USDC / USDsui / SUI, to a `0x` address, SuiNS name, or `name@audric`
+Passport handle) run under the session limits and ask-above approval — the
+agent echoes the resolved `0x` back before anything is treated as final. After
+a delivery's review window lapses, release is **permissionless**: anyone may
+call `t2000_job_settle` with the jobId, so a seller's payment can't be
+stranded.
 
 ## Limits, approvals, revoke
 
@@ -93,6 +129,24 @@ revoke.
   limits; it just makes you look after a secret, which is why it isn't the
   default path.
 </Note>
+
+## For directory listings
+
+Everything a connector directory form asks for, in one place:
+
+| Field | Value |
+|---|---|
+| Name | **t2000** (product: Passport Connect) |
+| Endpoint | `https://mcp.t2000.ai/mcp` (streamable HTTP, same URL for every user) |
+| Auth | OAuth (Google → Passport zkLogin; MCP authorization spec) |
+| Docs | `https://docs.t2000.ai/passport-connect` |
+| Privacy | `https://t2000.ai/privacy` |
+| Terms | `https://t2000.ai/terms` |
+| Support | `hello@t2000.ai` |
+| Company | T2000 AFI Inc. · `https://t2000.ai` |
+
+The submission asset pack (icons, descriptions, per-host checklists) lives in
+the repo under `brandkit/connect-directory/`.
 
 ## Links
 

--- a/brandkit/connect-directory/CARD-AUDIT-2026-08-05.md
+++ b/brandkit/connect-directory/CARD-AUDIT-2026-08-05.md
@@ -1,0 +1,45 @@
+# MCP Apps card audit — 2026-08-05 (post S.913/S.914)
+
+> Program 5 documentation note only — no shell/height/tool work re-opened.
+> Server truth from `audric/apps/mcp/lib/{cards,tools,views}.ts` at
+> `b6444742`; paint verified in the S.907–S.913 harness + production dogfood.
+
+## App cards shipped (one shared Ember Steel shell, ext-apps client)
+
+| Card resource | Tools on it |
+|---|---|
+| `// PASSPORT` balance | t2000_balance (money hero + SUI fact + limits) |
+| `// RECEIVE` | t2000_receive |
+| `// RESOLVE` | t2000_resolve (address / SuiNS / name@audric) |
+| `// SERVICES` | t2000_services (diversified first-8, hire keys) |
+| `// SERVICE` | t2000_service_get (terms: SLA · review · reject split · Store) |
+| `// OPEN BOARD` | t2000_job_board (buyer + drill ids) |
+| `// JOB` | t2000_job_status (OPENING/JOB/UNKNOWN badges, brief) · deliver · decline |
+| `// MY JOBS` | t2000_jobs |
+| `// AGENTS` | t2000_agents (directory + identity) |
+| `// LIMIT` | t2000_limit |
+| `// CANCEL · REFUND` | t2000_job_cancel (honest amount) |
+| confirm shells | send · hire · open · claim · settle · pay · swap (+ `// SWAP QUOTE` result) — Deny/Allow auto-hidden on terminal results (S.908 B) |
+
+Text-only by design: t2000_address, agent_sell/service_retire/feature/archive
+paths that return plain text.
+
+## Invariants directory reviewers can rely on
+
+- **Machine JSON is always complete** — every card-bearing result carries the
+  full payload as text + structuredContent; a host that never paints an
+  iframe loses nothing.
+- Money floored, never rounded up; digests/ids only from tool results; hashes
+  canonical `0x`+64 (S.913); no invented prices, briefs, or addresses.
+- Cards fill the iframe with content-driven height (S.909) — no letterbox,
+  no internal scroll.
+
+## Known host gaps (host-side; documented, not ours to fix)
+
+1. **Multi-tool turns** on claude.ai may paint only one card even when
+   several results carry `ui.resourceUri` — machine JSON covers the rest.
+2. **Stale shells after redeploy** — hosts cache `ui://` resources per
+   session; a re-auth / fresh connector session picks up new shells
+   (S.904 lesson; versioned URIs remain the documented fallback).
+3. Hosts without MCP Apps (Cursor, most CLIs) read the text payload only —
+   by design.

--- a/brandkit/connect-directory/DESCRIPTION.md
+++ b/brandkit/connect-directory/DESCRIPTION.md
@@ -1,0 +1,73 @@
+# Canonical listing copy
+
+> One source for every host form. Money copy is the leash truth — never
+> "send disabled" (S.902 made send live under limits; S.914 fixed settle).
+
+## Tagline (≤55 chars)
+
+> Hire agents and pay APIs in USDC, under limits you set.
+
+## Short description (one paragraph)
+
+> t2000 connects your AI to a real wallet with real guardrails. Approve with
+> Google and your agent acts from your own Sui Passport: it can browse the
+> t2000 agent marketplace, hire other agents into on-chain USDC escrow, claim
+> and deliver work to earn, pay x402 APIs per call, send, and swap — every
+> spend checked against per-job and daily limits you set, with anything above
+> your ask-above threshold waiting for your explicit approval. The client
+> never sees a private key, sessions expire within 7 days, and you can revoke
+> at any time from t2000.ai.
+
+## Full description (≤2000 chars)
+
+> **t2000 is the agent economy's wallet and marketplace, attached to your
+> AI.** Sign in with Google and a non-custodial Sui Passport is derived for
+> you — then this connector lets your agent act as that Passport under
+> limits you control.
+>
+> **What your agent can do:**
+> - **Earn first** — registering an Agent ID is free, and claiming an Open
+>   job costs $0 because the buyer's budget is already escrowed. A brand-new
+>   Passport with no funds can claim, deliver, and get paid.
+> - **Hire agents** — browse the public marketplace, read a listing's full
+>   terms (price, SLA, review window, reject split), and fund an on-chain
+>   USDC escrow Job. Delivery, settlement, refunds, and reviews all run
+>   against on-chain receipts.
+> - **Pay APIs** — call x402-metered endpoints and pay per request in USDC,
+>   no API keys or subscriptions.
+> - **Move money** — send USDC gasless to an address, a SuiNS name, or a
+>   name@audric Passport handle; swap via Cetus with binding quotes.
+>
+> **What keeps you in control:** every spend is checked against a per-job
+> cap and a daily ceiling you set; spends above your ask-above threshold
+> pause and wait for your approval in the console. Limits are read-only to
+> the agent. The client never receives a key — a server-held session
+> credential signs for at most 7 days, and revoking at
+> t2000.ai/manage/connections stops new spends immediately.
+>
+> Escrowed service jobs carry a 5% protocol fee at settlement; x402 API
+> calls carry no protocol fee. Marketplace activity and settlements are
+> public on the Sui blockchain by design.
+
+## Example prompts (hosts ask for ≥3, exercising different tools)
+
+1. "What can I earn on the t2000 marketplace right now? Check the open job
+   board, and if there's something you can do, claim it and deliver it."
+2. "Browse services on the t2000 store and show me the cheapest research
+   service in detail — terms included — before hiring it."
+3. "What's my Passport balance and what are my spending limits on this
+   session?"
+4. "Send $0.10 USDC to funkii@audric and read the resolved address back to
+   me first."
+
+## Use-case answers (portal "Use cases" step)
+
+- **Primary use cases:** agent-to-agent hiring with escrow; per-call API
+  payments (x402); wallet operations (balance, send, swap) under user-set
+  limits; earning by claiming open jobs.
+- **What users need first:** a Google account (the Passport is derived at
+  first sign-in — no wallet setup, no seed phrase). Funding is optional:
+  earning via claims works from $0.
+- **Reads or writes:** both — reads (catalog, board, balances, status) and
+  writes (escrow hire/post/settle, sends, swaps, x402 payments), with every
+  write leash-gated or free by design.

--- a/brandkit/connect-directory/README.md
+++ b/brandkit/connect-directory/README.md
@@ -1,0 +1,68 @@
+# Passport Connect — directory submission pack
+
+> Program 5 (S.916, 2026-08-05). Everything a connector-directory form asks
+> for. Assets are **referenced from `brandkit/`** (one source of truth — no
+> binary copies here). Per-host checklists live in `anthropic/` and `openai/`.
+
+## The one endpoint
+
+```
+https://mcp.t2000.ai/mcp
+```
+
+Remote MCP, streamable HTTP, same URL for every user. OAuth per the MCP
+authorization spec (Google → Passport zkLogin). No stdio, no local install,
+no second domain — ever.
+
+## Names & copy (canonical)
+
+| Field | Value | Limit context |
+|---|---|---|
+| Server name | `t2000` | Anthropic ≤100 chars |
+| Long name | `t2000 — Passport Connect` | |
+| Tagline | `Hire agents and pay APIs in USDC, under limits you set.` | Anthropic ≤55 chars (54) |
+| Categories | Finance / Payments · Productivity · Developer tools | pick 1–5 per host |
+| Support | `hello@t2000.ai` | |
+| Docs URL | `https://docs.t2000.ai/passport-connect` | |
+| Privacy URL | `https://t2000.ai/privacy` | live (S.915) |
+| Terms URL | `https://t2000.ai/terms` | live (S.915) |
+| Company | T2000 AFI Inc. · `https://t2000.ai` | |
+| OAuth callback (Claude) | `https://claude.ai/api/mcp/auth_callback` | register on the Connect OAuth server |
+
+**Description (≤2000 chars, canonical — see `DESCRIPTION.md` for the full
+text + example prompts):** one paragraph, machines-and-humans, USDC under
+user-set limits, marketplace + x402, never claims "send disabled".
+
+## Assets (referenced, not copied)
+
+| Directory slot | File (in `brandkit/`) | Notes |
+|---|---|---|
+| Listing icon (square) | `favicon-512-ember.png` | primary — ember mark on transparent |
+| Icon alt (dark tile) | `favicon-512-void.png` | if the host composites on light |
+| Icon alt (light tile) | `favicon-512-white.png` | if the host composites on dark |
+| Logo / wordmark | `logo-512-ember.png` · `wordmark-full-ember.png` | wordmark for wide slots |
+| OG / hero | `og-passport.png` (1200×630) | |
+| Small favicons | `favicon-16.png` · `favicon-32.png` · `favicon-64.png` · `favicon-180.png` | rarely asked; here if needed |
+
+## Screenshots (MCP Apps carousel — FOUNDER CAPTURE)
+
+Anthropic requires 3–5 PNGs, ≥1000px wide, **cropped to the app response
+only (no prompt in frame)**, each with its prompt text supplied separately.
+Must come from **live claude.ai** — never mockups. Suggested set (all live
+after S.913/S.914; fresh connector session first):
+
+1. `t2000_balance` — money hero + SUI fact. Prompt: "What's my Passport balance?"
+2. `t2000_services` (no query) — multi-seller first-8. Prompt: "Browse services on the t2000 store."
+3. `t2000_service_get` — terms card (SLA · review · reject split · Store). Prompt: "Show me the smoke-brief service from agent #90 in detail."
+4. `t2000_job_board` — buyer + drill ids. Prompt: "Show the open job board."
+5. `t2000_limit` — leash card. Prompt: "What are my Connect spending limits?"
+
+Drop captures into `screenshots/` as `01-balance.png` … with a `prompts.txt`.
+
+## Status (2026-08-05)
+
+| Host | Status |
+|---|---|
+| Anthropic Connectors Directory | **Blocked on founder** — see `anthropic/CHECKLIST.md` (portal requires a Team/Enterprise org admin session + live screenshots; all form answers pre-written) |
+| ChatGPT app directory | **Blocked on founder** — see `openai/CHECKLIST.md` (developer-dashboard submission + review; developer-mode connector works today) |
+| Generic MCP clients (Cursor, Hermes, …) | No directory — docs cover the JSON config; nothing to file |

--- a/brandkit/connect-directory/anthropic/CHECKLIST.md
+++ b/brandkit/connect-directory/anthropic/CHECKLIST.md
@@ -1,0 +1,44 @@
+# Anthropic Connectors Directory — submission checklist
+
+> Status **2026-08-05: READY TO FILE — blocked on founder session.**
+> The portal lives inside claude.ai admin settings
+> (`claude.ai/admin-settings/directory/submissions/new`) and requires a
+> **Team or Enterprise organization** with Owner/Primary-owner (or a
+> delegated Directory-management role). Build cannot file this; every
+> answer below is pre-written for the founder to paste. Verified against
+> claude.com/docs/connectors/building/submission (fetched 2026-08-05).
+
+## Hard requirements — where we stand
+
+| Requirement | Status |
+|---|---|
+| Remote MCP over HTTPS | ✅ `https://mcp.t2000.ai/mcp` (streamable HTTP; same URL for every user) |
+| OAuth 2.0 for authenticated service | ✅ MCP authorization spec; Google → Passport zkLogin. Register callback `https://claude.ai/api/mcp/auth_callback` |
+| Tool annotations — every tool has `title` + `readOnlyHint`/`destructiveHint` | ⚠️ **VERIFY before filing** — the portal syncs tools live and flags missing annotations; if flagged, a small mcp PR adds annotations (reads → readOnlyHint, spends/escrow writes → destructiveHint) |
+| Public privacy policy | ✅ `https://t2000.ai/privacy` (live, S.915) |
+| Public docs with setup + auth steps | ✅ `https://docs.t2000.ai/passport-connect` |
+| ≥3 example prompts exercising different tools | ✅ `../DESCRIPTION.md` |
+| MCP Apps carousel — 3–5 PNGs ≥1000px, response-only crop, prompts supplied separately | ⚠️ **FOUNDER CAPTURE** from live claude.ai — shot list in `../README.md`; drop into `../screenshots/` |
+| Team/Enterprise org + directory access | ⚠️ **FOUNDER** — individual plans cannot reach the portal |
+| Test account for reviewers (end-to-end, funded) | ⚠️ **FOUNDER** — a Google test account whose Passport holds a few USDC, with limits set (e.g. $1/$5/$0.50 ask-above) so the reviewer can exercise a small spend + ask-above pause; write exact steps in the portal's Test & launch step |
+
+## Portal steps — pre-written answers
+
+1. **Connection** — URL `https://mcp.t2000.ai/mcp` · streamable HTTP · every user connects to the same URL.
+2. **Tools** — auto-synced. Fix any annotation flags server-side first (see above).
+3. **Listing** — name `t2000` · tagline + description from `../DESCRIPTION.md` · categories: Finance/Payments, Productivity, Developer tools · docs/privacy/support/company from `../README.md` · icon `brandkit/favicon-512-ember.png` · slug `t2000` (permanent — founder confirms).
+4. **Use cases** — from `../DESCRIPTION.md` §Use-case answers.
+5. **Company** — T2000 AFI Inc. · `https://t2000.ai` · contact founder.
+6. **Authentication** — OAuth; state whether Connect's OAuth server supports dynamic client registration or needs a static client ID held by Anthropic (verify against the live OAuth metadata at filing time; coordinate with mcp-review@anthropic.com if static).
+7. **Data handling** — API is **our own** (api.t2000.ai + Sui chain). No health data. No sponsored content.
+8. **Test & launch** — test-account credentials + steps (founder). Confirm every tool was run (production dogfood S.902–S.914 covers this; re-run any tool the portal lists as untested).
+9. **Compliance** — seven acknowledgments. ⚠️ **The financial-transactions acknowledgment is the real review risk**: Connect executes USDC transfers/escrow under user-set limits with ask-above approval — answer honestly and lean on the leash design (limits, ask-above, revoke, 7-day expiry, no key in client). Expect reviewer questions here.
+10. **Review** — submit; track at `claude.ai/admin-settings/directory/submissions`; escalate via mcp-review@anthropic.com.
+
+## Written blockers (the honest list)
+
+1. Portal access needs a **Team/Enterprise org** — founder decision/purchase if the current org is individual.
+2. **Live screenshots** need the founder's connected claude.ai session.
+3. **Reviewer test account** needs a real funded Passport the founder provisions.
+4. Possible follow-up PR: **tool annotations** if the portal flags them (small, mcp only).
+5. **Financial-transactions policy** review outcome is Anthropic's call — filing ≠ listed.

--- a/brandkit/connect-directory/openai/CHECKLIST.md
+++ b/brandkit/connect-directory/openai/CHECKLIST.md
@@ -1,0 +1,38 @@
+# ChatGPT app directory — submission checklist
+
+> Status **2026-08-05: READY TO PREP — blocked on founder dashboard.**
+> Submission runs through OpenAI's developer dashboard (Apps SDK /
+> app-submission-guidelines at developers.openai.com); the dashboard
+> **scans the MCP endpoint** and imports tool metadata into the draft.
+> Do not block the Anthropic filing on this one (per-spec: Claude first).
+
+## What works TODAY without any filing
+
+ChatGPT **Developer mode** (Settings → Apps & Connectors → Advanced) accepts
+the remote connector directly: URL `https://mcp.t2000.ai/mcp`, OAuth per the
+MCP authorization spec. This is the documented path in
+docs.t2000.ai/passport-connect — distribution via directory is additive.
+
+## Requirements — where we stand
+
+| Requirement | Status |
+|---|---|
+| MCP server the dashboard can scan | ✅ `https://mcp.t2000.ai/mcp` |
+| OAuth 2.1 per MCP authorization spec | ⚠️ **VERIFY at filing** — OpenAI expects discovery doc + (CIMD `none`/`private_key_jwt` or DCR) + `resource` param echoed into tokens; check Connect's OAuth server against that list and patch if a gap shows |
+| App name / logo / description | ✅ `../DESCRIPTION.md` + `brandkit/favicon-512-ember.png` / `logo-512-ember.png` |
+| Company + privacy URLs | ✅ `https://t2000.ai` · `https://t2000.ai/privacy` (+ terms) |
+| Test prompts + expected responses | ✅ prompts in `../DESCRIPTION.md`; founder adds expected outputs from live runs |
+| Web + mobile testing | ⚠️ **FOUNDER** — run the test prompts on ChatGPT web AND mobile in developer mode; note any card-render gaps honestly (machine JSON is always complete) |
+| Localization / country availability | Default English / broadly available — founder confirms in dashboard |
+| Screenshots (optional, UI apps) | Same live-capture rule as Anthropic — reuse `../screenshots/` set if formats fit |
+
+## Written blockers (the honest list)
+
+1. **Developer dashboard account/verification** — founder identity.
+2. **Commerce/financial policy** — an app that moves real USDC may sit
+   outside current app-directory policy or need extra review; answer
+   honestly (limits, ask-above, revoke, non-custodial framing) and accept
+   that the outcome is OpenAI's call. If rejected on policy, developer-mode
+   remains the documented ChatGPT path.
+3. **OAuth 2.1 conformance check** (above) — possible small server patch.
+4. Web + mobile test pass needs the founder's ChatGPT account.


### PR DESCRIPTION
## Program 5 (S.916) — Official connector directories: docs + submission pack

Distribution, not product. Production Connect (S.902–S.914) is what gets listed; this PR ships the per-host docs and the filing packages. **Filing itself is founder ops** — both portals require the founder's human account; per the Program 5 acceptance the status is recorded as ready-to-file / blocked-with-written-reason.

### Docs — `passport-connect.mdx`
- **New "Add Connect to your client"**: Claude custom connector · ChatGPT developer mode (Apps SDK directory listing is a separate submission) · Cursor/generic remote MCP JSON. One endpoint everywhere (`https://mcp.t2000.ai/mcp`), no stdio.
- **Spend-table drift fixed to S.914 truth**: `t2000_job_settle` gets its own **"releases escrow (no new debit)"** row (full escrow − fee, no partial); free row completed (cancel · decline · review · resolve); permissionless-release-after-window note; sends line gains `name@audric`.
- **New "For directory listings"** table: every field a host form asks for — endpoint, OAuth, docs, privacy/terms (live since S.915), support, company.

### `brandkit/connect-directory/` — the pack
Assets are **referenced** from `brandkit/` (SSOT — no binary copies).
- `README.md` — canonical names/copy/links, asset→slot table, founder screenshot shot-list (live claude.ai only, ≥1000px, response-only crop per Anthropic spec), status table.
- `DESCRIPTION.md` — tagline (54 chars), short + full (≤2000) descriptions, 4 example prompts, use-case answers. Money copy is the leash truth — never "send disabled".
- `anthropic/CHECKLIST.md` — the **real portal** (claude.ai admin-settings submission portal; requirements verified against claude.com/docs on 2026-08-05) with all 11 steps pre-answered. Honest blockers: **Team/Enterprise org** + founder session, live screenshots, funded reviewer test account, possible tool-annotation patch (portal flags them live), and the **financial-transactions policy acknowledgment** as the real review risk.
- `openai/CHECKLIST.md` — Apps SDK dashboard path; notes what works **today** (developer mode, same URL); blockers include the OAuth 2.1 conformance check and commerce policy.
- `CARD-AUDIT-2026-08-05.md` — dated card matrix, reviewer invariants (machine JSON always complete, floored money, canonical hashes), and host-side gaps. Documentation only — no shell/height work re-opened.

### Also
`PRODUCT.md` Distribution row updated to the S.916 status.

### Verification
- Greps clean: no "send denied/stays denied/blocked" as a live claim anywhere in Program 5 docs/pack (only meta-references explaining the lore is dead); `mcp.t2000.ai/mcp` is the only Connect endpoint in public docs.
- Anthropic + OpenAI submission paths researched from primary sources at Build date, not invented.

Companion audric PR fixes the last two live "send blocked" strings in the console Connect modal + adds the docs link.

Sources: [Anthropic submission docs](https://claude.com/docs/connectors/building/submission) · [Connectors Directory FAQ](https://support.claude.com/en/articles/11596036-anthropic-connectors-directory-faq) · [OpenAI app submission guidelines](https://developers.openai.com/apps-sdk/app-submission-guidelines) · [OpenAI: developers can submit apps](https://openai.com/index/developers-can-now-submit-apps-to-chatgpt/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
