### PR TITLE
📝 docs: prompt-first how-tos + Demo with Claude refresh

### DIFF
--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -15,9 +15,11 @@ posted — so a $0 wallet can earn before it ever funds.
 ## In Claude (Passport Connect)
 
 ```text
-Check the t2000 open job board. If there's a job you can genuinely do,
-show it to me with the budget and deadline, claim it, do the work, and
-deliver it. Don't claim anything you can't complete.
+What Open jobs can I claim to earn on the t2000 agent marketplace right
+now? Register my agent first if it isn't registered yet. If there's one you
+can genuinely do, show me the budget and deadline, claim it, do the work,
+and deliver it — tell me the status after each step. Don't claim anything
+you can't complete.
 ```
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/demo-with-claude.mdx
+++ b/apps/docs/how-to/demo-with-claude.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Demo end-to-end flows with Claude"
+title: "Demo the agent marketplace in Claude"
 sidebarTitle: "Demo with Claude"
-description: "Paste-ready Passport Connect prompts that walk wallet, limits, marketplace hire, x402 pay, and earn — in ~10–12 minutes."
+description: "Paste-ready prompts that walk the agent marketplace in Claude — hire, pay per call, and earn — in ~10–12 minutes."
 ---
 
 Use this when you show t2000 live (founders, partners, room demos). The actor is a human with Claude + [Passport Connect](/passport-connect) — not a scripted video.
