### PR TITLE
🐛 fix(cli): tx-guard cancel_open + escrow::decline map (S.930.1)

### DIFF
--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -20,15 +20,9 @@
 
 import { createHash } from 'node:crypto';
 import {
-  assertLimitConfig,
-  dailySpentToday,
-  getLimits,
-  LimitExceededError,
-  recordDailySpend,
-} from '@t2000/sdk';
-
-/** The shared limit error advertises `--force`; job verbs don't have it. */
-const FORCE_HINT_RE = /\s*Use --force[^.]*\.\s*$/;
+  assertSpendAllowed,
+  recordSpendIfLanded,
+} from '../lib/spend-gate.js';
 import { expandAgentRefs, resolveAgentRef } from '../lib/agent-ref.js';
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
@@ -215,26 +209,8 @@ async function sponsoredJobVerb(opts: {
   // sponsored rail rather than the SDK write path, so it inherited neither
   // half of the gate: a $25 cap did not stop a hire, and a completed hire
   // left "spent today" reading $0.00.
-  if (opts.spendUsdc !== undefined && opts.spendUsdc > 0) {
-    try {
-      assertLimitConfig({
-        limits: getLimits(),
-        spentTodayUsd: dailySpentToday(),
-        operation: 'send',
-        amountUsd: opts.spendUsdc,
-        force: opts.force,
-      });
-    } catch (e) {
-      // The shared gate's message offers `--force`, which the job verbs do
-      // not have (and this slice deliberately did not invent). Point at the
-      // door that actually exists rather than one that doesn't.
-      if (e instanceof LimitExceededError) {
-        throw new Error(
-          `${e.message.replace(FORCE_HINT_RE, '')} Raise the cap with \`t2 limit set\` — job verbs have no --force.`,
-        );
-      }
-      throw e;
-    }
+  if (opts.spendUsdc !== undefined) {
+    assertSpendAllowed(opts.spendUsdc, opts.force);
   }
 
   const { digest } = await runSponsoredTx({
@@ -250,10 +226,7 @@ async function sponsoredJobVerb(opts: {
     },
   });
 
-  // Record only on a real digest — a failed hire must not eat the day's cap.
-  if (digest && opts.spendUsdc !== undefined && opts.spendUsdc > 0) {
-    recordDailySpend(opts.spendUsdc);
-  }
+  recordSpendIfLanded(opts.spendUsdc ?? 0, digest);
   return { address, digest };
 }
 

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -15,6 +15,10 @@
 // Registered flat on the `t2 job` group — one job noun.
 
 import { readFile } from 'node:fs/promises';
+import {
+  assertSpendAllowed,
+  recordSpendIfLanded,
+} from '../lib/spend-gate.js';
 import type { Command } from 'commander';
 import pc from 'picocolors';
 import {
@@ -119,6 +123,10 @@ export function registerOpenVerbs(group: Command) {
             throw new Error(`--max must be between 0.01 and ${MAX_JOB_USDC} USDC.`);
           }
           const brief = await resolveBrief(opts.brief);
+          // The budget escrows ON-CHAIN at post — a real outflow from the
+          // buyer's wallet, so it belongs under the same cap as a hire.
+          // (Claiming is free and is never recorded as spend.)
+          assertSpendAllowed(maxUsdc);
           const agent = await withAgent({ keyPath: opts.key });
           const digest = await postOpenJob(base, agent.signer, {
             title: opts.title.trim(),
@@ -127,6 +135,7 @@ export function registerOpenVerbs(group: Command) {
             slaMinutes: Math.round(parseDuration(opts.sla) / 60_000),
             openHours: parseDuration(opts.openFor) / 3_600_000,
           });
+          recordSpendIfLanded(maxUsdc, digest);
           const openingId = await resolveCreated(digest, '::opening::Opening<');
           if (isJsonMode()) {
             printJson({ digest, openingId });

--- a/packages/cli/src/lib/spend-gate.ts
+++ b/packages/cli/src/lib/spend-gate.ts
@@ -1,0 +1,59 @@
+import {
+  assertLimitConfig,
+  dailySpentToday,
+  getLimits,
+  LimitExceededError,
+  recordDailySpend,
+} from '@t2000/sdk';
+
+// Spending limits on the sponsored escrow paths (S.930 C, S.930.1 C).
+//
+// `send` / `swap` / `pay` inherit the gate from the SDK write path. The job
+// and open-board verbs do not: they go out through the sponsored rail, so
+// until this existed a $25 cap did not stop a hire and a completed hire left
+// "spent today" reading $0.00.
+//
+// Shared by `job.ts` and `open.ts` so the two can't drift — the interesting
+// part is WHICH verbs pass an amount, and that decision should be made once.
+
+/** The shared limit error offers `--force`; the job/open verbs don't have it. */
+const FORCE_HINT_RE = /\s*Use --force[^.]*\.\s*$/;
+
+/**
+ * Assert before the money moves. Throws with guidance that points at a door
+ * that actually exists.
+ */
+export function assertSpendAllowed(amountUsdc: number, force?: boolean): void {
+  if (!(Number.isFinite(amountUsdc) && amountUsdc > 0)) {
+    return;
+  }
+  try {
+    assertLimitConfig({
+      limits: getLimits(),
+      spentTodayUsd: dailySpentToday(),
+      operation: 'send',
+      amountUsd: amountUsdc,
+      force,
+    });
+  } catch (e) {
+    if (e instanceof LimitExceededError) {
+      throw new Error(
+        `${e.message.replace(FORCE_HINT_RE, '')} Raise the cap with \`t2 limit set\` — job verbs have no --force.`,
+      );
+    }
+    throw e;
+  }
+}
+
+/**
+ * Record after the money actually moved. `digest` is the proof — a failed
+ * verb must not eat the day's cap.
+ */
+export function recordSpendIfLanded(
+  amountUsdc: number,
+  digest: string | undefined,
+): void {
+  if (digest && Number.isFinite(amountUsdc) && amountUsdc > 0) {
+    recordDailySpend(amountUsdc);
+  }
+}

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -126,10 +126,20 @@ describe('B — intent assert', () => {
 
   it('refuses a module swap', async () => {
     const b64 = await buildTxB64(
-      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`,
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::opening::claim`,
     );
     expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
       IntentMismatchError,
+    );
+  });
+
+  it('refuses the right package with the wrong verb (package is pinned per action)', async () => {
+    const b64 = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`,
+    );
+    // A real t2000 package, a real function — but not what `create` calls.
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      /targets package/,
     );
   });
 
@@ -153,6 +163,73 @@ describe('B — intent assert', () => {
       assertTxMatchesIntent('bm90LWEtdHJhbnNhY3Rpb24=', { action: 'create' }),
     ).toThrow(/could not decode/);
   });
+});
+
+// S.930.1 — the first map was transcribed from the API's action strings
+// instead of the SDK builders, so it named two functions that do not exist on
+// mainnet and refused two real happy paths. These cases pin the map to the
+// builders; if a Move upgrade renames a target, they fail here rather than in
+// someone's terminal.
+describe('B — the map matches the SDK builders, verb for verb', () => {
+  const REAL_TARGETS: [string, string][] = [
+    ['create', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`],
+    ['deliver', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::deliver`],
+    ['release', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::release`],
+    ['reject', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::reject`],
+    ['refund', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::refund`],
+    // buildDeclineJobTx: OPENING package, `escrow` module — looks like a typo,
+    // isn't. `decline` shipped in the v3 upgrade.
+    ['decline', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::escrow::decline`],
+    [
+      'open-create',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open`,
+    ],
+    ['open-claim', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`],
+    [
+      'open-cancel',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::cancel_open`,
+    ],
+    [
+      'open-refund',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::refund_unclaimed`,
+    ],
+  ];
+
+  for (const [action, target] of REAL_TARGETS) {
+    it(`signs ${action} → ${target.split('::').slice(1).join('::')}`, async () => {
+      const b64 = await buildTxB64(target);
+      expect(() => assertTxMatchesIntent(b64, { action })).not.toThrow();
+    });
+  }
+
+  // The exact names the broken map expected. Neither exists on mainnet.
+  const PHANTOMS: [string, string][] = [
+    [
+      'open-cancel',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::cancel`,
+    ],
+    [
+      'decline',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::decline`,
+    ],
+    [
+      'open-create',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create`,
+    ],
+    [
+      'open-refund',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::refund`,
+    ],
+  ];
+
+  for (const [action, target] of PHANTOMS) {
+    it(`refuses the phantom ${target.split('::').slice(1).join('::')} under ${action}`, async () => {
+      const b64 = await buildTxB64(target);
+      expect(() => assertTxMatchesIntent(b64, { action })).toThrow(
+        IntentMismatchError,
+      );
+    });
+  }
 });
 
 describe('the funnel never signs what it refused', () => {

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -32,32 +32,91 @@ export const CANONICAL_API_ORIGIN = 'https://api.t2000.ai';
 /** The flag that lets a non-default host obtain a signature. */
 export const ALLOW_UNTRUSTED_FLAG = '--allow-untrusted-api';
 
-/** Packages the wallet will sign calls into. MAINNET literals from the SDK —
- *  deliberately NOT `A2A_ESCROW_PACKAGE_ID`, which reads `process.env` and so
- *  would let an attacker supply both the transaction and the yardstick. */
-const ALLOWED_PACKAGES = new Set([
-  MAINNET_A2A_ESCROW_PACKAGE_ID,
-  MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
-]);
-
-/** What the user typed → what the PTB is allowed to call. Fail closed: a verb
- *  absent from this map cannot be signed through the guarded path. */
-const ACTION_FUNCTIONS: Record<string, { module: string; functions: string[] }> =
-  {
-    // Buyer funds an escrow job from a listing or their own terms.
-    create: { module: 'escrow', functions: ['create'] },
-    // Seller-side lifecycle.
-    deliver: { module: 'escrow', functions: ['deliver'] },
-    release: { module: 'escrow', functions: ['release'] },
-    reject: { module: 'escrow', functions: ['reject'] },
-    refund: { module: 'escrow', functions: ['refund'] },
-    decline: { module: 'opening', functions: ['decline'] },
-    // Open board.
-    'open-create': { module: 'opening', functions: ['create', 'create_open'] },
-    'open-claim': { module: 'opening', functions: ['claim'] },
-    'open-cancel': { module: 'opening', functions: ['cancel'] },
-    'open-refund': { module: 'opening', functions: ['refund_unclaimed', 'refund'] },
-  };
+/** Every verb, mapped to the EXACT target its SDK builder emits.
+ *
+ *  Transcribed from `packages/sdk/src/wallet/{job,opening}.ts` — not from the
+ *  API's action strings, which is how the first cut of this map shipped
+ *  `opening::cancel` and `opening::decline`: two functions that do not exist
+ *  on mainnet, guarding two happy paths that therefore could not be signed at
+ *  all. A fail-closed check is only as good as its ground truth, so the table
+ *  below mirrors the builders line for line:
+ *
+ *    buildDeclineJobTx      → OPENING pkg :: escrow  :: decline   (v3)
+ *    buildCancelOpeningTx   → OPENING pkg :: opening :: cancel_open
+ *    buildRefundUnclaimedTx → OPENING pkg :: opening :: refund_unclaimed
+ *    buildOpenJobTx         → OPENING pkg :: opening :: create_open
+ *    buildClaimOpeningTx    → OPENING pkg :: opening :: claim
+ *    buildCreateJobTx       → ESCROW  pkg :: escrow  :: create
+ *    buildDeliverJobTx      → ESCROW  pkg :: escrow  :: deliver
+ *    jobCall                → ESCROW  pkg :: escrow  :: release|refund|reject
+ *
+ *  `decline` is the one that looks like a typo and isn't: it lives in the
+ *  OPENING package but the `escrow` module, because it shipped in the v3
+ *  upgrade. Package ids are the MAINNET literals — deliberately NOT the
+ *  env-overridable constants, which would let an attacker supply both the
+ *  transaction and the yardstick.
+ *
+ *  A Move upgrade that moves a verb to a new package needs a matching CLI
+ *  release. That is the cost of fail-closed, and it is the intended trade.
+ */
+const ACTION_TARGETS: Record<
+  string,
+  { pkg: string; module: string; functions: string[] }
+> = {
+  // v1 escrow package.
+  create: {
+    pkg: MAINNET_A2A_ESCROW_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['create'],
+  },
+  deliver: {
+    pkg: MAINNET_A2A_ESCROW_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['deliver'],
+  },
+  release: {
+    pkg: MAINNET_A2A_ESCROW_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['release'],
+  },
+  reject: {
+    pkg: MAINNET_A2A_ESCROW_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['reject'],
+  },
+  refund: {
+    pkg: MAINNET_A2A_ESCROW_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['refund'],
+  },
+  // v3 opening package — note the `escrow` module.
+  decline: {
+    pkg: MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+    module: 'escrow',
+    functions: ['decline'],
+  },
+  // Open board.
+  'open-create': {
+    pkg: MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+    module: 'opening',
+    functions: ['create_open'],
+  },
+  'open-claim': {
+    pkg: MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+    module: 'opening',
+    functions: ['claim'],
+  },
+  'open-cancel': {
+    pkg: MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+    module: 'opening',
+    functions: ['cancel_open'],
+  },
+  'open-refund': {
+    pkg: MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
+    module: 'opening',
+    functions: ['refund_unclaimed'],
+  },
+};
 
 /** Verbs that are NOT marketplace escrow calls and are verified by host pin
  *  alone — the registry package is not in the escrow allowlist, and its args
@@ -146,7 +205,7 @@ export function assertTxMatchesIntent(
     return;
   }
 
-  const expected = ACTION_FUNCTIONS[intent.action];
+  const expected = ACTION_TARGETS[intent.action];
   if (!expected) {
     throw new IntentMismatchError(
       `Refusing to sign: "${intent.action}" is not a verb this wallet knows how to verify.`,
@@ -186,9 +245,9 @@ export function assertTxMatchesIntent(
   }
 
   for (const call of calls) {
-    if (!ALLOWED_PACKAGES.has(call.pkg)) {
+    if (call.pkg !== expected.pkg) {
       throw new IntentMismatchError(
-        `Refusing to sign: transaction calls package ${call.pkg}, which is not a t2000 escrow package.`,
+        `Refusing to sign: "${intent.action}" targets package ${expected.pkg}, but the transaction calls ${call.pkg}.`,
       );
     }
     if (call.module !== expected.module) {


### PR DESCRIPTION
You were right, and it was worse than reported: **four** rows disagreed with the builders, not two.

I transcribed S.930's map from the API's *action strings* rather than the SDK builders. A fail-closed check is only as good as its ground truth, so the result was a guard that refused two real happy paths and "verified" two functions that don't exist on mainnet.

| Intent | Shipped (wrong) | Real builder |
|---|---|---|
| `decline` | `opening::decline` | **`escrow::decline`** (on the opening package) |
| `open-cancel` | `opening::cancel` | **`opening::cancel_open`** |
| `open-create` | `create` \| `create_open` | `create_open` — `create` was a phantom |
| `open-refund` | `refund_unclaimed` \| `refund` | `refund_unclaimed` — `refund` was a phantom |

The two phantom aliases wouldn't have broken anything, but they were holes in a fail-closed check: names that would have been accepted and can't exist.

## The map is now transcribed from the builders

Every row carries the builder it came from, in the file:

```
buildDeclineJobTx      → OPENING pkg :: escrow  :: decline   (v3)
buildCancelOpeningTx   → OPENING pkg :: opening :: cancel_open
buildRefundUnclaimedTx → OPENING pkg :: opening :: refund_unclaimed
buildOpenJobTx         → OPENING pkg :: opening :: create_open
buildClaimOpeningTx    → OPENING pkg :: opening :: claim
buildCreateJobTx       → ESCROW  pkg :: escrow  :: create
buildDeliverJobTx      → ESCROW  pkg :: escrow  :: deliver
jobCall                → ESCROW  pkg :: escrow  :: release|refund|reject
```

`decline` is the one that looks like a typo and isn't — it lives in the **opening package** under the **`escrow` module**, because it shipped in the v3 upgrade. That's now stated in a comment so the next person doesn't "fix" it.

**One tightening beyond the brief:** the package is pinned **per verb** instead of checked against a shared allowlist. Having exact ground truth for all ten verbs made the loose set unnecessary, and it closes the case where a real function name from the wrong package would have passed. Package ids remain the `MAINNET_*` literals.

## Tests pin the builders

10 real targets accepted, 4 phantoms refused, table-driven. A Move rename now fails here rather than in someone's terminal. **231 tests pass** (31 in tx-guard, up from 16); lint, typecheck, build clean.

## Fix C — open post now under the cap

Closes the parent's residual. Posting escrows the budget on-chain, so it's a real outflow and asserts/records exactly like a hire. **Claiming is free and is never recorded.**

The assert/record pair moved into `lib/spend-gate.ts` so `job` and `open` can't drift — the interesting decision is *which verbs pass an amount*, and it should be made once.

Verified on the built binary:

```
$ t2 job open --title x --brief y --max 10        # daily cap $5
  ✗ Exceeds daily spend limit ($5). Attempted $10.00.
    Raise the cap with `t2 limit set` — job verbs have no --force.

$ t2 job open --title … --max 1                   # within cap
  ✗ Insufficient balance …USDC                    ← passed the gate, reached chain
```

The second is the one that matters: the gate isn't blocking legitimate posts, and with no digest nothing was recorded.

## Unchanged

Threat model, host pin, arg-level checks (still not implemented — parent residual 2 stands), register intent map, no version bump, no publish.

**New residual:** pinning the package per verb means a Move upgrade that relocates a verb needs a matching CLI release before that verb can be signed. That's the intended cost of fail-closed, and it was already true of the shared allowlist — now it's true per-verb.