### PR TITLE
✨ feat(sdk): probeX402 — read half of the x402 pay split (S.919)

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,8 @@ export { T2000 } from './t2000.js';
 export type { TransactionSigner } from './signer.js';
 export { KeypairSigner } from './wallet/keypairSigner.js';
 export { ZkLoginSigner, type ZkLoginProof } from './wallet/zkLoginSigner.js';
-export { payWithX402, preflightPay } from './wallet/pay.js';
+export { payWithX402, preflightPay, probeX402 } from './wallet/pay.js';
+export type { X402Probe } from './wallet/pay.js';
 export {
   DEFAULT_ACTIVITY_REPORT_URL,
   reportX402Activity,

--- a/packages/sdk/src/t2000.ts
+++ b/packages/sdk/src/t2000.ts
@@ -17,7 +17,7 @@ import type { SerializedCetusRoute, SwapRouteResult } from './protocols/cetus-sw
 import type { TransactionSigner } from './signer.js';
 import { KeypairSigner } from './wallet/keypairSigner.js';
 import { executeTx } from './wallet/executeTx.js';
-import { payWithX402 } from './wallet/pay.js';
+import { payWithX402, probeX402, type X402Probe } from './wallet/pay.js';
 import { ZkLoginSigner, type ZkLoginProof } from './wallet/zkLoginSigner.js';
 import { buildSendTx } from './wallet/send.js';
 import { queryBalance } from './wallet/balance.js';
@@ -168,6 +168,16 @@ export class T2000 extends EventEmitter<T2000Events> {
   }
 
   // -- MPP Payments --
+
+  /**
+   * READ-ONLY price probe for an x402 endpoint (S.919). Reports what `pay()`
+   * would cost without signing or spending, so a caller (Connect's
+   * `t2000_pay_probe`, the CLI, a UI) can show terms before committing.
+   * No limit gate: nothing moves.
+   */
+  async payProbe(options: PayOptions): Promise<X402Probe> {
+    return await probeX402({ network: this.client.network, options });
+  }
 
   async pay(options: PayOptions): Promise<PayResult> {
     // Gate on the maxPrice ceiling pre-flight (USD); record the ACTUAL cost

--- a/packages/sdk/src/wallet/pay.test.ts
+++ b/packages/sdk/src/wallet/pay.test.ts
@@ -58,7 +58,7 @@ vi.mock('@mysten/sui/transactions', () => ({
   },
 }));
 
-import { payWithX402 } from './pay.js';
+import { payWithX402, probeX402 } from './pay.js';
 
 const USDC_TYPE = '0xusdc::usdc::USDC';
 
@@ -621,5 +621,94 @@ describe('payWithX402 — content-type defaulting', () => {
 
     const [, init] = fetchMock.mock.calls[0];
     expect(init.headers).toBeUndefined();
+  });
+});
+
+// --- S.919: probeX402 — the READ half of the pay split -----------------------
+// The probe must mirror every payWithX402 branch WITHOUT signing or spending,
+// so the portal's read tool can never promise terms the write tool refuses.
+describe('probeX402 — read-only price probe', () => {
+  const opts = { url: 'https://paid.example/x' };
+
+  it('reports a payable price without signing or spending', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ status: 402, body: x402Accepts('20000') }));
+
+    const probe = await probeX402({ network: 'mainnet', options: opts });
+
+    expect(probe).toEqual({
+      kind: 'payable',
+      priceUsdc: 0.02,
+      asset: USDC_TYPE,
+      payTo: '0xtreasury',
+      network: 'mainnet',
+    });
+    // ONE request, and nothing was ever signed.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(buildX402Mock).not.toHaveBeenCalled();
+    expect(executeTxMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a free endpoint as free (no 402, no payment)', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ status: 200, body: { ok: true } }));
+
+    const probe = await probeX402({ network: 'mainnet', options: opts });
+
+    expect(probe.kind).toBe('free');
+    expect(probe).toMatchObject({ status: 200 });
+    expect(buildX402Mock).not.toHaveBeenCalled();
+  });
+
+  it('classifies an escrow-intent 402 as escrow, not payable', async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        status: 402,
+        body: {
+          accepts: [
+            {
+              scheme: 'exact',
+              network: 'sui:mainnet',
+              asset: USDC_TYPE,
+              maxAmountRequired: '5000000',
+              payTo: '0xjobseller',
+              resource: 'https://seller.example/jobs/report',
+              maxTimeoutSeconds: 60,
+              extra: {
+                escrow: { deliverWithinMs: 86_400_000, reviewWindowMs: 3_600_000, rejectSplitBps: 8000 },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const probe = await probeX402({ network: 'mainnet', options: opts });
+
+    expect(probe.kind).toBe('escrow');
+    expect(probe).toMatchObject({ priceUsdc: 5, payTo: '0xjobseller' });
+  });
+
+  it('reports the header-only MPP dialect as unsupported (never payable)', async () => {
+    fetchMock.mockResolvedValueOnce(jmprShaped402(true));
+
+    const probe = await probeX402({ network: 'mainnet', options: opts });
+
+    expect(probe.kind).toBe('unsupported');
+    expect(probe).toMatchObject({ reason: 'header-only-402-unsupported' });
+  });
+
+  it('reports an incomplete x402 challenge instead of a price', async () => {
+    fetchMock.mockResolvedValueOnce(jmprShaped402(false));
+
+    const probe = await probeX402({ network: 'mainnet', options: opts });
+
+    expect(probe.kind).toBe('incomplete');
+    expect(probe).toMatchObject({ reason: 'incomplete-x402-accepts' });
+  });
+
+  it('still throws on invalid input — a URL that could never be paid', async () => {
+    await expect(
+      probeX402({ network: 'mainnet', options: { url: 'not-a-url' } }),
+    ).rejects.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/wallet/pay.ts
+++ b/packages/sdk/src/wallet/pay.ts
@@ -67,19 +67,114 @@ export function preflightPay(input: { url: string; maxPrice?: number }): Preflig
 // unrelated to any package dependency.
 // ---------------------------------------------------------------------------
 
-export async function payWithX402(args: {
-  signer: TransactionSigner;
-  client: SuiGrpcClient;
-  options: PayOptions;
-}): Promise<PayResult> {
-  const { signer, client } = args;
-  let options = args.options;
+/**
+ * What a paid call WOULD cost, without paying (S.919). Every branch mirrors
+ * a `payWithX402` outcome so the probe can never promise something the pay
+ * path then refuses — one dialect story, not two.
+ */
+export type X402Probe =
+  | { kind: 'free'; status: number; note: string }
+  | {
+      kind: 'payable';
+      priceUsdc: number;
+      asset: string;
+      payTo: string;
+      network: string;
+    }
+  | { kind: 'escrow'; priceUsdc: number; payTo: string; note: string }
+  | { kind: 'unsupported'; reason: string; note: string }
+  | { kind: 'incomplete'; reason: string; note: string }
+  | { kind: 'not-x402'; status: number; note: string };
 
-  // Layer 2 — cheap synchronous preflight (URL shape + maxPrice sanity) before
-  // any network round-trip. Rethrow the precise code+message verbatim.
-  const pf = preflightPay({ url: options.url, maxPrice: options.maxPrice });
+/**
+ * READ-ONLY x402 probe: issue the same request `pay()` would, read the 402,
+ * and report the terms. Never signs, never spends, never throws on a
+ * non-payable answer — an unpayable endpoint is information, not a failure.
+ * (Invalid input still throws, exactly as `pay()` would, so a caller can't
+ * probe a URL that could never be paid.)
+ */
+export async function probeX402(args: {
+  network: string;
+  options: PayOptions;
+}): Promise<X402Probe> {
+  const { network } = args;
+  const pf = preflightPay({ url: args.options.url, maxPrice: args.options.maxPrice });
   if (!pf.valid) throw new T2000Error(pf.code, pf.error);
 
+  const { reqInit } = normalizePayRequest(args.options);
+  const probe = await fetch(args.options.url, reqInit);
+  if (probe.status !== 402) {
+    return {
+      kind: 'free',
+      status: probe.status,
+      note: 'No payment required — this endpoint served without a 402.',
+    };
+  }
+
+  const pick = await pickSuiExactRequirements(probe, network);
+  if (pick.kind === 'payable') {
+    const requirements = pick.requirements;
+    const priceUsdc = atomicToHuman(
+      BigInt(requirements.maxAmountRequired),
+      await assetDecimals(requirements.asset),
+    );
+    const { isX402EscrowRequirements } = await import('@t2000/sui-x402');
+    if (isX402EscrowRequirements(requirements)) {
+      return {
+        kind: 'escrow',
+        priceUsdc,
+        payTo: requirements.payTo,
+        note:
+          'This endpoint sells deliverable work through on-chain escrow, not an instant call. ' +
+          'Hire it as a job instead — funds lock in a Job object and release on delivery.',
+      };
+    }
+    return {
+      kind: 'payable',
+      priceUsdc,
+      asset: requirements.asset,
+      payTo: requirements.payTo,
+      network,
+    };
+  }
+
+  if (hasPaymentAuthenticateHeader(probe)) {
+    return {
+      kind: 'unsupported',
+      reason: 'header-only-402-unsupported',
+      note:
+        'This seller answered a header-only 402 (WWW-Authenticate: Payment) with no payable ' +
+        'x402 accepts[] envelope. That dialect is no longer supported — the seller must offer ' +
+        'x402 (e.g. @t2000/serve emits it).',
+    };
+  }
+  if (pick.kind === 'incomplete') {
+    return {
+      kind: 'incomplete',
+      reason: 'incomplete-x402-accepts',
+      note:
+        "Seller's x402 challenge is incomplete (missing extra.suimpp) — the 402 advertises an " +
+        'exact/sui entry but carries no settlement challenge to bind a payment to.',
+    };
+  }
+  return {
+    kind: 'not-x402',
+    status: probe.status,
+    note:
+      `Endpoint returned 402 without an x402 'exact' / sui:${network} requirement in the body. ` +
+      'Nothing this SDK can pay.',
+  };
+}
+
+/**
+ * Shared request shaping for probe + pay so both legs send the SAME bytes —
+ * a probe that differed from the paid retry would report the wrong price.
+ */
+function normalizePayRequest(input: PayOptions): {
+  options: PayOptions;
+  reqInit: RequestInit;
+} {
+  let options = input;
   const method = (options.method ?? 'GET').toUpperCase();
   const canHaveBody = method !== 'GET' && method !== 'HEAD';
 
@@ -100,11 +195,33 @@ export async function payWithX402(args: {
     };
   }
 
-  const reqInit: RequestInit = {
-    method,
-    headers: options.headers,
-    body: canHaveBody ? options.body : undefined,
+  return {
+    options,
+    reqInit: {
+      method,
+      headers: options.headers,
+      body: canHaveBody ? options.body : undefined,
+    },
   };
+}
+
+export async function payWithX402(args: {
+  signer: TransactionSigner;
+  client: SuiGrpcClient;
+  options: PayOptions;
+}): Promise<PayResult> {
+  const { signer, client } = args;
+  let options = args.options;
+
+  // Layer 2 — cheap synchronous preflight (URL shape + maxPrice sanity) before
+  // any network round-trip. Rethrow the precise code+message verbatim.
+  const pf = preflightPay({ url: options.url, maxPrice: options.maxPrice });
+  if (!pf.valid) throw new T2000Error(pf.code, pf.error);
+
+  // Shared with `probeX402` (S.919) so both legs send identical bytes.
+  const normalized = normalizePayRequest(options);
+  options = normalized.options;
+  const reqInit = normalized.reqInit;
 
   // Probe (no payment). A paid endpoint answers 402; a free/cached one serves.
   const probe = await fetch(options.url, reqInit);


### PR DESCRIPTION
The SDK half of splitting `t2000_pay` into probe (read) + pay (write), which Anthropic's directory step 3 asks for. Connect already solved this shape for swaps (`t2000_swap_quote` read + `t2000_swap` write) — x402 gets the same treatment, and the probe lives in the SDK so CLI / console / Connect can't drift into three dialect stories.

### `probeX402({ network, options })`
Issues the same request `pay()` would and reports what it found, **without signing or spending**:

| kind | meaning |
|---|---|
| `free` | no 402 — the endpoint just serves |
| `payable` | `priceUsdc` (via the existing `atomicToHuman` + `assetDecimals`), asset, payTo, network |
| `escrow` | escrow-intent 402 — terms, not an instant challenge; route to a job |
| `unsupported` / `incomplete` / `not-x402` | header-only MPP, missing `extra.suimpp`, no sui entry |

Non-payable answers **return rather than throw** — for a read tool, "you can't pay this" is information, not a failure. Invalid input still throws, so a caller can't probe a URL `pay()` would reject outright.

### No second dialect story
Every branch and message is lifted from `payWithX402`. I also extracted **`normalizePayRequest`** so probe and pay send **identical bytes** (method, JSON content-type default, body) — a probe that differed from the paid retry would report the wrong price. `payWithX402` now calls it too, so the shaping can't fork.

Exposed as `T2000.payProbe()` (no limit gate — nothing moves) and barrel-exported with the `X402Probe` type.

### Tests
6 new cases on the existing pay harness, reusing its live-incident fixtures: payable price with `buildX402SignedPayment` **and** `executeTx` asserted **never called**, free serve, escrow classification, the JMPR header-only shape, incomplete `accepts[]`, and invalid-input throw with zero fetches. **SDK suite 551 green**; build + typecheck clean.

Companion audric PR (the `t2000_pay_probe` tool + card) follows after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)