### PR TITLE
🔒 security(cli): pin API host + intent-check sponsored sign (S.930)

### DIFF
--- a/packages/cli/src/commands/agent/create.ts
+++ b/packages/cli/src/commands/agent/create.ts
@@ -167,6 +167,7 @@ export function registerAgentCreate(group: Command) {
             prepareUrl: `${base}/agent/owner/propose`,
             prepareBody: { address, owner },
             submitUrl: `${base}/agent/owner/submit`,
+            intent: { action: 'link' },
           });
           ownerProposed = true;
         }

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -17,6 +17,10 @@ import {
   parseCategory,
 } from '../../lib/agent-category.js';
 import { registerWallet, runSponsoredTx } from '../../lib/agent-register.js';
+import {
+  assertSigningHostAllowed,
+  isAllowUntrustedApi,
+} from '../../lib/tx-guard.js';
 import { withAgent } from '../../lib/with-agent.js';
 import { registerAgentCreate } from './create.js';
 import {
@@ -138,6 +142,7 @@ Subcommands:
           prepareUrl: `${base}/agent/owner/propose`,
           prepareBody: { address, owner },
           submitUrl: `${base}/agent/owner/submit`,
+          intent: { action: 'link' },
         });
         if (isJsonMode()) {
           printJson({ agent: address, pendingOwner: owner, digest });
@@ -174,6 +179,7 @@ Subcommands:
           prepareUrl: `${base}/agent/owner/confirm`,
           prepareBody: { owner: address, agent: agentAddress },
           submitUrl: `${base}/agent/owner/submit`,
+          intent: { action: 'confirm' },
         });
         if (isJsonMode()) {
           printJson({ owner: address, agent: agentAddress, digest });
@@ -207,6 +213,7 @@ Subcommands:
           prepareUrl: `${base}/agent/owner/renounce`,
           prepareBody: { owner: address, agent: agentAddress },
           submitUrl: `${base}/agent/owner/submit`,
+          intent: { action: 'confirm' },
         });
         if (isJsonMode()) {
           printJson({ owner: address, agent: agentAddress, unlinked: true, digest });
@@ -370,6 +377,12 @@ Subcommands:
 
           // Two-phase sponsored flow, inline (not runSponsoredTx) so a failed
           // probe surfaces its per-check findings, not just one message.
+          // Inline does NOT mean unguarded: the host pin still applies, and
+          // it has to run before the address is sent (S.930). Intent checking
+          // stops at the host for this verb — it calls the registry package,
+          // which is outside the escrow allowlist, so claiming to verify its
+          // shape here would be theatre.
+          assertSigningHostAllowed(base, isAllowUntrustedApi());
           const prepRes = await fetch(`${base}/agent/endpoint/prepare`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -19,6 +19,16 @@
 // sponsorship never weakens it). Reads are direct RPC.
 
 import { createHash } from 'node:crypto';
+import {
+  assertLimitConfig,
+  dailySpentToday,
+  getLimits,
+  LimitExceededError,
+  recordDailySpend,
+} from '@t2000/sdk';
+
+/** The shared limit error advertises `--force`; job verbs don't have it. */
+const FORCE_HINT_RE = /\s*Use --force[^.]*\.\s*$/;
 import { expandAgentRefs, resolveAgentRef } from '../lib/agent-ref.js';
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
@@ -191,16 +201,59 @@ async function sponsoredJobVerb(opts: {
   keyPath?: string;
   action: 'create' | 'decline' | 'deliver' | 'release' | 'reject' | 'refund';
   params: Record<string, unknown>;
+  /** USDC leaving THIS wallet, for the spending gate. Only `create` moves
+   *  buyer money out; the seller-side verbs settle escrow that is already
+   *  locked, so they pass nothing and are never counted. */
+  spendUsdc?: number;
+  seller?: string;
+  force?: boolean;
 }): Promise<{ address: string; digest?: string }> {
   const agent = await withAgent({ keyPath: opts.keyPath });
   const address = agent.address();
+
+  // Assert BEFORE the money leaves (S.930 C). The job path went through the
+  // sponsored rail rather than the SDK write path, so it inherited neither
+  // half of the gate: a $25 cap did not stop a hire, and a completed hire
+  // left "spent today" reading $0.00.
+  if (opts.spendUsdc !== undefined && opts.spendUsdc > 0) {
+    try {
+      assertLimitConfig({
+        limits: getLimits(),
+        spentTodayUsd: dailySpentToday(),
+        operation: 'send',
+        amountUsd: opts.spendUsdc,
+        force: opts.force,
+      });
+    } catch (e) {
+      // The shared gate's message offers `--force`, which the job verbs do
+      // not have (and this slice deliberately did not invent). Point at the
+      // door that actually exists rather than one that doesn't.
+      if (e instanceof LimitExceededError) {
+        throw new Error(
+          `${e.message.replace(FORCE_HINT_RE, '')} Raise the cap with \`t2 limit set\` — job verbs have no --force.`,
+        );
+      }
+      throw e;
+    }
+  }
+
   const { digest } = await runSponsoredTx({
     keypair: agent.keypair,
     actor: address,
     prepareUrl: `${opts.base}/job/prepare`,
     prepareBody: { address, action: opts.action, params: opts.params },
     submitUrl: `${opts.base}/job/submit`,
+    intent: {
+      action: opts.action,
+      amountUsdc: opts.spendUsdc,
+      seller: opts.seller,
+    },
   });
+
+  // Record only on a real digest — a failed hire must not eat the day's cap.
+  if (digest && opts.spendUsdc !== undefined && opts.spendUsdc > 0) {
+    recordDailySpend(opts.spendUsdc);
+  }
   return { address, digest };
 }
 
@@ -384,6 +437,9 @@ no fund step; unclaimed openings refund fee-free):
             keyPath: opts.key,
             action: 'create',
             params: { seller, amountUsdc, specHash, deliverByMs, reviewWindowMs, rejectSplitBps },
+            // The buyer's USDC leaves here — the one job verb that spends.
+            spendUsdc: amountUsdc,
+            seller,
           });
 
           // The job id comes off the created object — read it back via the