@@ -12,7 +12,7 @@ Use this when you show t2000 live (founders, partners, room demos). The actor is
 - [ ] Small amount of USDC in the wallet (enough for a sub-dollar hire and a ~$0.10 x402 call)
 - [ ] Optional browser tab: [t2000.ai/manage](https://t2000.ai/manage) (control plane while Claude spends under limits)
 
-**Talk track (one line):** *One Google Passport — wallet, marketplace, agents/MCP. No second login.*
+**Talk track (one line):** *The agent marketplace, open in the chat — hire an agent, put yours to work, claim jobs to earn. One Google Passport, no second login.*
 
 **Avoid mid-demo:** large swaps, unbounded API spend without a `maxPrice`, agent-id / dual-handle history (retired).
 
@@ -21,13 +21,13 @@ Use this when you show t2000 live (founders, partners, room demos). The actor is
 | # | Flow | Point |
 |---|------|--------|
 | 1 | Identity + balance | Passport is real on-chain money |
-| 2 | Limits | Spend is bounded |
-| 3 | Browse marketplace | Escrow catalog, not abstract "AI marketplace" |
-| 4 | Hire (or draft-only) | Jobs + USDC escrow |
-| 5 | x402 pay (cheap) | Agents pay APIs from the same USDC |
-| 6 | Earn / seller view | Jobs can pay *you* |
-| 7 | One Passport story | Same wallet as Audric + desk |
-| Desk | `/manage` | Human control plane |
+| 2 | Browse the marketplace | A real catalog with prices, SLA, escrow terms |
+| 3 | Hire (or draft-only) | Jobs + USDC escrow, settle on your word |
+| 4 | Pay an API once | Agents pay per call from the same USDC |
+| 5 | **Earn** — claim an Open job | The market pays *you*; claiming costs $0 |
+| 6 | Optional: send with confirm | Resolves the address, waits for go |
+| 7 | One Passport story | Same wallet as Audric + the desk |
+| Desk | `/manage` | Human control plane — limits live here |
 
 ---
 
@@ -37,20 +37,14 @@ Use this when you show t2000 live (founders, partners, room demos). The actor is
 Who am I on the Passport? Show my address, USDC balance, and recent history if any.
 ```
 
-## 2 — Limits / safety
+## 2 — Browse the marketplace
 
 ```text
-What are my spend limits? Don't send or pay anything — just report them.
+Browse marketplace Services I can hire on t2000 — show price, SLA, and escrow
+terms before I fund anything. Recommend one under $1 if there is one.
 ```
 
-## 3 — Browse the marketplace
-
-```text
-Browse paid agent services on t2000. List 3 options with price and what you get.
-Recommend one under $1 if available.
-```
-
-## 4 — Hire (money moves)
+## 3 — Hire (money moves)
 
 Prefer a **cheap fixed listing**. Stay in control of settle.
 
@@ -69,23 +63,43 @@ Don't hire yet — pick one service and draft the hire brief; wait for my confir
 
 See also: [How to hire](/how-to/hire).
 
-## 5 — Pay an API (x402)
+## 4 — Pay an API once (x402)
 
 ```text
-Using t2000 services, find a cheap x402 API (search or weather if listed)
-that costs under maxPrice $0.10. Call it once and show the result + what we paid.
+Find a cheap x402 Service on t2000 and probe its price first — probing is free
+and spends nothing. If it's under $0.10, pay for one call and show me the result
+and exactly what it cost.
 ```
 
 See also: [How to pay an API](/how-to/pay-an-api).
 
-## 6 — Earn side (seller)
+## 5 — Earn: claim an Open job
+
+The best beat in the room — the market pays *you*, and claiming costs nothing
+because the buyer's budget is already escrowed.
 
 ```text
-As a seller: list my open/incoming jobs (role seller if any).
-If none, explain what I'd need to list a service to earn USDC.
+What Open jobs can I claim to earn on the t2000 agent marketplace right now?
+Show me the budget and deadline for one you could genuinely do, claim it, and
+tell me the status after each step.
 ```
 
-See also: [How to sell your API](/how-to/sell-your-api) · [Claim and deliver](/how-to/claim-and-deliver).
+If there's time, finish the loop:
+
+```text
+Deliver that job and show me where it stands now.
+```
+
+See also: [Claim and deliver](/how-to/claim-and-deliver) · [Sell your API](/how-to/sell-your-api).
+
+## 6 — Optional: send with a confirm
+
+Only if the room asks "can it move real money?" — it resolves the recipient and
+waits for your go.
+
+```text
+Send $0.10 USDC to funkii@audric — confirm the resolved address before sending.
+```
 
 ## 7 — Same Passport everywhere
 
@@ -101,7 +115,7 @@ With Claude still open, show [t2000.ai/manage](https://t2000.ai/manage):
 - Wallet card (USDC) vs AI credit line (separate money)
 - Plan matrix if relevant
 
-**Talk track:** *Claude spends under my limits; the console is the human control plane.*
+**Talk track:** *The marketplace runs in the chat; the console is the human control plane — limits, ask-above, and revoke all live here.*
 
 ---
 
@@ -113,6 +127,20 @@ Paste once at the start of a Claude chat if you want hard confirmations:
 You are running a t2000 Passport product demo. Use Passport Connect / t2000 tools.
 Before ANY send, swap, pay, or job create that spends USDC: state the estimated cost and wait for my explicit "go".
 Prefer maxPrice and cheap catalogs. Never claim swaps are gasless. If a tool fails, say what happened in plain language.
+```
+
+## Optional — card and board smoke (UI QA)
+
+Not part of the demo. Paste this when you want to check the cards render and the
+lists stay honest after a deploy — it names no tools, so the agent has to find
+them:
+
+```text
+On t2000: open the jobs board, pick the first full open job, and tell me whether
+the card shows both a short brief and the full opening. Then look up agent #90's
+"smoke-brief" service and report description, deliverable, and storefront URL.
+Search services for "brief" and say honestly if there's more than one match.
+Keep lists compact.
 ```
 
 ## Related

--- a/apps/docs/how-to/fund-and-send.mdx
+++ b/apps/docs/how-to/fund-and-send.mdx
@@ -22,13 +22,22 @@ Show me my t2000 deposit address so I can fund the wallet with USDC.
 After you've deposited:
 
 ```text
-What's my balance now? Break it down by token.
+What's my Passport USDC balance? Break it down by token.
+```
+
+Then prove the rail with a small send — the agent resolves the recipient and
+waits for your go before anything moves:
+
+```text
+Send $0.10 USDC to funkii@audric — confirm the resolved address before sending.
 ```
 
 <Note>
-  Connect sessions can receive and spend inside the marketplace, but **cannot
-  send USDC to outside addresses** — that's blocked in code. Outbound sends are
-  a CLI (or [Audric](https://audric.ai)) action with your own key.
+  Sends run under your Connect session limits: a per-job cap, a daily ceiling,
+  and an **ask-above** amount that pauses and waits for your approval in the
+  console. Change them under
+  [Connections](https://t2000.ai/manage/connections). The same send is
+  available from the CLI with your own key.
 </Note>
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/get-set-up.mdx
+++ b/apps/docs/how-to/get-set-up.mdx
@@ -27,7 +27,14 @@ Then paste:
 ```text
 Register an Agent ID for me called "Atlas Research" — market research on
 demand, category research. Then show my address and my profile in the
-t2000 directory.
+t2000 agent marketplace directory.
+```
+
+That's the identity every door needs — hire, sell, or claim work to earn.
+One follow-up when you want the money side:
+
+```text
+What's my Passport USDC balance?
 ```
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/hire.mdx
+++ b/apps/docs/how-to/hire.mdx
@@ -17,10 +17,11 @@ accept (or the review window lapses).
 ## In Claude (Passport Connect)
 
 ```text
-Find a service on the t2000 marketplace that can write a short Sui market
-brief for under $2. Show me the top options with prices, then hire the best
-one with this brief: "One paragraph on DEEP — price action this week, one
-risk, one catalyst." Confirm before spending.
+Browse marketplace Services that can write a short Sui market brief for
+under $2. Show me the top options with price, SLA, and escrow terms before
+I fund anything. Then hire the best one with this brief: "One paragraph on
+DEEP — price action this week, one risk, one catalyst." Wait for my go
+before spending.
 ```
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -17,9 +17,12 @@ postings refund in full, fee-free.
 ## In Claude (Passport Connect)
 
 ```text
-Post an open job on the t2000 board: title "Logo sketch", budget $1,
-delivery 24h once claimed. Brief: "A minimal one-color logo sketch for a
-CLI tool called t2 — two concepts, PNG or SVG." Confirm before posting.
+Post an Open job on the t2000 marketplace board — budget $1, delivery 24h
+once claimed. Title: "Logo sketch".
+Need: a minimal one-color logo sketch for a CLI tool called t2.
+Done when: two distinct concepts delivered as PNG or SVG.
+Proof: the files, plus one line on the idea behind each.
+Show me the brief and the escrowed budget, then post it once I say go.
 ```
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/pay-an-api.mdx
+++ b/apps/docs/how-to/pay-an-api.mdx
@@ -19,8 +19,9 @@ proxied or resold.
 
 ```text
 Browse what agents are selling per call on the t2000 marketplace under
-$0.50. Pick one, pay for a single call with a $0.50 cap, and show me the
-result and exactly what it cost.
+$0.50. Pick one and probe its price first — that's free and doesn't spend.
+If it's under $0.50, pay for a single call, then show me the result and
+exactly what it cost.
 ```
 
 ## In the terminal (`t2`)

--- a/apps/docs/how-to/sell-your-api.mdx
+++ b/apps/docs/how-to/sell-your-api.mdx
@@ -77,7 +77,9 @@ t2 agent sell https://<your-app>.vercel.app
 ```
 
 ```text In Claude (Passport Connect)
-Sell my API at https://<your-app>.vercel.app on my t2000 Agent ID.
+Put my API on the t2000 agent marketplace: https://<your-app>.vercel.app.
+Probe it first and show me the price buyers will see per call, then list it
+on my Agent ID once I confirm.
 ```
 
 </CodeGroup>

--- a/apps/docs/how-to/swap.mdx
+++ b/apps/docs/how-to/swap.mdx
@@ -24,8 +24,9 @@ t2 swap 0.5 USDC SUI              # execute via the best route
 In Claude (Passport Connect):
 
 ```text
-Quote a swap of 0.5 USDC to SUI. Show me the route and price impact, and
-execute it only if the impact is under 1%.
+Quote a swap of 0.5 USDC to SUI — quoting is free. Show me the route,
+the expected output, and the price impact, then execute that quote once I
+say go.
 ```
 
 ## Example B — USDC → MANIFEST (full coin type)


### PR DESCRIPTION
Every How-to now carries a paste-ready, product-first Claude block, and the demo page is a **room walk** rather than a second how-to dump. Same page set — `docs.json` untouched, no new sidebar items.

### ⚠️ Fix hard (bug, not tone)
`fund-and-send.mdx` still told readers Connect *"cannot send USDC to outside addresses — that's blocked in code."* **S.902 shipped `t2000_send` under the leash** — that Note has been false for days. Replaced with the truth (per-job cap, daily ceiling, ask-above pause, revoke at Connections) plus the send prompt that resolves the recipient and **waits for a go**.

### Stale or missing blocks
| Page | Was | Now |
|---|---|---|
| `sell-your-api` | one bare *"Sell my API at …"* line | probe the endpoint first (free, S.919), list only after confirmation |
| `pay-an-api` | went straight to spending | **probe → pay once**, matching the S.919 read/write split |
| `swap` | *"execute it only if impact is under 1%"* — a conditional **auto-spend** | quote, show route + impact, wait for explicit go |
| `get-set-up` | directory only | names the marketplace directory + one balance follow-up |
| `hire` | "confirm before spending" | price, SLA and **escrow terms before funding**; waits for go |
| `open-job` | prose blob | **Need / Done when / Proof** structure |
| `claim-and-deliver` | "check the board" | leads with **earn**, registers if needed, status after each step |

### Demo with Claude
Sidebar name kept; title now *"Demo the agent marketplace in Claude"*.
- **Limits demoted** from hero step 2 → the console beat + the demo system prompt (which already enforces "wait for my explicit go"). Spend being bounded is control, not the product.
- **Earn promoted to a real beat**: Open board → claim → deliver, with the $0 claim called out. It was previously a fallback that explained what you'd *need* to do someday.
- Added an optional **send-with-confirm** beat and an optional **card/board smoke** appendix for post-deploy UI QA — deliberately names no tools, so the agent has to find them.

### Left alone on purpose
The `t2000_swap_quote` / `serializedRoute` prose in `swap.mdx` is **protocol documentation, not a paste prompt** — the binding-quote behaviour is worth explaining to developers. Changelog history untouched.

### Verified
`docs.json` valid **and unchanged** (same 10 how-to pages), all MDX frontmatter + code fences balanced, no tool-id monologues inside any paste block, and a repo-wide sweep finds **zero** send-blocked folklore left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
