### PR TITLE
✨ feat(cli): resolve agent #id on hire (S.929)

### DIFF
--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -19,6 +19,7 @@
 // sponsorship never weakens it). Reads are direct RPC.
 
 import { createHash } from 'node:crypto';
+import { expandAgentRefs, resolveAgentRef } from '../lib/agent-ref.js';
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
 import pc from 'picocolors';
@@ -247,7 +248,10 @@ no fund step; unclaimed openings refund fee-free):
     .argument('[seller]', "The ASP's Sui address (omit when hiring a --service listing)")
     .description('Hire — fund an escrow job in one transaction (buyer): a listing (--agent + --service) or your own terms (amount + seller + --spec)')
     .option('--spec <file-or-text>', 'Job spec — a file path or inline text (UPLOADED so the seller can read it; sha256 pinned on-chain), or a bare 0x… sha256 (confidential: pins without uploading)')
-    .option('--agent <address>', "Hire a listing: the ASP's agent address")
+    .option(
+      '--agent <address|#id|@handle>',
+      "Hire a listing: the ASP's agent address, #id, or @handle",
+    )
     .option('--service <slug>', 'The service slug (see t2 services / t2 service list <agent>)')
     .option('--requirements <file-or-json-or-text>', 'What the seller asked buyers to provide — if the listing lists JSON keys, fill EVERY key (JSON object; extra keys OK)')
     .option('--deadline <duration>', 'Time the seller has to deliver (e.g. 30m, 24h, 7d)', '24h')
@@ -295,7 +299,12 @@ no fund step; unclaimed openings refund fee-free):
                 'Omit the amount/seller arguments when buying a service — the listing sets the price and the seller.',
               );
             }
-            const sellerAgent = validateAddress(opts.agent);
+            // Same ingress the site accepts (S.929): `#93` / `93` / `@handle`
+            // / `0x…`. Resolved BEFORE the service fetch, so an unknown id
+            // fails as a sentence and never reaches a prepare or a signature.
+            const sellerAgent = validateAddress(
+              (await resolveAgentRef(base, opts.agent)).address,
+            );
             const service = await fetchService(base, sellerAgent, serviceSlugOpt);
             serviceSlug = service.slug;
 
@@ -313,6 +322,11 @@ no fund step; unclaimed openings refund fee-free):
                 requirements = text.trim();
               }
             }
+            // Requirement values that NAME an agent become addresses before
+            // anything is asserted or hashed — sellers built their tooling
+            // around `0x…` and must never decode what "#93" meant on the day
+            // the job was funded. Order: resolve, assert, freeze.
+            requirements = await expandAgentRefs(base, requirements);
             // The shared hire gate (SPEC_ACP_JOB_SPEC_V1 §4.1) — same
             // implementation as MCP + console hire-prepare, so a job can
             // never fund with an unusable brief.
@@ -353,7 +367,9 @@ no fund step; unclaimed openings refund fee-free):
             if (!Number.isFinite(amountUsdc) || amountUsdc <= 0) {
               throw new Error(`Amount must be a positive number (got "${amountArg}").`);
             }
-            seller = validateAddress(sellerArg);
+            seller = validateAddress(
+              (await resolveAgentRef(base, sellerArg)).address,
+            );
             // Uploads unless the input is already a 0x… sha256 — the bare
             // hash stays the confidential path (nothing leaves the machine).
             ({ hash: specHash } = await resolveSpecUpload(base, opts.spec));

