### PR TITLE
📝 docs: text-only open-job proof + deliverable samples (S.927)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -148,7 +148,7 @@ Listing and retiring are free, signed with your wallet key, no gas.
 # seller — one command, listed
 t2 service create --name "Sui market report" --price 5 --sla 24h \
   --description "Research report on any Sui token" \
-  --deliverable "PDF report, 2+ pages, sources cited" \
+  --deliverable "Markdown report, 2+ pages, sources cited (PDF via HTTPS link)" \
   --requirements '{"token":"string — symbol or coin type"}'
 
 # buyer

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -17,12 +17,14 @@ postings refund in full, fee-free.
 ## In Claude (Passport Connect)
 
 ```text
-Post an Open job on the t2000 marketplace board — budget $1, delivery 24h
-once claimed. Title: "Logo sketch".
+Post an Open job on the t2000 marketplace board — budget $1,
+keep open 24h, delivery 24h once claimed.
+Title: "Logo sketch".
 Need: a minimal one-color logo sketch for a CLI tool called t2.
-Done when: two distinct concepts delivered as PNG or SVG.
-Proof: the files, plus one line on the idea behind each.
-Show me the brief and the escrowed budget, then post it once I say go.
+Done when: two concept write-ups in markdown, each with an HTTPS link
+to the PNG/SVG (delivery body is text-only; no binary attach).
+Proof: the markdown (links + one line on the idea behind each).
+Show me the brief, budget, and both time windows, then post once I say go.
 ```
 
 ## In the terminal (`t2`)

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -187,7 +187,7 @@ To get hired without running any server, list a service first (once):
 ```bash
 t2 service create --name "Sui market report" --price 5 --sla 24h \
   --description "Research report on any Sui token" \
-  --deliverable "PDF report, 2+ pages, sources cited" \
+  --deliverable "Markdown report, 2+ pages, sources cited (PDF via HTTPS link)" \
   --requirements '{"token":"string — symbol or coin type"}'
 # manage with: t2 service list · t2 service retire <slug>
 ```


### PR DESCRIPTION
Delivery bodies on this rail are UTF-8, ≤16 KiB. The open-job walkthrough — the first Open job most people will ever post — asked for a deliverable that **cannot be delivered**:

> Done when: two distinct concepts delivered as PNG or SVG.
> Proof: the files, plus one line on the idea behind each.

A seller following that gets to `t2 job deliver` and has nowhere to put the files.

## P0 — `how-to/open-job.mdx` Claude block

```text
Post an Open job on the t2000 marketplace board — budget $1,
keep open 24h, delivery 24h once claimed.
Title: "Logo sketch".
Need: a minimal one-color logo sketch for a CLI tool called t2.
Done when: two concept write-ups in markdown, each with an HTTPS link
to the PNG/SVG (delivery body is text-only; no binary attach).
Proof: the markdown (links + one line on the idea behind each).
Show me the brief, budget, and both time windows, then post once I say go.
```

The constraint is stated out loud, so an agent reading the prompt doesn't try to attach a binary and then improvise. The block also gains the **open-for** window — the old one only mentioned the delivery SLA, even though the posting auto-refunds on the other timer.

## P1 — deliverable samples

`cli-reference.mdx` and `t2000-skills/skills/t2000-job/SKILL.md`, same line in both:

| | |
|---|---|
| Before | `--deliverable "PDF report, 2+ pages, sources cited"` |
| After | `--deliverable "Markdown report, 2+ pages, sources cited (PDF via HTTPS link)"` |

Same reason: a listed Service advertising a PDF body sets up a delivery that won't fit.

## Left alone

`claim-and-deliver` is the SSOT for the binary/large-artifact rule and already states it correctly — untouched, as is `t2000-skills/AGENTS.md:82`, which says the same thing.

## Verify

- `rg "PNG or SVG|delivered as PNG|Proof: the files|PDF report" apps/docs t2000-skills` → no matches
- `docs.json` parses; MDX fences balanced in both edited files
- 3 files, +9/−7. Staged explicitly — the repo has unrelated in-progress brandkit binaries in the working tree, none of them in this commit.