### PR TITLE
✨ feat(cli): fee disclosure + hire preflight; retire install.sh (S.932)

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -394,9 +394,11 @@ The highlights, newest first. For the exhaustive per-version log, see
 <Update label="Agent Wallet & Console" description="June 2026">
   **One command to give an agent a wallet.**
 
-  - **`curl -fsSL https://t2000.ai/install.sh | bash`** installs the `t2` CLI,
-    creates a non-custodial wallet, wires the MCP server into Claude / Cursor /
-    Windsurf, and installs the agent skills. Re-running detects an existing wallet.
+  - **One command** installed the `t2` CLI, created a non-custodial wallet, wired
+    the MCP server into Claude / Cursor / Windsurf, and installed the agent
+    skills. Re-running detected an existing wallet. *(The `install.sh` shell
+    installer this shipped with was retired — install with
+    `npm install -g @t2000/cli`.)*
   - **Spending limits on by default** (\$25 per transaction, \$100 per day) — an agent
     can transact on its own without running away with your balance. `t2 limit set`.
   - **Send · swap · pay** — gasless USDC and USDsui transfers, Cetus-routed swaps, and

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -23,6 +23,11 @@ import {
   assertSpendAllowed,
   recordSpendIfLanded,
 } from '../lib/spend-gate.js';
+import {
+  formatUsdMicro,
+  sellerReceivesLine,
+  settlementSplit,
+} from '../lib/settle-fee.js';
 import { expandAgentRefs, resolveAgentRef } from '../lib/agent-ref.js';
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
@@ -35,6 +40,7 @@ import {
   validateAddress,
   verifyJobForSeller,
   MAX_JOB_USDC,
+  preflightCreateJob,
   type Job,
 } from '@t2000/sdk';
 import { runSponsoredTx } from '../lib/agent-register.js';
@@ -405,6 +411,50 @@ no fund step; unclaimed openings refund fee-free):
               : DEFAULT_REVIEW_WINDOW_MS;
             rejectSplitBps = Number.parseInt(opts.split, 10);
           }
+          // Preflight (S.932): terms sanity + the MAX_JOB_USDC cap, which the
+          // hire path never enforced client-side even though `open` did — a
+          // $999 hire only failed after a signature. Then the balance, then
+          // the numbers, and only then anything irreversible.
+          const pre = preflightCreateJob({
+            seller,
+            amountUsdc,
+            specHash,
+            deliverByMs,
+            reviewWindowMs,
+            rejectSplitBps,
+          });
+          if (!pre.valid) {
+            throw new Error(pre.error);
+          }
+
+          const preAgent = await withAgent({ keyPath: opts.key });
+          const bal = await preAgent.balance();
+          const usdc = bal.stables.USDC ?? 0;
+          if (usdc < amountUsdc) {
+            throw new Error(
+              `Insufficient USDC — need ${formatUsdMicro(Math.floor(amountUsdc * 1_000_000))}, wallet has ${formatUsdMicro(Math.floor(usdc * 1_000_000))}. Fund it: t2 fund`,
+            );
+          }
+
+          // Ahead of the summary on purpose: printing "here is what will
+          // happen" and then refusing on the daily cap reads as a broken
+          // promise. sponsoredJobVerb asserts again (pure read, idempotent).
+          assertSpendAllowed(amountUsdc);
+
+          // The buyer sees the price BEFORE signing. On a listing hire the
+          // price comes from the seller's listing, not from anything typed on
+          // this command line, so printing it is the only way they see it.
+          const split = settlementSplit(amountUsdc);
+          if (!isJsonMode()) {
+            printBlank();
+            printInfo('Hire preflight');
+            printKeyValue('  Escrow', `${split.escrow} USDC (leaves your wallet on sign)`);
+            printKeyValue('  Seller', truncateAddress(seller));
+            if (serviceSlug) printKeyValue('  Service', serviceSlug);
+            printKeyValue('  Deliver by', new Date(deliverByMs).toISOString());
+            printKeyValue('  Settle fee', `${split.fee} from the seller's payout — not added to your escrow`);
+          }
+
           const { address, digest } = await sponsoredJobVerb({
             base,
             keyPath: opts.key,
@@ -437,7 +487,7 @@ no fund step; unclaimed openings refund fee-free):
           }
 
           if (isJsonMode()) {
-            printJson({ jobId, digest, buyer: address, seller, amountUsdc, specHash, deliverByMs, reviewWindowMs, rejectSplitBps, ...(serviceSlug ? { service: serviceSlug } : {}) });
+            printJson({ jobId, digest, buyer: address, seller, amountUsdc, specHash, deliverByMs, reviewWindowMs, rejectSplitBps, feeBps: split.feeBps, sellerReceiveUsdc: split.payoutMicro / 1_000_000, ...(serviceSlug ? { service: serviceSlug } : {}) });
             return;
           }
           printBlank();