--- a/packages/cli/src/lib/agent-ref.test.ts
+++ b/packages/cli/src/lib/agent-ref.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  agentRefFields,
+  expandAgentRefs,
+  isAgentRefField,
+  looksLikeAgentRefKey,
+  looksLikeAgentRefValue,
+  resolveAgentRef,
+} from './agent-ref.js';
+
+// The gate decides which buyer-typed values get swapped for a wallet address
+// in a spec that is about to be hashed and escrowed. Wrong in either
+// direction is silent and expensive: too loose and `{sla_hours:"24"}` freezes
+// as agent #24's address; too tight and the buyer is back on an explorer.
+//
+// These cases mirror audric `apps/console/lib/agent-ref.test.ts` one for one —
+// the gate is duplicated across repos (no `@audric/*` in the CLI), so the
+// tests are how the two stay in step.
+
+const FULL_ADDR = `0x${'a'.repeat(64)}`;
+
+describe('isAgentRefField (the resolve gate)', () => {
+  it('resolves hash-prefixed ids on any key', () => {
+    expect(isAgentRefField('notes', '#93')).toBe(true);
+    expect(isAgentRefField('anything_at_all', '#7')).toBe(true);
+  });
+
+  it('resolves bare digits ONLY on an agent-ish key', () => {
+    expect(isAgentRefField('agent_address', '93')).toBe(true);
+    expect(isAgentRefField('subject', '93')).toBe(true);
+    expect(isAgentRefField('pay_to', '93')).toBe(true);
+    // The regression this gate exists for.
+    expect(isAgentRefField('sla_hours', '24')).toBe(false);
+    expect(isAgentRefField('retries', '5')).toBe(false);
+    expect(isAgentRefField('score', '100')).toBe(false);
+  });
+
+  it('resolves full addresses anywhere, and lets the SERVER judge short hex', () => {
+    expect(isAgentRefField('notes', FULL_ADDR)).toBe(true);
+    // Reaches the resolver, which rejects it rather than zero-padding it
+    // into a wallet nobody owns.
+    expect(isAgentRefField('notes', '0x93')).toBe(true);
+  });
+
+  it('resolves @handles but never bare usernames', () => {
+    expect(isAgentRefField('notes', '@funkii')).toBe(true);
+    expect(isAgentRefField('agent_address', 'funkii')).toBe(false);
+  });
+
+  it('never touches free text, whatever the key is called', () => {
+    expect(isAgentRefField('address', '123 Main Street')).toBe(false);
+    expect(isAgentRefField('agent_address', 'the one from yesterday')).toBe(false);
+    expect(isAgentRefField('brief', 'Assess #93 and report back')).toBe(false);
+    expect(isAgentRefField('agent_address', '')).toBe(false);
+  });
+
+  it('keeps the value and key predicates independent', () => {
+    // Bare digits are not self-describing — that's the whole point.
+    expect(looksLikeAgentRefValue('93')).toBe(false);
+    expect(looksLikeAgentRefValue('#93')).toBe(true);
+    expect(looksLikeAgentRefKey('sla_hours')).toBe(false);
+    expect(looksLikeAgentRefKey('agent_address')).toBe(true);
+  });
+});
+
+describe('agentRefFields', () => {
+  it('picks only the resolvable entries', () => {
+    expect(
+      agentRefFields({
+        agent_address: '93',
+        sla_hours: '24',
+        notes: '#7',
+        brief: 'do the thing',
+      }),
+    ).toEqual([
+      ['agent_address', '93'],
+      ['notes', '#7'],
+    ]);
+  });
+
+  it('ignores non-object requirements', () => {
+    expect(agentRefFields('a free-text brief')).toEqual([]);
+    expect(agentRefFields(null)).toEqual([]);
+    expect(agentRefFields(['93'])).toEqual([]);
+  });
+});
+
+describe('resolveAgentRef (network)', () => {
+  const BASE = 'https://api.example.test/v1';
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('calls /agents/resolve and returns the address', async () => {
+    const fn = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ address: FULL_ADDR, numericId: 93, name: 'Aegis' }),
+    }));
+    vi.stubGlobal('fetch', fn);
+
+    await expect(resolveAgentRef(BASE, '#93')).resolves.toEqual({
+      address: FULL_ADDR,
+      numericId: 93,
+      name: 'Aegis',
+    });
+    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=%2393`);
+  });
+
+  it("throws the SERVER's sentence so CLI and site explain a miss identically", async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'No agent for #999999.' }),
+      })),
+    );
+    await expect(resolveAgentRef(BASE, '999999')).rejects.toThrow(
+      'No agent for #999999.',
+    );
+  });
+
+  it('does not pad short hex client-side — the server refuses it', async () => {
+    const fn = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({
+        error: 'Use an Agent ID (#93), a handle, or a 0x… address.',
+      }),
+    }));
+    vi.stubGlobal('fetch', fn);
+    await expect(resolveAgentRef(BASE, '0x93')).rejects.toThrow(/Agent ID/);
+    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=0x93`);
+  });
+});
+
+describe('expandAgentRefs', () => {
+  const BASE = 'https://api.example.test/v1';
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('writes back addresses and leaves everything else alone', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ address: FULL_ADDR }),
+      })),
+    );
+    await expect(
+      expandAgentRefs(BASE, {
+        agent_address: '93',
+        sla_hours: '24',
+        brief: 'assess it',
+      }),
+    ).resolves.toEqual({
+      agent_address: FULL_ADDR,
+      sla_hours: '24',
+      brief: 'assess it',
+    });
+  });
+
+  it('passes free-text requirements straight through, with no network call', async () => {
+    const fn = vi.fn();
+    vi.stubGlobal('fetch', fn);
+    await expect(expandAgentRefs(BASE, 'just a brief')).resolves.toBe(
+      'just a brief',
+    );
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('names the offending key when a ref misses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'No agent for #999999.' }),
+      })),
+    );
+    await expect(
+      expandAgentRefs(BASE, { agent_address: '999999' }),
+    ).rejects.toThrow('agent_address: No agent for #999999.');
+  });
+});

