### PR TITLE
🐛 fix(sdk): loud shape error for malformed serializedRoute (S.947)

### DIFF
--- a/packages/sdk/src/swap-route-binding.test.ts
+++ b/packages/sdk/src/swap-route-binding.test.ts
@@ -151,4 +151,56 @@ describe('T2000.swap serializedRoute binding', () => {
     await expect(agent.swap({ from: 'SUI', to: 'USDC', amount: 1 })).rejects.toThrow(SENTINEL);
     expect(findSwapRoute).toHaveBeenCalledTimes(1);
   });
+
+  // S.947 — the "undefined -> undefined" bug class: agents passed the WHOLE
+  // swapQuote response (or a stripped partial) as serializedRoute. The whole
+  // response unwraps once and executes; anything without the coin-type
+  // snapshot fails loud with a shape error, never "undefined -> undefined".
+
+  it('the WHOLE quote response as serializedRoute unwraps once and executes', async () => {
+    const agent = makeAgent();
+    stubBalance(agent);
+    const wholeQuoteResponse = {
+      fromToken: 'SUI',
+      toToken: 'USDC',
+      fromAmount: 1,
+      toAmount: 3.5,
+      priceImpact: 0.001,
+      route: 'FLOWXV3 + AFTERMATH',
+      serializedRoute: quotedRoute(),
+    };
+    await expect(
+      agent.swap({
+        from: 'SUI',
+        to: 'USDC',
+        amount: 1,
+        serializedRoute: wholeQuoteResponse as never,
+      }),
+    ).rejects.toThrow(SENTINEL);
+    expect(findSwapRoute).not.toHaveBeenCalled();
+  });
+
+  it('a shape without coin types fails loud with the recovery — never "undefined -> undefined"', async () => {
+    const agent = makeAgent();
+    const stripped = { ...quotedRoute() } as Record<string, unknown>;
+    stripped.fromCoinType = undefined;
+    stripped.toCoinType = undefined;
+    const err = await agent
+      .swap({ from: 'SUI', to: 'USDC', amount: 1, serializedRoute: stripped as never })
+      .then(() => null, (e: unknown) => e);
+    expect(err).toBeInstanceOf(T2000Error);
+    expect((err as T2000Error).code).toBe('SWAP_ROUTE_MISMATCH');
+    expect((err as T2000Error).message).toMatch(/missing fromCoinType\/toCoinType/);
+    expect((err as T2000Error).message).not.toMatch(/undefined -> undefined/);
+    expect(findSwapRoute).not.toHaveBeenCalled();
+  });
+
+  it('the mismatch message reports full coin types on the expected side', async () => {
+    const agent = makeAgent();
+    const err = await agent
+      .swap({ from: 'USDC', to: 'SUI', amount: 1, serializedRoute: quotedRoute() })
+      .then(() => null, (e: unknown) => e);
+    expect((err as T2000Error).message).toContain(USDC_TYPE);
+    expect((err as T2000Error).message).toContain(SUI_TYPE);
+  });
 });

--- a/packages/sdk/src/t2000.ts
+++ b/packages/sdk/src/t2000.ts
@@ -293,11 +293,31 @@ export class T2000 extends EventEmitter<T2000Events> {
     let route: SwapRouteResult | null;
     if (params.serializedRoute) {
       // Quote-bound execution: validate, never silently re-discover.
-      const s = params.serializedRoute;
+      let s = params.serializedRoute;
+      // Shape forgiveness (one level only): agents often pass the WHOLE
+      // swapQuote response — `{ ..., serializedRoute: {...} }` — instead of
+      // its `serializedRoute` field. If the nested object has the real
+      // shape, unwrap it once; anything else still fails loud below.
+      const nested = (s as { serializedRoute?: SerializedCetusRoute }).serializedRoute;
+      if (
+        nested && typeof nested === 'object' &&
+        typeof nested.fromCoinType === 'string' && nested.routerData
+      ) {
+        s = nested;
+      }
+      // A real quote ALWAYS carries the coin-type snapshot
+      // (serializeCetusRoute sets both). Absent types = this is not the
+      // object t2000 quoted — say so, instead of "undefined -> undefined".
+      if (typeof s.fromCoinType !== 'string' || typeof s.toCoinType !== 'string') {
+        throw new T2000Error(
+          'SWAP_ROUTE_MISMATCH',
+          'serializedRoute is not the object t2000 quoted — it is missing fromCoinType/toCoinType. Pass quote.serializedRoute exactly as the quote returned it (not the whole quote response), or omit serializedRoute to discover a fresh route.',
+        );
+      }
       if (!verifyCetusRouteCoinMatch(s, { fromCoinType: fromType, toCoinType: toType })) {
         throw new T2000Error(
           'SWAP_ROUTE_MISMATCH',
-          `The quoted route is for ${s.fromCoinType} -> ${s.toCoinType}, not ${params.from} -> ${params.to}. Re-quote and pass the new serializedRoute.`,
+          `The quoted route is for ${s.fromCoinType} -> ${s.toCoinType}, not ${fromType} -> ${toType}. Re-quote and pass the new serializedRoute.`,
         );
       }
       if (s.byAmountIn !== byAmountIn || BigInt(s.amountIn) !== rawAmount) {


### PR DESCRIPTION
## Bug

Connect swaps failed with `The quoted route is for undefined -> undefined, not 0x…USDC -> 0x…DEEP`. Root: `T2000.swap` verifies the bound route's coin snapshot, but agents often pass the **whole** `swapQuote` response (or a stripped partial) as `serializedRoute` — so `fromCoinType`/`toCoinType` were `undefined` and the mismatch message printed them.

## Fix (packages/sdk/src/t2000.ts — binding unchanged for well-formed routes)

1. **Unwrap once**: if the arg carries a nested `.serializedRoute` with the real shape (`routerData` + string `fromCoinType`), use it — the whole-quote mistake now simply works.
2. **Fail loud on shape**: absent coin types after the unwrap → `SWAP_ROUTE_MISMATCH` with an explicit recovery ("pass `quote.serializedRoute` exactly as the quote returned it, or omit it to discover a fresh route") — never "undefined -> undefined".
3. **Better mismatch message**: the expected side now reports the resolved full coin types (`fromType -> toType`) instead of raw `params.from/to`.

No change to Cetus routing, freshness/amount binding, or rediscovery semantics — coin types present-but-wrong still fail loud, never silently re-route.

## Tests

`swap-route-binding.test.ts` +3: whole-quote response unwraps and executes (reaches the execute sentinel, `findSwapRoute` never called) · typeless shape fails with the new message and never the `undefined ->` string · mismatch message carries both full coin types. **554/554**, `tsc` clean, lint 0 errors (7 pre-existing warnings in unrelated test files).

Companion audric PR adds the same unwrap + a no-spend shape recovery to Connect `t2000_swap` (works with the current published SDK; this SDK fix rides the next patch release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)