### PR TITLE
🔧 chore(cli): remove dead formatApyPercent (S.934)

### DIFF
--- a/packages/cli/src/output.test.ts
+++ b/packages/cli/src/output.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { explorerUrl, setJsonMode, isJsonMode, formatApyPercent } from './output.js';
+import { explorerUrl, setJsonMode, isJsonMode } from './output.js';
 
 describe('explorerUrl', () => {
   it('builds mainnet URL by default', () => {
@@ -15,49 +15,6 @@ describe('explorerUrl', () => {
   it('builds mainnet URL when explicitly specified', () => {
     const url = explorerUrl('0xdef456', 'mainnet');
     expect(url).toBe('https://suiscan.xyz/mainnet/tx/0xdef456');
-  });
-});
-
-describe('formatApyPercent', () => {
-  // Regression for S.318 — SDK returns APY in DECIMAL form
-  // (e.g. 0.0473 = 4.73%). Pre-S.318 every CLI display did
-  // `apy.toFixed(2)` directly which produced "0.05%" instead of "4.73%".
-  // formatApyPercent multiplies by 100 in ONE place so every display site
-  // gets the conversion right by construction.
-
-  it('converts NAVI USDC supply apy (0.0473) to "4.73%"', () => {
-    expect(formatApyPercent(0.0473)).toBe('4.73%');
-  });
-
-  it('converts NAVI USDC borrow apy (0.0489) to "4.89%"', () => {
-    expect(formatApyPercent(0.0489)).toBe('4.89%');
-  });
-
-  it('converts the realistic decimal-form value from agent.rates()', () => {
-    // This is the actual value `agent.rates()` returned on 2026-05-25
-    // during the smoke that surfaced the bug.
-    expect(formatApyPercent(0.047259999999999996)).toBe('4.73%');
-  });
-
-  it('handles 0 (no-yield case)', () => {
-    expect(formatApyPercent(0)).toBe('0.00%');
-  });
-
-  it('handles 1.0 (100% APY edge case)', () => {
-    expect(formatApyPercent(1.0)).toBe('100.00%');
-  });
-
-  it('supports custom digit precision', () => {
-    expect(formatApyPercent(0.0473, 1)).toBe('4.7%');
-    expect(formatApyPercent(0.0473, 4)).toBe('4.7300%');
-  });
-
-  it('never accidentally renders percent-as-decimal (the S.318 regression we caught)', () => {
-    // If someone reintroduces the bug, the input to formatApyPercent
-    // would be 4.73 (already percent form) and would render as "473.00%"
-    // — which would be obvious in any smoke run. This test pins the
-    // contract: input MUST be decimal form.
-    expect(formatApyPercent(4.73)).toBe('473.00%');
   });
 });
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -68,20 +68,6 @@ export function printSeparator() {
   console.log(`  ${pc.dim('──────────────────────────────────────')}`);
 }
 
-/**
- * Format an APY value for display.
- *
- * The SDK returns APYs in **decimal form** — e.g. `agent.rates()` returns
- * `{ USDC: { saveApy: 0.0473 } }` meaning 4.73%. Every consumer that wants
- * to render `4.73%` must multiply by 100 first.
- *
- * Use this helper at EVERY APY display site to keep the conversion in one
- * place. Without it the CLI accumulates off-by-100x bugs (S.318).
- */
-export function formatApyPercent(decimal: number, digits = 2): string {
-  return `${(decimal * 100).toFixed(digits)}%`;
-}
-
 export function explorerUrl(txHash: string, network = 'mainnet'): string {
   const base = network === 'testnet'
     ? 'https://suiscan.xyz/testnet/tx'


### PR DESCRIPTION
An APY formatter with no APYs.

`formatApyPercent`'s only importer was its own test, and its doc comment cited `agent.rates()` / `saveApy` — an SDK surface that left with DeFi on 2026-06-14 (S.444). The function and its 7-case regression block go together; keeping the tests would have meant testing something nothing calls.

```
rg -n "formatApyPercent" packages apps --glob '!node_modules'   → zero hits
```

`lint` · `typecheck` · `build` clean; **233 tests across 17 files** (was 240 — the 7 removed are the APY block).

## The optional half: checked, deliberately not taken

I ran the hard checks and the answer came back "leave it", on evidence rather than caution:

**1. The import costs nothing at runtime.** `SuiJsonRpcClient` is used only in type positions, so TypeScript already elides it:

| bundle | `jsonRpc` occurrences |
|---|---|
| `dist/index.js` | **0** |
| `dist/browser.js` | **0** |
| `dist/index.cjs` | **0** |
| `dist/*.d.ts` | present — type-only, as expected |

Switching to `import type` would be pure explicitness with zero functional gain, on a published package.

**2. Narrowing the union is not internal-only.** `SuiCoreClient` isn't exported from `index.ts` or `browser.ts`, so at first glance it looks free to change — but it's the parameter type of ~40 sites including **exported** functions (`getJob`, `executeTx`, `composeTx`, the wallet builders). Narrowing `SuiJsonRpcClient | SuiGrpcClient` → `SuiGrpcClient` would tighten those signatures for anyone still passing a JSON-RPC client. Their code is already broken at runtime (mainnet JSON-RPC was deactivated 2026-07-31), but their *build* would newly fail — a type-surface break landing in what would be a patch.

Per the brief's "prefer leave when unsure", and because the only real benefit was already delivered by the compiler, the SDK is untouched. No new JSON-RPC usage was introduced anywhere.

## Also untouched, per the brief

`classify.test.ts` NAVI/suilend strings (may still classify historical ledger rows), BlockVision comments, S.933 middleware/robots/tombstone.

**No version bump, no publish** — this is dead-code removal with no consumer-visible effect, so it can ride the next release whenever you cut one.