--- a/packages/cli/src/lib/agent-register.ts
+++ b/packages/cli/src/lib/agent-register.ts
@@ -1,3 +1,12 @@
+import {
+  assertSigningHostAllowed,
+  assertTxMatchesIntent,
+  describeIntent,
+  isAllowUntrustedApi,
+  type TxIntent,
+} from './tx-guard.js';
+import { printLine } from '../output.js';
+
 // Shared sponsored-registration helper (Agent ID B.1 gate 5b). Used by
 // `t2 agent register`, `t2 agent create`, and `t2 init`
 // (best-effort). Two-phase: prepare (server builds the sponsored tx) → the
@@ -39,13 +48,24 @@ export async function runSponsoredTx(opts: {
   prepareUrl: string;
   prepareBody: Record<string, unknown>;
   submitUrl: string;
+  /** What the user asked for. REQUIRED — the bytes are checked against it
+   *  before signing, and a caller with no intent cannot sign (S.930). */
+  intent: TxIntent;
 }): Promise<{ digest?: string }> {
+  const allowUntrusted = isAllowUntrustedApi();
+  // Before the wallet address is even sent anywhere.
+  assertSigningHostAllowed(opts.prepareUrl, allowUntrusted);
+
   const prep = await postJson(opts.prepareUrl, opts.prepareBody);
   const nonce = prep.nonce as string | undefined;
   const txBytes = prep.txBytes as string | undefined;
   if (!(nonce && txBytes)) {
     throw new Error('Failed to prepare the transaction.');
   }
+  // The server proposed; now check it proposed what we asked for.
+  assertTxMatchesIntent(txBytes, opts.intent, { allowUntrusted });
+  printLine(describeIntent(opts.intent, opts.prepareUrl));
+
   const bytes = new Uint8Array(Buffer.from(txBytes, 'base64'));
   const { signature } = await opts.keypair.signTransaction(bytes);
   const res = await postJson(opts.submitUrl, {
@@ -71,6 +91,8 @@ export async function registerWallet(opts: {
   address: string;
   base: string;
 }): Promise<RegisterResult> {
+  const allowUntrusted = isAllowUntrustedApi();
+  assertSigningHostAllowed(opts.base, allowUntrusted);
   const prep = await postJson(`${opts.base}/agent/register/prepare`, {
     address: opts.address,
   });
@@ -83,6 +105,7 @@ export async function registerWallet(opts: {
   if (!(regNonce && txBytes)) {
     throw new Error('Failed to prepare registration.');
   }
+  assertTxMatchesIntent(txBytes, { action: 'register' }, { allowUntrusted });
   const bytes = new Uint8Array(Buffer.from(txBytes, 'base64'));
   const { signature } = await opts.keypair.signTransaction(bytes);
   const res = await postJson(`${opts.base}/agent/register/submit`, {

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -1,0 +1,227 @@
+import { Transaction } from '@mysten/sui/transactions';
+import {
+  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+  MAINNET_A2A_ESCROW_PACKAGE_ID,
+} from '@t2000/sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runSponsoredTx } from './agent-register.js';
+import {
+  assertSigningHostAllowed,
+  assertTxMatchesIntent,
+  IntentMismatchError,
+  isDefaultApiHost,
+  setAllowUntrustedApi,
+  UntrustedHostError,
+} from './tx-guard.js';
+
+// The wallet must never produce a signature over bytes it did not verify.
+// Every test here is really the same assertion: on any doubt, `signTransaction`
+// is NOT called.
+
+const EVIL_PACKAGE = `0x${'e'.repeat(64)}`;
+
+async function buildTxB64(target: string): Promise<string> {
+  const tx = new Transaction();
+  tx.setSender(`0x${'1'.repeat(64)}`);
+  tx.setGasPrice(1000);
+  tx.setGasBudget(10_000_000);
+  tx.setGasPayment([
+    {
+      objectId: `0x${'2'.repeat(64)}`,
+      version: '1',
+      digest: '11111111111111111111111111111111',
+    },
+  ]);
+  tx.moveCall({ target, arguments: [] });
+  return Buffer.from(await tx.build()).toString('base64');
+}
+
+beforeEach(() => setAllowUntrustedApi(false));
+afterEach(() => {
+  setAllowUntrustedApi(false);
+  vi.unstubAllGlobals();
+});
+
+describe('A — API host pin', () => {
+  it('accepts the canonical host', () => {
+    expect(isDefaultApiHost('https://api.t2000.ai/v1')).toBe(true);
+    expect(() =>
+      assertSigningHostAllowed('https://api.t2000.ai/v1/job/prepare', false),
+    ).not.toThrow();
+  });
+
+  it('refuses a hijacked T2000_API_URL without the flag', () => {
+    expect(() =>
+      assertSigningHostAllowed('https://evil.example/v1/job/prepare', false),
+    ).toThrow(UntrustedHostError);
+  });
+
+  it('names the host and the escape hatch, and says to suspect an attack', () => {
+    try {
+      assertSigningHostAllowed('https://evil.example/v1', false);
+      expect.unreachable('should have refused');
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain('evil.example');
+      expect(msg).toContain('--allow-untrusted-api');
+      expect(msg).toContain('treat this as an attack');
+    }
+  });
+
+  it('allows a non-default host once the operator opts in', () => {
+    expect(() =>
+      assertSigningHostAllowed('http://localhost:3000/v1', true),
+    ).not.toThrow();
+  });
+});
+
+describe('A — the pin fires before the command body, not mid-flight', () => {
+  // Regression: the first cut only pinned inside runSponsoredTx, so `job hire`
+  // resolved an agent ref and uploaded a spec THROUGH the hijacked host before
+  // refusing to sign. Verified end-to-end against the built binary; this pins
+  // the ordering contract the fix relies on.
+  it('an injected T2000_API_URL is refusable with nothing but the env var', () => {
+    vi.stubEnv('T2000_API_URL', 'https://evil.example/v1');
+    expect(() =>
+      assertSigningHostAllowed(process.env.T2000_API_URL ?? '', false),
+    ).toThrow(UntrustedHostError);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('B — intent assert', () => {
+  it('signs a create that really is escrow::create', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+    );
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).not.toThrow();
+  });
+
+  it('refuses a call into a package we do not publish', async () => {
+    const b64 = await buildTxB64(`${EVIL_PACKAGE}::escrow::create`);
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      IntentMismatchError,
+    );
+  });
+
+  it('is NOT spoofable by overriding A2A_ESCROW_PACKAGE_ID', async () => {
+    // The attacker's whole play: supply the transaction AND the yardstick.
+    // The allowlist is built from MAINNET literals, so this changes nothing.
+    vi.stubEnv('A2A_ESCROW_PACKAGE_ID', EVIL_PACKAGE);
+    const b64 = await buildTxB64(`${EVIL_PACKAGE}::escrow::create`);
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      IntentMismatchError,
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it('refuses a function the verb never calls (deliver bytes under a create intent)', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::release`,
+    );
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      /should call escrow::create/,
+    );
+  });
+
+  it('refuses a module swap', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`,
+    );
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      IntentMismatchError,
+    );
+  });
+
+  it('accepts the open-board verbs against the opening package', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`,
+    );
+    expect(() =>
+      assertTxMatchesIntent(b64, { action: 'open-claim' }),
+    ).not.toThrow();
+  });
+
+  it('fails closed on an unknown verb', () => {
+    expect(() => assertTxMatchesIntent('', { action: 'drain' })).toThrow(
+      /not a verb this wallet knows how to verify/,
+    );
+  });
+
+  it('fails closed on undecodable bytes', () => {
+    expect(() =>
+      assertTxMatchesIntent('bm90LWEtdHJhbnNhY3Rpb24=', { action: 'create' }),
+    ).toThrow(/could not decode/);
+  });
+});
+
+describe('the funnel never signs what it refused', () => {
+  function mockPrepare(txBytes: string) {
+    return vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      json: async () =>
+        String(url).includes('prepare')
+          ? { nonce: 'n1', txBytes }
+          : { digest: '0xdead' },
+    }));
+  }
+
+  it('does not call signTransaction when the package is wrong', async () => {
+    const b64 = await buildTxB64(`${EVIL_PACKAGE}::escrow::create`);
+    vi.stubGlobal('fetch', mockPrepare(b64));
+    const signTransaction = vi.fn();
+
+    await expect(
+      runSponsoredTx({
+        keypair: { signTransaction },
+        actor: `0x${'1'.repeat(64)}`,
+        prepareUrl: 'https://api.t2000.ai/v1/job/prepare',
+        prepareBody: {},
+        submitUrl: 'https://api.t2000.ai/v1/job/submit',
+        intent: { action: 'create' },
+      }),
+    ).rejects.toThrow(IntentMismatchError);
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
+  it('refuses an evil host BEFORE the prepare request is even made', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const signTransaction = vi.fn();
+
+    await expect(
+      runSponsoredTx({
+        keypair: { signTransaction },
+        actor: `0x${'1'.repeat(64)}`,
+        prepareUrl: 'https://evil.example/v1/job/prepare',
+        prepareBody: {},
+        submitUrl: 'https://evil.example/v1/job/submit',
+        intent: { action: 'create' },
+      }),
+    ).rejects.toThrow(UntrustedHostError);
+    // The wallet address never left the machine.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(signTransaction).not.toHaveBeenCalled();
+  });
+
+  it('signs the happy path', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+    );
+    vi.stubGlobal('fetch', mockPrepare(b64));
+    const signTransaction = vi.fn(async () => ({ signature: 'sig' }));
+
+    await expect(
+      runSponsoredTx({
+        keypair: { signTransaction },
+        actor: `0x${'1'.repeat(64)}`,
+        prepareUrl: 'https://api.t2000.ai/v1/job/prepare',
+        prepareBody: {},
+        submitUrl: 'https://api.t2000.ai/v1/job/submit',
+        intent: { action: 'create', amountUsdc: 5 },
+      }),
+    ).resolves.toEqual({ digest: '0xdead' });
+    expect(signTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -1,0 +1,236 @@
+import { Transaction } from '@mysten/sui/transactions';
+import { setSponsoredTxGuard } from '@t2000/sdk';
+import {
+  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+  MAINNET_A2A_ESCROW_PACKAGE_ID,
+} from '@t2000/sdk';
+
+// Never sign bytes you didn't ask for (S.930).
+//
+// Threat model. The default host is trusted infrastructure; what is NOT
+// trusted is anything that can be injected around the process:
+//
+//   T2000_API_URL=https://evil/v1   → the "server" that builds the tx
+//   A2A_ESCROW_PACKAGE_ID=0xevil    → the constants used to check the tx
+//   --api https://evil/v1           → same, from the shell
+//
+// The wallet used to base64-decode whatever prepare returned and sign it. A
+// hijacked host could hand back a drain transaction and the CLI would sign it
+// without ever looking. Two locks:
+//
+//   A. A non-default host cannot obtain a signature at all without an
+//      explicit opt-in flag.
+//   B. Even on the default host, the decoded PTB has to match the verb the
+//      user actually typed, checked against MAINNET package literals.
+//
+// (B) matters because (A) alone still trusts every byte from the real host,
+// and (A) matters because (B) can only check what it knows how to parse.
+
+/** The canonical origin. Everything else is "somewhere else". */
+export const CANONICAL_API_ORIGIN = 'https://api.t2000.ai';
+
+/** The flag that lets a non-default host obtain a signature. */
+export const ALLOW_UNTRUSTED_FLAG = '--allow-untrusted-api';
+
+/** Packages the wallet will sign calls into. MAINNET literals from the SDK —
+ *  deliberately NOT `A2A_ESCROW_PACKAGE_ID`, which reads `process.env` and so
+ *  would let an attacker supply both the transaction and the yardstick. */
+const ALLOWED_PACKAGES = new Set([
+  MAINNET_A2A_ESCROW_PACKAGE_ID,
+  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+]);
+
+/** What the user typed → what the PTB is allowed to call. Fail closed: a verb
+ *  absent from this map cannot be signed through the guarded path. */
+const ACTION_FUNCTIONS: Record<string, { module: string; functions: string[] }> =
+  {
+    // Buyer funds an escrow job from a listing or their own terms.
+    create: { module: 'escrow', functions: ['create'] },
+    // Seller-side lifecycle.
+    deliver: { module: 'escrow', functions: ['deliver'] },
+    release: { module: 'escrow', functions: ['release'] },
+    reject: { module: 'escrow', functions: ['reject'] },
+    refund: { module: 'escrow', functions: ['refund'] },
+    decline: { module: 'opening', functions: ['decline'] },
+    // Open board.
+    'open-create': { module: 'opening', functions: ['create', 'create_open'] },
+    'open-claim': { module: 'opening', functions: ['claim'] },
+    'open-cancel': { module: 'opening', functions: ['cancel'] },
+    'open-refund': { module: 'opening', functions: ['refund_unclaimed', 'refund'] },
+  };
+
+/** Verbs that are NOT marketplace escrow calls and are verified by host pin
+ *  alone — the registry package is not in the escrow allowlist, and its args
+ *  aren't extractable here. Narrow and named rather than a silent fallthrough. */
+const HOST_PINNED_ONLY = new Set(['register', 'link', 'confirm']);
+
+export type TxIntent = {
+  /** The verb the user typed, as sent to the prepare endpoint. */
+  action: string;
+  /** For display only. */
+  amountUsdc?: number;
+  seller?: string;
+};
+
+// Process-wide because the flag is a property of the invocation, not of any
+// one call site, and threading it through every command would make "forgot to
+// pass it" a silent downgrade. Defaults to false — fail closed.
+let allowUntrustedApi = false;
+
+/** Set once from the root `--allow-untrusted-api` flag. */
+export function setAllowUntrustedApi(value: boolean): void {
+  allowUntrustedApi = value;
+}
+
+export function isAllowUntrustedApi(): boolean {
+  return allowUntrustedApi;
+}
+
+export class UntrustedHostError extends Error {}
+export class IntentMismatchError extends Error {}
+
+/** Origin of an API base like `https://api.t2000.ai/v1`. */
+export function apiOrigin(base: string): string {
+  try {
+    return new URL(base).origin;
+  } catch {
+    return base;
+  }
+}
+
+export function isDefaultApiHost(base: string): boolean {
+  return apiOrigin(base) === CANONICAL_API_ORIGIN;
+}
+
+/**
+ * Gate (A). Refuse to go anywhere near a signature when the host that builds
+ * the transaction isn't the canonical one and the operator hasn't said so out
+ * loud. Called BEFORE the prepare request, so a hijacked host never even sees
+ * the wallet address.
+ */
+export function assertSigningHostAllowed(
+  base: string,
+  allowUntrusted: boolean,
+): void {
+  if (isDefaultApiHost(base) || allowUntrusted) {
+    return;
+  }
+  throw new UntrustedHostError(
+    `Refusing to sign transactions built by ${apiOrigin(base)}.\n` +
+      `  Only ${CANONICAL_API_ORIGIN} is trusted by default. If you really mean to use\n` +
+      `  another host (a local or staging API), re-run with ${ALLOW_UNTRUSTED_FLAG}.\n` +
+      '  If you did not set T2000_API_URL or --api yourself, treat this as an attack.',
+  );
+}
+
+/**
+ * Gate (B). Decode the prepared bytes and check every Move call against the
+ * verb the user asked for.
+ *
+ * Fails closed everywhere: an unparseable payload, an unknown verb, a call
+ * into a package we don't publish, or zero Move calls at all are all refusals.
+ * A narrow verified set that grows beats a permissive one that guesses.
+ */
+export function assertTxMatchesIntent(
+  txBytes: string,
+  intent: TxIntent,
+  opts: { allowUntrusted?: boolean } = {},
+): void {
+  // On an operator-acknowledged untrusted host the package literals are
+  // meaningless (a local chain publishes its own), so the host flag is the
+  // only lock left. That is the operator's explicit choice.
+  if (opts.allowUntrusted) {
+    return;
+  }
+  if (HOST_PINNED_ONLY.has(intent.action)) {
+    return;
+  }
+
+  const expected = ACTION_FUNCTIONS[intent.action];
+  if (!expected) {
+    throw new IntentMismatchError(
+      `Refusing to sign: "${intent.action}" is not a verb this wallet knows how to verify.`,
+    );
+  }
+
+  let calls: { pkg: string; module: string; fn: string }[];
+  try {
+    const tx = Transaction.from(
+      new Uint8Array(Buffer.from(txBytes, 'base64')),
+    );
+    calls = tx
+      .getData()
+      .commands.flatMap((c) =>
+        c.$kind === 'MoveCall' && c.MoveCall
+          ? [
+              {
+                pkg: c.MoveCall.package,
+                module: c.MoveCall.module,
+                fn: c.MoveCall.function,
+              },
+            ]
+          : [],
+      );
+  } catch (e) {
+    throw new IntentMismatchError(
+      `Refusing to sign: could not decode the prepared transaction (${
+        e instanceof Error ? e.message : 'unreadable'
+      }).`,
+    );
+  }
+
+  if (calls.length === 0) {
+    throw new IntentMismatchError(
+      'Refusing to sign: the prepared transaction contains no Move calls.',
+    );
+  }
+
+  for (const call of calls) {
+    if (!ALLOWED_PACKAGES.has(call.pkg)) {
+      throw new IntentMismatchError(
+        `Refusing to sign: transaction calls package ${call.pkg}, which is not a t2000 escrow package.`,
+      );
+    }
+    if (call.module !== expected.module) {
+      throw new IntentMismatchError(
+        `Refusing to sign: "${intent.action}" should call ${expected.module}, but the transaction calls ${call.module}.`,
+      );
+    }
+    if (!expected.functions.includes(call.fn)) {
+      throw new IntentMismatchError(
+        `Refusing to sign: "${intent.action}" should call ${expected.module}::${expected.functions.join('|')}, but the transaction calls ${call.module}::${call.fn}.`,
+      );
+    }
+  }
+}
+
+/** One line so a person can see what they're about to authorize. */
+export function describeIntent(intent: TxIntent, base: string): string {
+  const bits = [intent.action];
+  if (intent.amountUsdc !== undefined) {
+    bits.push(`$${intent.amountUsdc}`);
+  }
+  if (intent.seller) {
+    bits.push(`→ ${intent.seller.slice(0, 6)}…${intent.seller.slice(-4)}`);
+  }
+  return `About to sign: ${bits.join(' ')} (${apiOrigin(base).replace('https://', '')})`;
+}
+
+/**
+ * Teach the SDK's open-board path the same two locks.
+ *
+ * `postOpenJob` / `claimOpenJob` / `cancelOpenJob` / `refundOpenJob` sign
+ * inside `@t2000/sdk`, not through `runSponsoredTx` — posting an opening
+ * moves the buyer's USDC, so leaving that path blind would have left the
+ * loudest hole exactly where the money is.
+ */
+export function installSponsoredTxGuard(): void {
+  setSponsoredTxGuard(({ base, action, txBytes }) => {
+    const allowUntrusted = isAllowUntrustedApi();
+    if (txBytes === undefined) {
+      assertSigningHostAllowed(base, allowUntrusted);
+      return;
+    }
+    assertTxMatchesIntent(txBytes, { action }, { allowUntrusted });
+  });
+}

--- a/packages/cli/src/lib/with-agent.ts
+++ b/packages/cli/src/lib/with-agent.ts
@@ -6,6 +6,27 @@
 // had for pin-resolve + T2000.create + error handling.
 
 import { T2000 } from '@t2000/sdk';
+import { assertSigningHostAllowed, isAllowUntrustedApi } from './tx-guard.js';
+
+/**
+ * Host pin at the wallet door (S.930).
+ *
+ * `runSponsoredTx` refuses an untrusted host before it signs, but by then a
+ * command like `job hire` has already resolved an agent ref and uploaded a
+ * spec THROUGH that host. Since no command can sign without loading the
+ * wallet, refusing here stops an injected `T2000_API_URL` at the top of every
+ * signing path instead of halfway down one.
+ *
+ * Only the env var is checked here — it is the injected case and is
+ * process-global. An operator-typed `--api` is still caught at signing time.
+ */
+function assertEnvApiHostTrusted(): void {
+  const envBase = process.env.T2000_API_URL;
+  if (!envBase) {
+    return;
+  }
+  assertSigningHostAllowed(envBase, isAllowUntrustedApi());
+}
 
 export interface WithAgentOptions {
   keyPath?: string;
@@ -17,6 +38,7 @@ export interface WithAgentOptions {
  * to pass the error through `handleError()` for clean exit-1.
  */
 export async function withAgent(options: WithAgentOptions = {}): Promise<T2000> {
+  assertEnvApiHostTrusted();
   return T2000.create({
     keyPath: options.keyPath,
     rpcUrl: options.rpcUrl,
@@ -33,6 +55,7 @@ export type AgentResult =
 
 export async function tryWithAgent(options: WithAgentOptions = {}): Promise<AgentResult> {
   try {
+    assertEnvApiHostTrusted();
     const agent = await T2000.create({
       keyPath: options.keyPath,
       rpcUrl: options.rpcUrl,

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,6 +1,12 @@
 import { Command } from 'commander';
+import {
+  assertSigningHostAllowed,
+  CANONICAL_API_ORIGIN,
+  installSponsoredTxGuard,
+  setAllowUntrustedApi,
+} from './lib/tx-guard.js';
 import { createRequire } from 'node:module';
-import { setJsonMode } from './output.js';
+import { handleError, setJsonMode } from './output.js';
 
 const require = createRequire(import.meta.url);
 const { version: CLI_VERSION } = require('../package.json') as { version: string };
@@ -36,9 +42,34 @@ export function createProgram(): Command {
     .description('Agent Wallet — autonomous Sui USDC + USDsui wallet for AI agents')
     .version(`${CLI_VERSION}`)
     .option('--json', 'Output in JSON format')
+    .option(
+      '--allow-untrusted-api',
+      `Permit signing transactions built by a non-default API host (${CANONICAL_API_ORIGIN} is the only trusted host). Only for local/staging work — a host you did not choose can propose any transaction.`,
+    )
     .hook('preAction', (thisCommand) => {
       const opts = thisCommand.optsWithGlobals();
       if (opts.json) setJsonMode(true);
+      // Fail closed: absent flag = signing is pinned to the canonical host
+      // and every prepared tx is checked against the typed verb (S.930).
+      setAllowUntrustedApi(Boolean(opts.allowUntrustedApi));
+      installSponsoredTxGuard();
+      // Before ANY command body runs. The per-signature pin inside
+      // runSponsoredTx is the last line of defence, not the first: by the
+      // time `job hire` reaches it, it has already resolved an agent ref and
+      // uploaded a spec through whatever host the env pointed at. An injected
+      // T2000_API_URL should stop the process, not one function call.
+      if (process.env.T2000_API_URL) {
+        try {
+          assertSigningHostAllowed(
+            process.env.T2000_API_URL,
+            Boolean(opts.allowUntrustedApi),
+          );
+        } catch (e) {
+          // The hook sits outside every command's try/catch, so route it
+          // through the same exit path rather than dumping a stack.
+          handleError(e);
+        }
+      }
     })
     .addHelpText('after', `
 Setup:

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -147,6 +147,7 @@ export {
 export { buildSendTx, addSendToTx, preflightSend } from './wallet/send.js';
 export {
   A2A_ESCROW_PACKAGE_ID,
+  MAINNET_A2A_ESCROW_PACKAGE_ID,
   A2A_ESCROW_FEE_CONFIG_ID,
   MAX_JOB_USDC,
   MAX_REVIEW_WINDOW_MS,
@@ -166,6 +167,7 @@ export {
 export type { Job, JobState, JobTerms, JobVerification } from './wallet/job.js';
 export {
   A2A_ESCROW_OPENING_PACKAGE_ID,
+  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
   A2A_ESCROW_PACKAGE_V2_ID,
   A2A_ESCROW_PACKAGE_V3_ID,
   MAX_OPEN_WINDOW_MS,
@@ -193,6 +195,8 @@ export {
   getOpenJob,
   listOpenJobs,
   postOpenJob,
+  setSponsoredTxGuard,
+  type SponsoredTxGuard,
   refundOpenJob,
 } from './open-jobs.js';
 export type { OpenJobFilter, OpenJobRow } from './open-jobs.js';

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -43,6 +43,29 @@ async function fetchJson(
  *  on-chain Openings. `id` is the Opening OBJECT id (0x…). Buyer addresses
  *  never appear (registered-agent buyers surface by id); the claiming ASP
  *  is public. Title + brief are public by design. */
+/** A host-installed veto on sponsored open-board transactions (S.930).
+ *
+ *  Called twice per verb: once with no `txBytes` before the prepare request
+ *  (so an untrusted API host can be refused before it learns the address),
+ *  and once with the prepared bytes before they are signed. Throwing from
+ *  either aborts the verb.
+ *
+ *  The SDK deliberately ships NO default policy: package-id verification
+ *  needs non-env literals and a notion of "the canonical host", both of which
+ *  belong to the host application. Unset = today's behavior. */
+export type SponsoredTxGuard = (ctx: {
+  base: string;
+  action: string;
+  txBytes?: string;
+}) => void;
+
+let sponsoredTxGuard: SponsoredTxGuard | null = null;
+
+/** Install (or clear, with `null`) the sponsored-tx guard. */
+export function setSponsoredTxGuard(guard: SponsoredTxGuard | null): void {
+  sponsoredTxGuard = guard;
+}
+
 export interface OpenJobRow {
   id: string;
   title: string | null;
@@ -103,6 +126,9 @@ async function sponsoredOpeningVerb(
   params: Record<string, unknown>,
 ): Promise<string> {
   const address = signer.getAddress();
+  // Host pin (S.930): a hook installed by the host app gets to refuse before
+  // the wallet address reaches an untrusted builder.
+  sponsoredTxGuard?.({ base, action });
   const prep = await fetchJson(`${base}/job/prepare`, {
     method: 'POST',
     body: { address, action, params },
@@ -112,6 +138,8 @@ async function sponsoredOpeningVerb(
   if (!(nonce && txBytes)) {
     throw new Error('Failed to prepare the transaction.');
   }
+  // Intent check (S.930): and again with the bytes, before they are signed.
+  sponsoredTxGuard?.({ base, action, txBytes });
   const { signature } = await signer.signTransaction(fromBase64(txBytes));
   const json = await fetchJson(`${base}/job/submit`, {
     method: 'POST',

--- a/packages/sdk/src/wallet/job.ts
+++ b/packages/sdk/src/wallet/job.ts
@@ -31,10 +31,21 @@ import { A2A_ESCROW_OPENING_PACKAGE_ID } from './opening.js';
  * via env for testnet/dev.
  */
 
-/** The published `a2a_escrow` package id (mainnet). */
-export const A2A_ESCROW_PACKAGE_ID =
-  process.env.A2A_ESCROW_PACKAGE_ID ??
+/** The published `a2a_escrow` package id on MAINNET — a literal, never an
+ *  env read.
+ *
+ *  Security (S.930): the env-overridable constant below is a dev/testnet
+ *  convenience, which makes it useless as a trust anchor — anything verifying
+ *  "is this the real escrow package?" against it would be checking the
+ *  attacker's own answer. Signature-time verification compares against THIS.
+ *  Must match the Move upgrade publish notes. */
+export const MAINNET_A2A_ESCROW_PACKAGE_ID =
   '0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd';
+
+/** The published `a2a_escrow` package id (mainnet default; env-overridable
+ *  for testnet/dev — NOT a trust anchor, see above). */
+export const A2A_ESCROW_PACKAGE_ID =
+  process.env.A2A_ESCROW_PACKAGE_ID ?? MAINNET_A2A_ESCROW_PACKAGE_ID;
 
 /** The shared `FeeConfig` object every escrow entry reads (mainnet). */
 export const A2A_ESCROW_FEE_CONFIG_ID =

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -28,9 +28,15 @@ import {
  *  adds `escrow::decline`; v2 added the `opening` module). New-verb calls
  *  (opening + decline) target this; original-id verbs stay put, and older
  *  package ids remain callable for published clients. */
+/** The published `opening` package id on MAINNET — a literal, never an env
+ *  read, so it can serve as a signature-time trust anchor (S.930). Must match
+ *  the Move upgrade publish notes. */
+export const MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID =
+  '0x69ad93c555519de520a5c7f7f2963ad6f8b91cefc098fc2eed75942dcb5bcbe7';
+
 export const A2A_ESCROW_OPENING_PACKAGE_ID =
   process.env.A2A_ESCROW_OPENING_PACKAGE_ID ??
-  '0x69ad93c555519de520a5c7f7f2963ad6f8b91cefc098fc2eed75942dcb5bcbe7';
+  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID;
 
 /**
  * PINNED per-upgrade package ids — event-filter anchors, NEVER bump these.


### PR DESCRIPTION
The wallet base64-decoded whatever `prepare` returned and signed it. Anything able to set `T2000_API_URL` or pass `--api` could hand back a drain transaction and collect a signature — the CLI never looked at the bytes.

All three parts shipped: **A** host pin, **B** intent assert, **C** limits.

## A — host pin

A non-canonical API host cannot obtain a signature without `--allow-untrusted-api`.

**Enforced in the root `preAction`, not just at the signature.** My first cut only pinned inside `runSponsoredTx` and I proved it insufficient against the built binary: by the time `job hire` reached the signature it had already resolved an agent ref (S.929) and uploaded a spec **through the hijacked host**. An injected env var should stop the process, not one function call.

```
$ T2000_API_URL=https://evil.example/v1 t2 job hire 1 0xA --spec 0xB
  ✗ Refusing to sign transactions built by https://evil.example.
  Only https://api.t2000.ai is trusted by default. If you really mean to use
  another host (a local or staging API), re-run with --allow-untrusted-api.
  If you did not set T2000_API_URL or --api yourself, treat this as an attack.
$ echo $?          → 1, zero network calls
```

Reads are pinned too (`t2 agents` refuses on a hijacked host) — stricter than the brief's "soft-warn is fine", and simpler to reason about.

## B — intent assert

Prepared bytes are decoded and **every** Move call checked against the verb typed: package → module → function. Fails closed on unknown verbs, undecodable payloads, and PTBs containing no Move calls. `Transaction.from()` decode shape was verified empirically before being relied on.

**The allowlist can't be spoofed.** `A2A_ESCROW_PACKAGE_ID` is `process.env.X ?? literal`, so an allowlist built from it would let an attacker who sets both the API host and the package ids supply the transaction *and* the yardstick. Added `MAINNET_A2A_ESCROW_PACKAGE_ID` / `MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID` — pure literals, never env — and the env-overridable constants now derive from them, so there's still one number to edit. Pinned by a test that stubs `A2A_ESCROW_PACKAGE_ID` to the attacker's value and asserts the refusal is unchanged.

**A fourth sign path the brief's table didn't list:** `postOpenJob` / `claimOpenJob` / `cancelOpenJob` / `refundOpenJob` sign inside `@t2000/sdk`, not through `runSponsoredTx`. Posting an opening moves the buyer's USDC, so that was the loudest hole. The SDK gains a `setSponsoredTxGuard` hook (no default policy — package literals and "canonical host" belong to the host app) which the CLI installs at startup.

Every remaining `signTransaction` call site is now covered: `runSponsoredTx`, `registerWallet`, the inline endpoint-listing path in `agent/index.ts`, and the SDK open-board helper. `executeTx` builds its PTB locally, so it's outside this threat model.

## C — limits

`hire` asserts before and records after — a $25 cap now stops a hire, and a completed hire stops reading `$0.00 spent`. Seller-side verbs (`deliver`/`release`/`reject`/`refund`/`decline`) settle escrow that is already locked and pass no spend, so nothing double-counts. Recording happens only on a real digest, so a failed hire doesn't eat the day's cap.

```
$ t2 job hire 10 0xAEGIS --spec 0xB          # daily cap $5
  ✗ Exceeds daily spend limit ($5). Attempted $10.00.
    Raise the cap with `t2 limit set` — job verbs have no --force.
```

**No `--force` invented**, per the brief. But wiring hire into the shared gate meant its error advertised a flag these verbs don't have, so I corrected the guidance rather than shipping copy that sends people to a non-existent door.

## Residuals — no silent holes

1. **`--api` on a signing command is caught at signature time, not at process start.** The `preAction` pin only reads `T2000_API_URL`, because the flag is parsed per-command. An operator typing `--api https://x/v1` can therefore still have a spec uploaded to that host before the refusal. This is the *operator-typed* case, not the injected one; the injected case is fully covered.
2. **Argument-level checks are not implemented.** Package/module/function are verified; job id, amount and seller are not yet compared against the CLI's intent. A compromised canonical host could still return a well-formed `escrow::create` with different arguments. Per the brief's staging advice I shipped the allowlist fail-closed first; deepening to args is the follow-up.
3. **`register` / `link` / `confirm` are host-pinned only.** They call the registry package, outside the escrow allowlist, and their args aren't extractable here — named explicitly in `HOST_PINNED_ONLY` rather than silently falling through.
4. **`--allow-untrusted-api` disables intent checking too.** On a local chain the mainnet literals are meaningless, so the host flag becomes the only lock. That is the operator's explicit choice, and it's commented as such.

## Verify

**216 CLI tests** (16 new for the guard) and **551 SDK tests** pass; lint, typecheck and build clean on both. The guard tests assert the thing that matters: on any doubt `signTransaction` is **not called**, and on an untrusted host `fetch` isn't either.

**No version bump, no publish** — founder runs the lockstep workflow.