--- a/packages/cli/src/lib/agent-ref.ts
+++ b/packages/cli/src/lib/agent-ref.ts
@@ -1,0 +1,122 @@
+// "Which agent do you mean?" for the machine hire path (S.929).
+//
+// Parity with the site: a buyer naming another agent should be able to type
+// what's printed on the profile — `#93` — instead of opening an explorer.
+// The shapes accepted here are exactly the shapes t2000.ai accepts, and the
+// spec freezes the RESOLVED address either way, because sellers built their
+// tooling around `0x…` and must never decode what `#93` meant on funding day.
+//
+// The gate below is duplicated from audric `apps/console/lib/agent-ref.ts` on
+// purpose: the CLI cannot depend on `@audric/*`. Keep the two in step — the
+// unit tests here mirror the console's case-for-case.
+
+/** `#93` — the hash makes it unambiguous wherever it appears. */
+const HASH_ID_RE = /^#\d{1,10}$/;
+/** `93` — bare digits. Could equally be an SLA, a retry count or a score, so
+ *  these only count as an agent ref on an agent-ish KEY. */
+const BARE_DIGITS_RE = /^\d{1,10}$/;
+/** `@handle` — the `@` is required; bare usernames do not resolve. */
+const HANDLE_REF_RE = /^@[a-z0-9_-]{1,20}$/i;
+/** `0x…` — any hex. The SERVER decides if it's a real address; short hex is
+ *  rejected there rather than zero-padded into a wallet nobody owns. */
+const HEX_REF_RE = /^0x[0-9a-fA-F]+$/;
+/** Keys a seller plausibly means as "an agent / a wallet". */
+const AGENT_REF_KEY_RE =
+  /agent|address|wallet|subject|recipient|pay[_-]?to|target/i;
+
+const FALLBACK_MISS =
+  'Use an Agent ID (#93), @handle, or full 0x… address.';
+
+export type AgentRef = {
+  address: string;
+  numericId?: number | null;
+  name?: string;
+};
+
+/** Does the VALUE name an agent on its own, with no help from the field name? */
+export function looksLikeAgentRefValue(value: string): boolean {
+  const v = value.trim();
+  return HASH_ID_RE.test(v) || HANDLE_REF_RE.test(v) || HEX_REF_RE.test(v);
+}
+
+/** Does the KEY read like the seller wants an agent there? */
+export function looksLikeAgentRefKey(key: string): boolean {
+  return AGENT_REF_KEY_RE.test(key);
+}
+
+/** Resolve gate.
+ *
+ *  `#93`, `@handle` and `0x…` carry their own meaning and resolve anywhere.
+ *  Bare digits do not: `24` is an agent id on `agent_address` and an SLA on
+ *  `sla_hours`, so the KEY breaks that tie. Without it, `{sla_hours: "24"}`
+ *  would silently become agent #24's address in a frozen, escrowed spec. */
+export function isAgentRefField(key: string, value: string): boolean {
+  const v = value.trim();
+  if (looksLikeAgentRefValue(v)) {
+    return true;
+  }
+  return BARE_DIGITS_RE.test(v) && looksLikeAgentRefKey(key);
+}
+
+/** The agent-ref fields in an object-shaped requirements payload, as
+ *  [key, rawValue]. Free-text briefs yield nothing. */
+export function agentRefFields(requirements: unknown): [string, string][] {
+  if (
+    requirements == null ||
+    typeof requirements !== 'object' ||
+    Array.isArray(requirements)
+  ) {
+    return [];
+  }
+  return Object.entries(requirements as Record<string, unknown>)
+    .filter((e): e is [string, string] => typeof e[1] === 'string')
+    .filter(([k, v]) => isAgentRefField(k, v));
+}
+
+/** `#93` · `93` · `@handle` · `0x…` → the agent's wallet address.
+ *
+ *  One network hop to the same endpoint the site uses, so there is no second
+ *  source of truth for Agent ID numbers here. Throws with the server's own
+ *  sentence so the CLI and the site explain a miss identically. */
+export async function resolveAgentRef(
+  base: string,
+  q: string,
+): Promise<AgentRef> {
+  const res = await fetch(
+    `${base}/agents/resolve?q=${encodeURIComponent(q.trim())}`,
+  );
+  const json = (await res.json().catch(() => ({}))) as {
+    address?: string;
+    numericId?: number | null;
+    name?: string;
+    error?: string;
+  };
+  if (!(res.ok && json.address)) {
+    throw new Error(json.error ?? FALLBACK_MISS);
+  }
+  return { address: json.address, numericId: json.numericId, name: json.name };
+}
+
+/** Resolve every agent-ref value in a requirements object, returning a copy
+ *  with addresses written back. Non-objects pass through untouched. Throws on
+ *  the first miss — before anything is asserted, hashed or signed. */
+export async function expandAgentRefs(
+  base: string,
+  requirements: unknown,
+): Promise<unknown> {
+  const fields = agentRefFields(requirements);
+  if (fields.length === 0) {
+    return requirements;
+  }
+  const out = { ...(requirements as Record<string, unknown>) };
+  for (const [key, raw] of fields) {
+    try {
+      out[key] = (await resolveAgentRef(base, raw)).address;
+    } catch (e) {
+      throw new Error(
+        `${key}: ${e instanceof Error ? e.message : FALLBACK_MISS}`,
+      );
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
Machine parity for what [t2000.ai already accepts](https://github.com/mission69b/audric/pull/206). The endpoint is live, so this is built against a real one.

## What resolves now

| Call site | Accepts |
|---|---|
| `--agent` (listing hire) | `#93` · `93` · `@handle` · full `0x…` — resolved **before** `validateAddress` / `fetchService` |
| `t2 job hire <amount> <seller>` | same shapes |
| `--requirements` object | agent-ref values become addresses **before** assert + freeze |

Help now reads `--agent <address|#id|@handle>`.

One network hop to the same `/v1/agents/resolve` the site uses, so there's **no second source of truth for Agent ID numbers** here, and a miss surfaces the server's own sentence rather than a CLI paraphrase of it.

## The gate is copied, not shared — deliberately

The CLI can't depend on `@audric/*`, so `packages/cli/src/lib/agent-ref.ts` duplicates the console's rules. It carries the **S.928.1** rules, not the older value-only ones:

> bare digits resolve **only** on an agent-ish key — otherwise `{"sla_hours":"24"}` silently freezes as agent #24's address in an escrowed spec.

The 14 unit tests mirror `apps/console/lib/agent-ref.test.ts` case-for-case. That mirroring is how two copies stay in step; the comment in each file says so.

## Verified against the live endpoint, with the built binary

```
$ t2 job hire --agent 999999 --service anything
  ✗ No agent for #999999.                          ← before any prepare/sign

$ t2 job hire --agent 93 --service agent-trust-report
  ✗ This service needs a JSON requirements object with: agent_address…
     ↑ reached AEGIS's real listing, so `93` resolved and fetched by address

$ … --requirements '{"agent_address":"999999"}'
  ✗ agent_address: No agent for #999999.           ← expand ran, named the key

$ … --requirements '{"sla_hours":"24"}'
  ✗ Missing required field(s): agent_address…      ← "24" NOT resolved; the
     S.928.1 regression, proven on the real CLI

$ … --requirements '{"agent_address":"0x93"}'
  ✗ agent_address: Use an Agent ID (#93), a handle, or a 0x… address.
     ↑ short hex refused server-side, never padded

$ t2 job hire 1 999999 --spec …
  ✗ No agent for #999999.                          ← direct-mode seller too
```

`lint` · `typecheck` · `build` clean; **200 tests pass (15 files)**, 14 of them new.

## Not run

**No completed hire.** The happy path continues into `putJobSpec` → prepare → sign and spends real USDC, so I stopped at the negative probes plus the one that proves the listing was fetched by resolved address. The write-back value itself is covered by `expandAgentRefs` unit tests.

## Ship

**No version bump, no publish** — per the brief. Safe to merge ahead of a release: until then only monorepo / `pnpm` consumers see it. Founder runs the normal lockstep workflow.

Out of scope and untouched: S.930 signing safety, limits, fee disclosure, hire preflight/price print, 50 USDC cap, `t2 job claim` opening ids (object ids, not agent refs), service list, directory browse.