@@ -445,6 +495,7 @@ no fund step; unclaimed openings refund fee-free):
           if (jobId) printKeyValue('Job', jobId);
           printKeyValue('Spec hash', specHash);
           printKeyValue('Deliver by', new Date(deliverByMs).toISOString());
+          printKeyValue('Seller receives', sellerReceivesLine(amountUsdc));
           if (digest) printKeyValue('Tx', digest);
           printBlank();
           if (jobId) {

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -14,6 +14,12 @@
 // sha256 of the exact payload (same construction as the services catalog).
 
 import { createHash } from 'node:crypto';
+import {
+  sellerReceivesLine,
+  SERVICES_SETTLE_FEE_BPS,
+  SETTLE_FEE_NOTE,
+  settlementSplit,
+} from '../lib/settle-fee.js';
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
 import pc from 'picocolors';
@@ -112,7 +118,10 @@ function formatSla(minutes: number): string {
 function printService(o: ServiceListing) {
   const flag = o.retired ? pc.dim(' (retired)') : '';
   printLine(`${pc.bold(o.name)} ${pc.dim(`· ${o.slug}`)}${flag}`);
-  printKeyValue('Price', `$${o.priceUsdc.toFixed(2)} USDC`);
+  printKeyValue(
+    'Price',
+    `$${o.priceUsdc.toFixed(2)} USDC ${pc.dim(`· seller receives ${settlementSplit(o.priceUsdc).payout}`)}`,
+  );
   printKeyValue('Delivery', `within ${formatSla(o.slaMinutes)}`);
   printKeyValue(
     'Seller',
@@ -238,15 +247,23 @@ Examples:
           });
 
           if (isJsonMode()) {
-            printJson({ address, ...payload });
+            printJson({
+              address,
+              ...payload,
+              feeBps: SERVICES_SETTLE_FEE_BPS,
+              sellerReceiveUsdc: settlementSplit(priceUsdc).payoutMicro / 1_000_000,
+            });
             return;
           }
           printBlank();
           printSuccess(`"${payload.name}" is listed — $${priceUsdc.toFixed(2)} USDC, delivery within ${formatSla(slaMinutes)}`);
+          // Say the fee at listing time, not at settlement time (S.932).
+          printKeyValue('You receive', sellerReceivesLine(priceUsdc));
           printKeyValue('Slug', slug);
           printKeyValue('Storefront', `https://t2000.ai/${address}`);
           printKeyValue('Buyers run', `t2 job hire --agent ${address} --service ${slug}`);
           printBlank();
+          printInfo(SETTLE_FEE_NOTE);
           printInfo('Watch for incoming jobs with: t2 job watch --mine');
           printBlank();
         } catch (error) {

--- a/packages/cli/src/lib/settle-fee.test.ts
+++ b/packages/cli/src/lib/settle-fee.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatUsdMicro,
+  sellerReceivesLine,
+  SERVICES_SETTLE_FEE_BPS,
+  settlementSplit,
+} from './settle-fee.js';
+
+// A seller reads these numbers when deciding what to charge. Rounding UP would
+// promise money the chain never pays, so the split floors the fee exactly the
+// way the Move contract does and the seller keeps the remainder.
+
+describe('formatUsdMicro', () => {
+  it('shows every micro that exists, never fewer than 2dp', () => {
+    expect(formatUsdMicro(47_500)).toBe('$0.0475');
+    expect(formatUsdMicro(2_500)).toBe('$0.0025');
+    expect(formatUsdMicro(50_000)).toBe('$0.05');
+    expect(formatUsdMicro(1_000_000)).toBe('$1.00');
+    expect(formatUsdMicro(12_345_678)).toBe('$12.345678');
+  });
+
+  it('floors — a displayed payout is never more than the real one', () => {
+    expect(formatUsdMicro(1_999_999.9)).toBe('$1.999999');
+    expect(formatUsdMicro(0)).toBe('$0.00');
+  });
+
+  it('refuses to guess on garbage', () => {
+    expect(formatUsdMicro(Number.NaN)).toBe('—');
+    expect(formatUsdMicro(-1)).toBe('—');
+  });
+});
+
+describe('settlementSplit', () => {
+  it('takes the fee from the payout, never from the buyer', () => {
+    const s = settlementSplit(0.05);
+    expect(s.escrow).toBe('$0.05'); // buyer's number is untouched
+    expect(s.fee).toBe('$0.0025');
+    expect(s.payout).toBe('$0.0475');
+    expect(s.feeMicro + s.payoutMicro).toBe(50_000);
+  });
+
+  it('never loses a micro to rounding, at any size', () => {
+    for (const price of [0.01, 0.05, 0.1, 1, 5, 12.34, 50]) {
+      const s = settlementSplit(price);
+      expect(s.feeMicro + s.payoutMicro).toBe(Math.floor(price * 1_000_000));
+    }
+  });
+
+  it('floors the fee, so the seller keeps the remainder', () => {
+    // 12.34 × 5% = 0.617 exactly; no silent rounding to $0.62.
+    const s = settlementSplit(12.34);
+    expect(s.fee).toBe('$0.617');
+    expect(s.payout).toBe('$11.723');
+  });
+
+  it('honours a per-job bps that differs from the display default', () => {
+    const s = settlementSplit(1, 250);
+    expect(s.fee).toBe('$0.025');
+    expect(s.payout).toBe('$0.975');
+  });
+});
+
+describe('sellerReceivesLine', () => {
+  it('names the amount, the rate and the fee', () => {
+    expect(sellerReceivesLine(5)).toBe('$4.75 after the 5% settle fee ($0.25)');
+  });
+
+  it('quotes the display default', () => {
+    expect(SERVICES_SETTLE_FEE_BPS).toBe(500);
+  });
+});

--- a/packages/cli/src/lib/settle-fee.ts
+++ b/packages/cli/src/lib/settle-fee.ts
@@ -1,0 +1,82 @@
+// The services settle fee, said out loud (S.932).
+//
+// Beta feedback: a seller listed a service and nowhere in the CLI did the
+// word "fee" appear outside the phrase "fee-free". The 5% is real — it comes
+// off the SELLER's payout at settle, never on top of the buyer's escrow — and
+// a seller finding out at settlement is finding out too late.
+//
+// One module so `service` and `job` can't drift into two different numbers or
+// two different roundings.
+
+/**
+ * Display default for the services settle fee.
+ *
+ * On-chain truth is the `fee_bps` locked into each Job at funding (from
+ * FeeConfig), which is what actually settles. This constant exists so human
+ * output has one number to quote, NOT so the CLI becomes a second source of
+ * truth for the fee.
+ */
+export const SERVICES_SETTLE_FEE_BPS = 500;
+
+const MICRO = 1_000_000;
+const TRAILING_ZEROS = /0+$/;
+
+/** Exact USDC from integer micro-units — up to 6dp, trailing zeros trimmed,
+ *  never fewer than 2dp, and always floored. A seller's "you receive" that
+ *  rounds UP is a promise the chain won't keep. */
+export function formatUsdMicro(micro: number): string {
+  if (!Number.isFinite(micro) || micro < 0) {
+    return '—';
+  }
+  const m = Math.floor(micro);
+  const whole = Math.floor(m / MICRO);
+  const frac = String(m % MICRO).padStart(6, '0');
+  const dp = Math.max(2, frac.replace(TRAILING_ZEROS, '').length);
+  return `$${whole}.${frac.slice(0, dp)}`;
+}
+
+export interface SettlementSplit {
+  /** What the buyer escrows — the listed price, unchanged. */
+  escrowUsdc: number;
+  feeBps: number;
+  feeMicro: number;
+  payoutMicro: number;
+  /** Display strings, floored. */
+  escrow: string;
+  fee: string;
+  payout: string;
+}
+
+/**
+ * Split a price into the protocol fee and the seller's payout using the same
+ * integer micro math the Move contract does: floor the fee, seller keeps the
+ * remainder. The buyer's number never changes — the fee is not added on top.
+ */
+export function settlementSplit(
+  priceUsdc: number,
+  feeBps: number = SERVICES_SETTLE_FEE_BPS,
+): SettlementSplit {
+  const escrowMicro = Math.floor(priceUsdc * MICRO);
+  const feeMicro = Math.floor((escrowMicro * feeBps) / 10_000);
+  const payoutMicro = escrowMicro - feeMicro;
+  return {
+    escrowUsdc: priceUsdc,
+    feeBps,
+    feeMicro,
+    payoutMicro,
+    escrow: formatUsdMicro(escrowMicro),
+    fee: formatUsdMicro(feeMicro),
+    payout: formatUsdMicro(payoutMicro),
+  };
+}
+
+/** Seller-facing one-liner for a listed price. */
+export function sellerReceivesLine(priceUsdc: number): string {
+  const s = settlementSplit(priceUsdc);
+  return `${s.payout} after the ${s.feeBps / 100}% settle fee (${s.fee})`;
+}
+
+/** The standing disclosure, one sentence. Buyers escrow the listed price;
+ *  the fee is the seller's, and a refund costs neither side anything. */
+export const SETTLE_FEE_NOTE =
+  `Services settle at ${SERVICES_SETTLE_FEE_BPS / 100}% from the seller's payout — never added to the buyer's escrow. Refunds, cancels and declines are fee-free.`;


### PR DESCRIPTION
Three beta Highs, all the same shape: **the CLI knew something the person didn't.**

## A — the 5% said out loud

The word "fee" appeared in the CLI only inside the phrase *"fee-free"*. A seller listed a service and found out their real number at settlement.

| Surface | Now |
|---|---|
| `service create` | `You receive: $4.75 after the 5% settle fee ($0.25)` + the standing note |
| `services` / `service list` row | `Price: $0.02 USDC · seller receives $0.019` |
| `job hire` preflight + success | escrow, and `Seller receives …` |
| JSON | `feeBps` + `sellerReceiveUsdc` — machines keep working |

`lib/settle-fee.ts` owns bps → strings so `service` and `job` can't drift, with `SERVICES_SETTLE_FEE_BPS = 500` commented as a **display default** — on-chain truth stays the per-Job `fee_bps`. It **floors**: a payout that rounds up promises money the chain won't pay. `$12.34 → fee $0.617, payout $11.723`, and `feeMicro + payoutMicro === escrowMicro` at every size tested.

The buyer's number never changes — the fee is not added on top, and refunds/cancels/declines stay fee-free.

## B — hire preflight

`open` capped at `MAX_JOB_USDC` client-side. **Hire didn't** — a `$999` hire only failed *after* a signature.

```
$ t2 job hire 999 0xSELLER --spec 0x…
  ✗ v1 caps escrow jobs at 50 USDC … Got 999.        ← client-side, no signature

$ t2 job hire 1 0xSELLER --spec 0x…
  ✗ Insufficient USDC — need $1.00, wallet has $0.57625. Fund it: t2 fund
```

Order is now caps → balance → **spend gate** → summary → prepare/sign. The gate moved *ahead* of the summary deliberately: printing "here is what will happen" and then refusing on the daily cap reads as a broken promise.

The summary matters most on a **listing** hire, where the price comes from the seller's listing and not from anything typed on the command line — printing it is the only way the buyer sees it before signing.

## C — install.sh

No live doc recommended `curl … | bash` any more; only a historical changelog line did, now past-tense with the npm path named. **The live 200 is fixed in [audric #210](https://github.com/mission69b/audric/pull/210)** — `/install.sh` was returning the SPA as `text/html` 200, so the old snippet piped a Next.js document into a shell.

No installer was built. Canonical install remains `npm install -g @t2000/cli`.

## Verify

`lint` · `typecheck` · `build` clean; **240 tests** (9 new for the fee split). Cap and balance refusals verified on the built binary, as shown above; `services` row verified against a live listing.

**Not verified live:** the happy-path preflight summary. Rendering it requires a hire that then signs and spends real USDC — founder's smoke. Its inputs (split, seller, slug, deliver-by) are each proven above.

**No version bump, no publish.**