### PR TITLE
✨ feat(sdk): send any held coin type (S.957)

### DIFF
--- a/apps/docs/agent-wallet.mdx
+++ b/apps/docs/agent-wallet.mdx
@@ -44,7 +44,7 @@ The core loop is four commands — everything else (swap, history, limits, ident
 |---|---|
 | `t2 init` | Create the wallet + a free on-chain Agent ID. `--import` restores a `suiprivkey1…` secret. |
 | `t2 fund` | Deposit address + QR. |
-| `t2 send <amount> <asset> <recipient>` | USDC / USDsui (gasless) or SUI. Recipient: `0x…` or SuiNS name (incl. subnames like `alice.audric.sui`). |
+| `t2 send <amount> <asset> <recipient>` | Any held token — registry symbol (`USDC`, `MANIFEST`) or full coin type. USDC / USDsui are gasless; the rest need SUI for gas. Recipient: `0x…` or SuiNS name (incl. subnames like `alice.audric.sui`). |
 | `t2 pay <url>` | Pay an x402 API — 402 challenge → USDC payment → response, automatic. |
 
 Every command takes `--json` (machine-parseable) and `--key <path>` (non-default wallet).

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -36,7 +36,7 @@ t2 history          # last transactions, newest first
 
 | Command | What it does |
 | --- | --- |
-| `t2 send <amount> <asset> <recipient>` | Send USDC, USDsui, or SUI. USDC + USDsui are gasless. Recipient: `0x…` address, SuiNS name, or `@audric` handle. |
+| `t2 send <amount> <asset> <recipient>` | Send any held token (registry symbol or full coin type). USDC + USDsui are gasless; everything else needs SUI for gas. Recipient: `0x…` address, SuiNS name, or `@audric` handle. |
 | `t2 swap <amount> <from> <to>` | Swap any token pair via the Cetus aggregator. `--quote` previews without executing; `--slippage <pct>` caps slippage (default 1%). |
 
 ```bash

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -85,7 +85,7 @@ That's why Connect exposes `t2000_agent_register`, `t2000_job_board` and
 | **Releases escrow (no new debit)** | `t2000_job_settle` — always pays the **full** escrow already locked in the Job to the seller (− protocol fee); there is no partial settle, and nothing new leaves your balance |
 | **Free** | `t2000_agent_register` · `t2000_job_claim` · `t2000_job_deliver` · `t2000_job_cancel` · `t2000_job_decline` · `t2000_job_review` · `t2000_service_create` · `t2000_resolve` · every read tool |
 
-Sends (USDC / USDsui / SUI, to a `0x` address, SuiNS name, or `name@audric`
+Sends (any held token — USDC / USDsui gasless, the rest gas-paid — to a `0x` address, SuiNS name, or `name@audric`
 Passport handle) run under the session limits and ask-above approval — the
 agent echoes the resolved `0x` back before anything is treated as final. After
 a delivery's review window lapses, release is **permissionless**: anyone may

--- a/packages/cli/src/commands/send.test.ts
+++ b/packages/cli/src/commands/send.test.ts
@@ -1,7 +1,8 @@
 // [SPEC_AGENT_WALLET_GREENFIELD Phase A Day 3 — 2026-05-26]
-// Parser tests for `t2 send <amount> <asset> <recipient>` v4 surface.
-// Locks in the SPEC's "asset required, no USDC default" rule + the
-// constrained whitelist (USDC / USDsui / SUI).
+// Parser tests for `t2 send <amount> <asset> <recipient>`.
+// Locks in the "asset required, no USDC default" rule + [S.957] the
+// widened surface: any resolvable coin type (registry symbol or full
+// 0x…::module::TYPE) parses; unresolvable symbols still hard-fail.
 
 import { describe, it, expect } from 'vitest';
 import { parseSendArgs } from './send.js';
@@ -75,30 +76,38 @@ describe('parseSendArgs (v4)', () => {
     });
   });
 
-  describe('asset whitelist (USDC | USDsui | SUI)', () => {
-    it('rejects USDT with a swap hint', () => {
-      expect(() => parseSendArgs(['5', 'USDT', '0xabc'])).toThrow(/Unsupported asset/);
-      expect(() => parseSendArgs(['5', 'USDT', '0xabc'])).toThrow(/Swap to USDC or USDsui first/);
+  describe('any resolvable asset (S.957)', () => {
+    it('parses a registry alt symbol (MANIFEST) — no more "swap first"', () => {
+      expect(parseSendArgs(['10', 'MANIFEST', '0xabc'])).toEqual({
+        amount: 10,
+        asset: 'MANIFEST',
+        recipient: '0xabc',
+      });
     });
 
-    it('rejects USDY (one of the Sui-allowlisted stables we do NOT track)', () => {
-      expect(() => parseSendArgs(['5', 'USDY', '0xabc'])).toThrow(/Unsupported asset/);
+    it('parses previously-rejected registry assets (USDT / WAL / GOLD)', () => {
+      for (const asset of ['USDT', 'WAL', 'GOLD']) {
+        expect(parseSendArgs(['5', asset, '0xabc']).asset).toBe(asset);
+      }
     });
 
-    it('rejects USDe', () => {
-      expect(() => parseSendArgs(['5', 'USDe', '0xabc'])).toThrow(/Unsupported asset/);
+    it('parses a full coin type verbatim', () => {
+      const full =
+        '0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb4355::manifest::MANIFEST';
+      expect(parseSendArgs(['10', full, '0xabc'])).toEqual({
+        amount: 10,
+        asset: full,
+        recipient: '0xabc',
+      });
     });
 
-    it('rejects GOLD (XAUM)', () => {
-      expect(() => parseSendArgs(['5', 'GOLD', '0xabc'])).toThrow(/Unsupported asset/);
+    it('still rejects an unresolvable bogus symbol', () => {
+      expect(() => parseSendArgs(['5', 'FOOBAR_NOT_A_TOKEN', '0xabc'])).toThrow(/Unknown asset/);
+      expect(() => parseSendArgs(['5', 'XYZ', '0xabc'])).toThrow(/Unknown asset/);
     });
 
-    it('rejects WAL', () => {
-      expect(() => parseSendArgs(['5', 'WAL', '0xabc'])).toThrow(/Unsupported asset/);
-    });
-
-    it('rejects a bogus symbol', () => {
-      expect(() => parseSendArgs(['5', 'XYZ', '0xabc'])).toThrow(/Unsupported asset/);
+    it('rejects a malformed :: type', () => {
+      expect(() => parseSendArgs(['5', '0xnot::a', '0xabc'])).toThrow(/Unknown asset/);
     });
   });
 

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -1,18 +1,18 @@
 // [SPEC_AGENT_WALLET_GREENFIELD Phase A Day 3 — 2026-05-26]
 // `t2 send <amount> <asset> <recipient>` — v4 Agent Wallet surface.
 //
-// Contract changes vs. the pre-pivot legacy command:
+// Contract:
 //   - `<asset>` is REQUIRED. There is no USDC default. A bare
 //     `t2 send 5 alice.sui` exits 1 with a clear error.
-//   - Asset is constrained to USDC / USDsui / SUI (matches SDK
-//     `OPERATION_ASSETS.send` after Day 2). Any other token gets a
-//     `unsupported asset` error pointing at `t2 swap` as the path to
-//     get into USDC / USDsui / SUI first.
+//   - [S.957 — 2026-08-08] Asset is ANY held coin type — a registry
+//     symbol (USDC, MANIFEST, …) or a full `0x…::module::TYPE`.
+//     Unresolvable symbols still exit 1. USDC + USDsui are gasless;
+//     everything else (SUI included) needs SUI for gas.
 //   - USDC + USDsui transfers go through the SDK's gasless
-//     `0x2::balance::send_funds` path (Day 2 rewrite). When the SDK
-//     reports `gasCost === 0`, the receipt renders a `gasless ⚡`
-//     badge so the operator sees the protocol-level zero-gas semantic
-//     actually kicked in.
+//     `0x2::balance::send_funds` path. When the SDK reports
+//     `gasCost === 0`, the receipt renders a `gasless ⚡` badge so the
+//     operator sees the protocol-level zero-gas semantic actually
+//     kicked in.
 //   - PIN flow removed. Uses `withAgent` from `lib/with-agent.ts`.
 //
 // SuiNS resolution is delegated to the SDK's `T2000.resolveRecipient` —
@@ -22,7 +22,7 @@
 
 import type { Command } from 'commander';
 import pc from 'picocolors';
-import { truncateAddress, formatUsd, type SupportedAsset } from '@t2000/sdk';
+import { truncateAddress, formatUsd, classifySendAsset } from '@t2000/sdk';
 import {
   printSuccess,
   printKeyValue,
@@ -34,35 +34,40 @@ import {
 } from '../output.js';
 import { withAgent } from '../lib/with-agent.js';
 
-const ACCEPTED_ASSETS = ['USDC', 'USDsui', 'SUI'] as const;
-type AcceptedAsset = (typeof ACCEPTED_ASSETS)[number];
-
-const ACCEPTED_ASSETS_LIST = ACCEPTED_ASSETS.join(', ');
+const ASSET_HINT =
+  'a registry symbol (USDC, USDsui, SUI, MANIFEST, …) or a full coin type (0x…::module::TYPE)';
 
 /**
- * Pure parser for the v4 `t2 send` positional args.
+ * Pure parser for the `t2 send` positional args.
  *
  * Accepted shapes (all asset-required):
  *   - `t2 send 5 USDC 0x…`
+ *   - `t2 send 10 MANIFEST 0x…`                    ← S.957: any held token
+ *   - `t2 send 10 0xc466…::manifest::MANIFEST 0x…` ← full coin type
  *   - `t2 send 5 USDC alice.sui`
- *   - `t2 send 5 USDC alice.audric.sui`
  *   - `t2 send 5 USDC to 0x…`  ← legacy "to" filler word still tolerated
  *
  * Rejected:
- *   - `t2 send 5 0x…`            → asset required
- *   - `t2 send 5`                → usage error
- *   - `t2 send 5 USDY 0x…`       → unsupported asset
+ *   - `t2 send 5 0x…`               → asset required
+ *   - `t2 send 5`                   → usage error
+ *   - `t2 send 5 FOOBAR 0x…`        → unresolvable asset
+ *
+ * [S.957] Validation delegates to the SDK's `classifySendAsset` — the same
+ * resolvability rule the write path enforces (single source of truth). The
+ * returned `asset` keeps the canonical symbol for the big three (so display
+ * stays `USDsui`, not `usdsui`) and passes anything else through verbatim
+ * for the SDK to resolve again.
  */
 export function parseSendArgs(args: string[]): {
   amount: number;
-  asset: AcceptedAsset;
+  asset: string;
   recipient: string;
 } {
   const filtered = args.filter((a) => a.toLowerCase() !== 'to');
 
   if (filtered.length < 2) {
     throw new Error(
-      `Usage: t2 send <amount> <asset> <recipient>\n  asset must be one of: ${ACCEPTED_ASSETS_LIST}\n  recipient can be a 0x address or SuiNS name (alice.sui, alice.audric.sui)`,
+      `Usage: t2 send <amount> <asset> <recipient>\n  asset is ${ASSET_HINT}\n  recipient can be a 0x address or SuiNS name (alice.sui, alice.audric.sui)`,
     );
   }
 
@@ -70,7 +75,7 @@ export function parseSendArgs(args: string[]): {
     // `t2 send 5 alice.sui` — asset omitted. Error rather than
     // silently defaulting to USDC.
     throw new Error(
-      `Missing required <asset> argument. Use one of: ${ACCEPTED_ASSETS_LIST}. Example: t2 send ${filtered[0]} USDC ${filtered[1]}`,
+      `Missing required <asset> argument. Use ${ASSET_HINT}. Example: t2 send ${filtered[0]} USDC ${filtered[1]}`,
     );
   }
 
@@ -80,10 +85,10 @@ export function parseSendArgs(args: string[]): {
   }
 
   const candidate = filtered[1];
-  const normalized = normalizeAssetSymbol(candidate);
-  if (!normalized) {
+  const cls = classifySendAsset(candidate);
+  if (!cls) {
     throw new Error(
-      `Unsupported asset "${candidate}". Use one of: ${ACCEPTED_ASSETS_LIST}. Swap to USDC or USDsui first with \`t2 swap\`, or send SUI.`,
+      `Unknown asset "${candidate}". Use ${ASSET_HINT}. Check your holdings with \`t2 balance\`.`,
     );
   }
 
@@ -92,20 +97,11 @@ export function parseSendArgs(args: string[]): {
     throw new Error(`Missing recipient. Usage: t2 send <amount> <asset> <recipient>.`);
   }
 
-  return { amount, asset: normalized, recipient };
-}
-
-/**
- * Case-insensitive normalisation. `usdc` / `USDC` / `usdsui` /
- * `USDSUI` / `USDsui` / `sui` / `SUI` all map. Anything else returns
- * `undefined`.
- */
-function normalizeAssetSymbol(input: string): AcceptedAsset | undefined {
-  const lower = input.toLowerCase();
-  if (lower === 'usdc') return 'USDC';
-  if (lower === 'usdsui') return 'USDsui';
-  if (lower === 'sui') return 'SUI';
-  return undefined;
+  // Canonical symbol for the well-known three (display consistency); a full
+  // coin type or alt symbol passes through as typed — the SDK re-resolves.
+  const asset =
+    cls.kind === 'gasless-stable' || cls.kind === 'sui' ? cls.symbol : candidate;
+  return { amount, asset, recipient };
 }
 
 export function registerSend(program: Command) {
@@ -114,9 +110,11 @@ export function registerSend(program: Command) {
     .argument('<amount>', 'Amount of <asset> to send (denominated in asset units, NOT USD)')
     .argument(
       '[args...]',
-      'Asset (USDC | USDsui | SUI), optional "to" keyword, and recipient (0x address or SuiNS name like alice.sui)',
+      'Asset (registry symbol like USDC / MANIFEST, or a full 0x…::module::TYPE coin type), optional "to" keyword, and recipient (0x address or SuiNS name like alice.sui)',
     )
-    .description('Send USDC, USDsui, or SUI. USDC + USDsui are gasless (no SUI required).')
+    .description(
+      'Send any held token. USDC + USDsui are gasless; everything else needs SUI for gas.',
+    )
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--force', 'Override spending limits for this call (see `t2 limit`)')
     .addHelpText(
@@ -126,6 +124,8 @@ Examples:
   $ t2 send 5 USDC 0xabc…              Send 5 USDC (gasless) to a hex address
   $ t2 send 5 USDsui alice.sui         Send 5 USDsui (gasless) to a SuiNS name
   $ t2 send 0.1 SUI alice.audric.sui   Send 0.1 SUI (gas required) to a SuiNS subname
+  $ t2 send 10 MANIFEST 0xabc…         Send any held token (gas required)
+  $ t2 send 10 0xc466…::manifest::MANIFEST 0xabc…   Full coin type works too
 `,
     )
     .action(async (amount: string, args: string[], opts: { key?: string; force?: boolean }) => {
@@ -140,10 +140,9 @@ Examples:
         const result = await agent.send({
           to: recipient,
           amount: parsedAmount,
-          // The CLI parser already narrowed asset to USDC / USDsui / SUI;
-          // the SDK accepts `SupportedAsset` and re-validates via
-          // `assertAllowedAsset('send', …)` at runtime.
-          asset: asset as SupportedAsset,
+          // [S.957] Any resolvable asset string — the SDK re-resolves via
+          // `classifySendAsset` (same rule the parser used).
+          asset,
           force: opts.force,
         });
 
@@ -160,9 +159,14 @@ Examples:
           ? `${result.suinsName} ${pc.dim(`(${truncateAddress(result.to)})`)}`
           : truncateAddress(result.to);
 
-        const amountDisplay = asset === 'SUI'
-          ? `${result.amount.toFixed(4)} SUI`
-          : `${formatUsd(result.amount)} ${asset}`;
+        // Stables render as USD (1:1); SUI keeps its 4dp habit; any other
+        // token renders plain `<amount> <asset>` — never an invented $.
+        const amountDisplay =
+          asset === 'USDC' || asset === 'USDsui'
+            ? `${formatUsd(result.amount)} ${asset}`
+            : asset === 'SUI'
+              ? `${result.amount.toFixed(4)} SUI`
+              : `${result.amount} ${asset}`;
 
         printBlank();
         printSuccess(`Sent ${amountDisplay} → ${displayTo}`);

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -103,7 +103,8 @@ export type { SwapRouteResult, OverlayFeeConfig } from './protocols/cetus-swap.j
 // host runs these in the agent loop before the tap-to-confirm card.
 // buildSendTx is browser-safe (builds a gasless PTB; the client is injected) —
 // the Audric client signs it in-browser with the zkLogin session (send_transfer).
-export { buildSendTx, preflightSend } from './wallet/send.js';
+export { buildSendTx, preflightSend, classifySendAsset, invalidSendAssetMessage } from './wallet/send.js';
+export type { SendAssetClass } from './wallet/send.js';
 
 // A2A escrow job builders + readers — browser-safe (client injected, no fs).
 // Store surfaces build the buyer-side legs on a zkLogin session key.

--- a/packages/sdk/src/composeTx.ts
+++ b/packages/sdk/src/composeTx.ts
@@ -78,7 +78,7 @@ import {
   GASLESS_MIN_STABLE_AMOUNT,
   GASLESS_STABLE_TYPES,
   SUPPORTED_ASSETS,
-  assertAllowedAsset,
+  SENDABLE_ASSETS,
   type SendableAsset,
   type SupportedAsset,
 } from './constants.js';
@@ -114,8 +114,8 @@ export type WriteToolName =
  * type is the wider `SupportedAsset` rather than the narrower
  * `SendableAsset` so callers that thread a wide-typed asset through
  * (primarily the engine LLM tool surface) compile without modification.
- * Runtime narrowing happens via `assertAllowedAsset('send', asset)`,
- * which throws `INVALID_ASSET` for anything outside the
+ * Runtime narrowing happens via the appender's local `SENDABLE_ASSETS`
+ * check, which throws `INVALID_ASSET` for anything outside the
  * `['USDC', 'USDsui', 'SUI']` whitelist. USDC + USDsui route through
  * the gasless `0x2::balance::send_funds` Move call; SUI uses the
  * standard `transferObjects` path.
@@ -344,18 +344,23 @@ export const WRITE_APPENDER_REGISTRY: {
   send_transfer: async (tx, input, ctx) => {
     const recipient = validateAddress(input.to);
     // [v4.0 Phase A Day 2] Asset is required (no `?? 'USDC'` default).
-    // assertAllowedAsset narrows the runtime value to
-    // `'USDC' | 'USDsui' | 'SUI'` and throws INVALID_ASSET otherwise.
-    // The TypeScript shape is `SupportedAsset` (wider, accommodates
-    // engine LLM tool callers that pass wide-typed assets through);
-    // the runtime assertion is the canonical gate.
+    // [S.957] The single-step wallet `send` widened to any coin type, but
+    // this appender keeps the narrow stables+SUI list on purpose: bundles
+    // run under Enoki sponsorship constraints (coin-object-only selection,
+    // no `coinWithBalance` FundsWithdrawal) that the generic path doesn't
+    // satisfy. Widening here is a separate, deliberate slice.
     if (!input.asset) {
       throw new T2000Error(
         'INVALID_ASSET',
         "send_transfer requires an explicit asset. Use one of: USDC, USDsui, SUI.",
       );
     }
-    assertAllowedAsset('send', input.asset);
+    if (!SENDABLE_ASSETS.some((a) => a.toLowerCase() === input.asset.toLowerCase())) {
+      throw new T2000Error(
+        'INVALID_ASSET',
+        `send_transfer only supports ${SENDABLE_ASSETS.join(', ')}. Cannot use ${input.asset}. Swap to USDC or USDsui first, or send SUI.`,
+      );
+    }
     const asset: SendableAsset = input.asset as SendableAsset;
     const assetInfo = SUPPORTED_ASSETS[asset];
     if (input.amount <= 0) {

--- a/packages/sdk/src/constants.test.ts
+++ b/packages/sdk/src/constants.test.ts
@@ -26,12 +26,13 @@ describe('STABLE_ASSETS', () => {
   });
 });
 
-// [NAVI removed] The only live operations are `send` (gasless-eligible stables
-// + SUI) and `swap` (unrestricted — Cetus routes any pair). save / borrow /
-// withdraw / repay were removed with the DeFi surface.
+// [NAVI removed] The only live operations are `send` and `swap`.
+// [S.957] BOTH are wildcards now — send widened to any resolvable coin type;
+// the real send gate is `classifySendAsset` (wallet/send.ts), which still
+// hard-fails unresolvable symbols.
 describe('OPERATION_ASSETS', () => {
-  it('restricts send to USDC + USDsui + SUI', () => {
-    expect(OPERATION_ASSETS.send).toEqual(['USDC', 'USDsui', 'SUI']);
+  it('allows any asset for send (resolvability gated in wallet/send.ts)', () => {
+    expect(OPERATION_ASSETS.send).toBe('*');
   });
 
   it('allows any asset for swap', () => {
@@ -46,18 +47,10 @@ describe('isAllowedAsset', () => {
     }
   });
 
-  it('returns true for USDC + USDsui + SUI on send, false for other assets', () => {
-    expect(isAllowedAsset('send', 'USDC')).toBe(true);
-    expect(isAllowedAsset('send', 'USDsui')).toBe(true);
-    expect(isAllowedAsset('send', 'SUI')).toBe(true);
-    expect(isAllowedAsset('send', 'usdc')).toBe(true);
-    expect(isAllowedAsset('send', 'usdsui')).toBe(true);
-    expect(isAllowedAsset('send', 'USDT')).toBe(false);
-    expect(isAllowedAsset('send', 'USDe')).toBe(false);
-    expect(isAllowedAsset('send', 'WAL')).toBe(false);
-    expect(isAllowedAsset('send', 'ETH')).toBe(false);
-    expect(isAllowedAsset('send', 'NAVX')).toBe(false);
-    expect(isAllowedAsset('send', 'GOLD')).toBe(false);
+  it('returns true for any asset on send (S.957 wildcard)', () => {
+    for (const asset of ['USDC', 'USDsui', 'SUI', 'usdc', 'USDT', 'WAL', 'MANIFEST']) {
+      expect(isAllowedAsset('send', asset)).toBe(true);
+    }
   });
 });
 
@@ -79,22 +72,9 @@ describe('assertAllowedAsset', () => {
     expect(() => assertAllowedAsset('send', 'SUI')).not.toThrow();
   });
 
-  it('throws T2000Error with INVALID_ASSET for USDT on send + hints at swap path', () => {
-    expect(() => assertAllowedAsset('send', 'USDT')).toThrow(T2000Error);
-    try {
-      assertAllowedAsset('send', 'USDT');
-    } catch (e) {
-      const err = e as T2000Error;
-      expect(err.code).toBe('INVALID_ASSET');
-      expect(err.message).toContain('send only supports USDC, USDsui, SUI');
-      expect(err.message).toContain('Cannot use USDT');
-      expect(err.message).toContain('Swap to USDC or USDsui first, or send SUI');
-    }
-  });
-
-  it('throws for WAL / ETH / NAVX / GOLD on send', () => {
-    for (const asset of ['WAL', 'ETH', 'NAVX', 'GOLD'] as const) {
-      expect(() => assertAllowedAsset('send', asset)).toThrow(T2000Error);
+  it('does not throw for registry alts on send (S.957 — gate moved to classifySendAsset)', () => {
+    for (const asset of ['USDT', 'WAL', 'ETH', 'NAVX', 'GOLD', 'MANIFEST'] as const) {
+      expect(() => assertAllowedAsset('send', asset)).not.toThrow();
     }
   });
 });

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -83,18 +83,18 @@ export const STABLE_ASSETS: readonly StableAsset[] = ['USDC', 'USDsui'] as const
 // Operation → allowed asset rules (single source of truth)
 // ---------------------------------------------------------------------------
 
-// [v4.0 Phase A Day 2 — 2026-05-26] `send` is constrained to
-// `['USDC', 'USDsui', 'SUI']`. Rationale (SPEC_AGENT_WALLET_GREENFIELD §A):
-// - USDC + USDsui are gasless via `0x2::balance::send_funds` (Sui mainnet
-//   protocol allowlist) — the two foundation stables.
-// - SUI is the only non-stable kept on the allowlist so users with no
-//   stablecoin balance can still pay gas-native SUI transfers.
-// - USDT, USDe, WAL, ETH, NAVX, GOLD are NOT sendable — users must swap to
-//   USDC/USDsui first (one-step) or hold SUI and use a manual Move call.
-// `swap` is unrestricted (Cetus routes any pair). The DeFi operations
+// [S.957 — 2026-08-08] `send` widened from `['USDC', 'USDsui', 'SUI']` to
+// `'*'`: any asset that RESOLVES to a Sui coin type (registry symbol or full
+// `0x…::module::TYPE`) with sufficient balance is sendable. The real gate is
+// `classifySendAsset` (wallet/send.ts) — unresolvable symbols still throw
+// INVALID_ASSET, and only USDC/USDsui ride the gasless
+// `0x2::balance::send_funds` path; everything else pays gas in SUI.
+// (The composeTx `send_transfer` appender keeps the narrow stables+SUI list —
+// sponsored bundles carry Enoki-shaped constraints of their own.)
+// `swap` was always unrestricted (Cetus routes any pair). The DeFi operations
 // (save/borrow/withdraw/repay) were removed with NAVI.
 export const OPERATION_ASSETS = {
-  send: ['USDC', 'USDsui', 'SUI'],
+  send: '*',
   swap: '*',
 } as const;
 
@@ -135,9 +135,10 @@ export function assertAllowedAsset(op: Operation, asset: string | undefined): vo
 }
 
 /**
- * [v4.0 Phase A Day 2] Narrow type alias for assets sendable through the
- * Agent Wallet. Matches `OPERATION_ASSETS.send` exactly. Exported so the
- * CLI / SDK / composeTx can share one type without re-declaring it.
+ * [v4.0 Phase A Day 2] Narrow type alias for the composeTx `send_transfer`
+ * appender (sponsored bundles stay stables+SUI) and the gasless docs.
+ * [S.957] No longer the single-step `send` gate — that widened to any
+ * resolvable coin type via `classifySendAsset`.
  */
 export type SendableAsset = 'USDC' | 'USDsui' | 'SUI';
 export const SENDABLE_ASSETS: readonly SendableAsset[] = ['USDC', 'USDsui', 'SUI'] as const;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -144,7 +144,8 @@ export {
   exportPrivateKey,
   getAddress,
 } from './wallet/keyManager.js';
-export { buildSendTx, addSendToTx, preflightSend } from './wallet/send.js';
+export { buildSendTx, addSendToTx, preflightSend, classifySendAsset, invalidSendAssetMessage } from './wallet/send.js';
+export type { SendAssetClass } from './wallet/send.js';
 export {
   A2A_ESCROW_PACKAGE_ID,
   MAINNET_A2A_ESCROW_PACKAGE_ID,

--- a/packages/sdk/src/preflight.test.ts
+++ b/packages/sdk/src/preflight.test.ts
@@ -72,13 +72,16 @@ describe('preflightSend', () => {
     expect(preflightSend({ to: VALID_ADDRESS, amount: 1, asset: 'USDC' })).toEqual(PREFLIGHT_OK);
   });
 
-  it('rejects a non-sendable asset with the canonical message', () => {
-    const r = preflightSend({ to: VALID_ADDRESS, amount: 1, asset: 'USDT' });
+  // [S.957] USDT is sendable now (any resolvable coin type); the hard
+  // failure is reserved for UNRESOLVABLE symbols, with the canonical message.
+  it('accepts a registry alt (USDT) and rejects an unresolvable symbol', () => {
+    expect(preflightSend({ to: VALID_ADDRESS, amount: 1, asset: 'USDT' })).toEqual(PREFLIGHT_OK);
+    const r = preflightSend({ to: VALID_ADDRESS, amount: 1, asset: 'FOOBAR_NOT_A_TOKEN' });
     expect(r.valid).toBe(false);
     if (!r.valid) {
       expect(r.code).toBe('INVALID_ASSET');
-      expect(r.error).toMatch(/send only supports USDC, USDsui, SUI/);
-      expect(r.error).toMatch(/Swap to USDC or USDsui first/);
+      expect(r.error).toMatch(/Unknown asset "FOOBAR_NOT_A_TOKEN"/);
+      expect(r.error).toMatch(/registry symbol|full coin type/);
     }
   });
 

--- a/packages/sdk/src/t2000.ts
+++ b/packages/sdk/src/t2000.ts
@@ -19,7 +19,7 @@ import { KeypairSigner } from './wallet/keypairSigner.js';
 import { executeTx } from './wallet/executeTx.js';
 import { payWithX402, probeX402, type X402Probe } from './wallet/pay.js';
 import { ZkLoginSigner, type ZkLoginProof } from './wallet/zkLoginSigner.js';
-import { buildSendTx } from './wallet/send.js';
+import { buildSendTx, classifySendAsset, invalidSendAssetMessage } from './wallet/send.js';
 import { queryBalance } from './wallet/balance.js';
 import { queryHistory, queryTransaction } from './wallet/history.js';
 import { resolveSymbol, resolveCoinDecimals } from './token-registry.js';
@@ -54,7 +54,7 @@ import {
   type ChatResult,
 } from './inference.js';
 import { verifyReceipt, type VerifyOptions, type VerifyResult } from './verify.js';
-import { SUPPORTED_ASSETS, assertAllowedAsset, type SendableAsset, type SupportedAsset } from './constants.js';
+import { SUPPORTED_ASSETS, type SupportedAsset } from './constants.js';
 
 import { truncateAddress } from './utils/sui.js';
 import { LimitEnforcer, MemoryLimitEnforcer, approxUsdValue } from './limits/index.js';
@@ -501,49 +501,43 @@ export class T2000 extends EventEmitter<T2000Events> {
   /**
    * Send `amount` of `asset` to `to` (hex address or SuiNS name).
    *
-   * [v4.0 Phase A Day 2 — SPEC_AGENT_WALLET_GREENFIELD §A]
+   * [S.957 — 2026-08-08] `asset` accepts **any held coin type** — a
+   * registry symbol (`USDC`, `MANIFEST`) or a full `0x…::module::TYPE`.
+   * Unresolvable strings throw `INVALID_ASSET`; empty balances throw
+   * `INSUFFICIENT_BALANCE`.
    *
-   * **Breaking changes from v3.x:**
-   * - `asset` is now REQUIRED (no implicit `?? 'USDC'` default). Callers
-   *   must specify `'USDC' | 'USDsui' | 'SUI'`. Sending `'USDT'` /
-   *   `'USDe'` / `'WAL'` / `'ETH'` / `'NAVX'` / `'GOLD'` now errors
-   *   with `INVALID_ASSET` — swap to a stable first.
    * - USDC + USDsui builds go through `SuiGrpcClient` so the gRPC build
    *   resolver auto-detects `0x2::balance::send_funds` eligibility and
-   *   zeros gas at simulate time. Result: **gasless USDC / USDsui sends
-   *   from a zero-SUI wallet.** SUI sends stay on the standard gas-paid
-   *   path.
+   *   zeros gas at simulate time — **gasless sends from a zero-SUI
+   *   wallet.** They remain the ONLY gasless assets.
+   * - SUI and every other coin type are gas-paid (the sender needs SUI).
+   * - `asset` stays REQUIRED (no implicit `?? 'USDC'` default — v4 rule).
    *
    * Submission stays on the JSON-RPC client (the rest of the SDK
    * expects JSON-RPC for read paths, and Sui's docs explicitly support
    * the "build via gRPC, execute via JSON-RPC" hybrid).
    */
-  async send(params: { to: string; amount: number; asset: SupportedAsset; force?: boolean }): Promise<SendResult> {
-    // [v4.0 Phase A Day 2] Asset is REQUIRED at runtime (no more silent
-    // USDC default). The parameter type is `SupportedAsset` (the wider
-    // SDK surface) rather than `SendableAsset` so callers that still
-    // hand a wide-typed asset through — primarily the engine LLM tool
-    // surface — compile without modification. Runtime narrowing happens
-    // via `assertAllowedAsset('send', asset)`, which throws
-    // `INVALID_ASSET` for anything outside `['USDC', 'USDsui', 'SUI']`.
-    // This matches the SPEC verification gate `asset: 'USDY'` →
-    // `INVALID_ASSET` (runtime check, not compile check).
+  async send(params: { to: string; amount: number; asset: string; force?: boolean }): Promise<SendResult> {
     const asset = params.asset;
     if (!asset) {
       throw new T2000Error(
         'INVALID_ASSET',
-        "send() requires an explicit asset. Use one of: USDC, USDsui, SUI.",
+        'send() requires an explicit asset. Use a registry symbol (USDC, USDsui, SUI, MANIFEST, …) or a full coin type (0x…::module::TYPE).',
       );
     }
-    assertAllowedAsset('send', asset);
-    // `assertAllowedAsset('send', asset)` narrows the runtime value to
-    // one of `SendableAsset` (USDC / USDsui / SUI). Cast statically.
-    const sendableAsset = asset as SendableAsset;
+    // [S.957] Resolve BEFORE the limit gate so nonsense symbols fail as
+    // INVALID_ASSET (not a limits question) and so stables passed as full
+    // coin types still price 1:1 at the gate (no gating bypass by type).
+    const cls = classifySendAsset(asset);
+    if (!cls) {
+      throw new T2000Error('INVALID_ASSET', invalidSendAssetMessage(asset));
+    }
 
-    // Spending-limit gate (USD; stables 1:1, SUI ungated). `force` bypasses.
+    // Spending-limit gate (USD; stables 1:1 via canonical symbol; SUI and
+    // unpriced alts stay ungated — never invent a price). `force` bypasses.
     this.limits.assert({
       operation: 'send',
-      amountUsd: approxUsdValue(sendableAsset, params.amount) ?? 0,
+      amountUsd: approxUsdValue(cls.symbol, params.amount) ?? 0,
       force: params.force,
     });
 
@@ -552,23 +546,21 @@ export class T2000 extends EventEmitter<T2000Events> {
     const sendTo = resolved.address;
 
     // Gasless-eligible stables (USDC / USDsui) build via the dedicated gRPC
-    // client so the resolver can zero gas at simulate. SUI is not on the
-    // `balance::send_funds` allowlist, so it builds via the default client
-    // (also gRPC post-cutover) with normal gas — no separate build client.
-    const useGrpc = sendableAsset === 'USDC' || sendableAsset === 'USDsui';
-    const buildClient = useGrpc ? getSuiGrpcClient() : undefined;
+    // client so the resolver can zero gas at simulate. Everything else
+    // builds via the default client with normal gas.
+    const buildClient = cls.kind === 'gasless-stable' ? getSuiGrpcClient() : undefined;
 
     const gasResult = await executeTx(
       this.client,
       this._signer,
-      () => buildSendTx({ client: this.client, address: this._address, to: sendTo, amount: sendAmount, asset: sendableAsset }),
+      () => buildSendTx({ client: this.client, address: this._address, to: sendTo, amount: sendAmount, asset }),
       { buildClient },
     );
 
-    this.limits.record(approxUsdValue(sendableAsset, sendAmount) ?? 0);
+    this.limits.record(approxUsdValue(cls.symbol, sendAmount) ?? 0);
     const balance = await this.balance();
 
-    this.emitBalanceChange(sendableAsset, sendAmount, 'send', gasResult.digest);
+    this.emitBalanceChange(cls.symbol, sendAmount, 'send', gasResult.digest);
 
     return {
       success: true,

--- a/packages/sdk/src/wallet/send.test.ts
+++ b/packages/sdk/src/wallet/send.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Transaction } from '@mysten/sui/transactions';
-import { buildSendTx, addSendToTx } from './send.js';
+import { buildSendTx, addSendToTx, classifySendAsset } from './send.js';
 import { SUPPORTED_ASSETS } from '../constants.js';
 
 function mockClient(balanceOverride?: bigint, coinType?: string) {
@@ -142,33 +142,113 @@ describe('buildSendTx — SUI gas-native path', () => {
   });
 });
 
-describe('buildSendTx — asset constraint (v4)', () => {
-  it('throws INVALID_ASSET for USDT', async () => {
+// [S.957] Send widened to any held coin type. The old 3-asset whitelist
+// pins are replaced by: unresolvable symbols hard-fail, resolvable alts
+// build a GAS-PAID transfer (never the gasless send_funds shape), and
+// insufficient balance stays a clear error.
+describe('buildSendTx — any held coin type (S.957)', () => {
+  const MANIFEST_TYPE =
+    '0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb4355::manifest::MANIFEST';
+
+  it('throws INVALID_ASSET for an unresolvable bare symbol', async () => {
     const client = mockClient();
     await expect(
-      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 1, asset: 'USDT' as any }),
-    ).rejects.toThrow(/send only supports USDC, USDsui, SUI/);
+      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 1, asset: 'FOOBAR_NOT_A_TOKEN' }),
+    ).rejects.toThrow(/Unknown asset "FOOBAR_NOT_A_TOKEN"/);
   });
 
-  it('throws INVALID_ASSET for USDe', async () => {
-    const client = mockClient();
-    await expect(
-      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 1, asset: 'USDe' as any }),
-    ).rejects.toThrow(/send only supports USDC, USDsui, SUI/);
+  it('builds a gas-paid transfer for a registry alt symbol (MANIFEST) — no send_funds', async () => {
+    const client = mockClient(10_000_000_000n, MANIFEST_TYPE);
+    const tx = await buildSendTx({
+      client,
+      address: VALID_ADDRESS,
+      to: VALID_ADDRESS,
+      amount: 1,
+      asset: 'MANIFEST',
+    });
+    expect(tx).toBeInstanceOf(Transaction);
+    const data = tx.getData();
+    const moveCalls = data.commands.filter(
+      (c) => 'MoveCall' in (c as Record<string, unknown>),
+    );
+    expect(moveCalls.length).toBe(0); // NOT the gasless send_funds shape
+    const transfers = data.commands.filter(
+      (c) => 'TransferObjects' in (c as Record<string, unknown>),
+    );
+    expect(transfers.length).toBe(1);
+    // Registry decimals (9) resolve offline — no metadata round-trip.
+    expect(client.core.getBalance).toHaveBeenCalledWith({
+      owner: VALID_ADDRESS,
+      coinType: MANIFEST_TYPE,
+    });
   });
 
-  it('throws INVALID_ASSET for WAL', async () => {
-    const client = mockClient();
-    await expect(
-      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 1, asset: 'WAL' as any }),
-    ).rejects.toThrow(/send only supports/);
+  it('accepts the full coin type string too', async () => {
+    const client = mockClient(10_000_000_000n, MANIFEST_TYPE);
+    const tx = await buildSendTx({
+      client,
+      address: VALID_ADDRESS,
+      to: VALID_ADDRESS,
+      amount: 1,
+      asset: MANIFEST_TYPE,
+    });
+    expect(tx).toBeInstanceOf(Transaction);
   });
 
-  it('error message hints at swapping to USDC / USDsui first', async () => {
-    const client = mockClient();
+  it('reads decimals from on-chain metadata for a non-registry type', async () => {
+    const alienType = `0x${'f'.repeat(64)}::alien::ALIEN`;
+    const client = mockClient(10_000n, alienType);
+    client.core.getCoinMetadata = vi.fn().mockResolvedValue({ metadata: { decimals: 2 } });
+    const tx = await buildSendTx({
+      client,
+      address: VALID_ADDRESS,
+      to: VALID_ADDRESS,
+      amount: 100, // 100 × 10^2 = 10_000 raw — exactly the mocked balance
+      asset: alienType,
+    });
+    expect(tx).toBeInstanceOf(Transaction);
+    expect(client.core.getCoinMetadata).toHaveBeenCalledWith({ coinType: alienType });
+  });
+
+  it('throws INSUFFICIENT_BALANCE for a held-token shortfall', async () => {
+    const client = mockClient(100n, MANIFEST_TYPE);
     await expect(
-      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 1, asset: 'GOLD' as any }),
-    ).rejects.toThrow(/Swap to USDC or USDsui first/);
+      buildSendTx({ client, address: VALID_ADDRESS, to: VALID_ADDRESS, amount: 5, asset: 'MANIFEST' }),
+    ).rejects.toThrow(/Insufficient MANIFEST balance/);
+  });
+
+  it('USDC stays gasless when passed as its full coin type (no gate bypass)', async () => {
+    const client = mockClient();
+    const tx = await buildSendTx({
+      client,
+      address: VALID_ADDRESS,
+      to: VALID_ADDRESS,
+      amount: 1,
+      asset: SUPPORTED_ASSETS.USDC.type,
+    });
+    const moveCalls = tx.getData().commands.filter(
+      (c) => 'MoveCall' in (c as Record<string, unknown>),
+    ) as Array<{ MoveCall: { module: string; function: string } }>;
+    expect(moveCalls.length).toBe(1);
+    expect(moveCalls[0].MoveCall.function).toBe('send_funds');
+  });
+});
+
+describe('classifySendAsset (S.957)', () => {
+  it('classifies stables, SUI, registry alts, and full types', () => {
+    expect(classifySendAsset('USDC')).toMatchObject({ kind: 'gasless-stable', symbol: 'USDC' });
+    expect(classifySendAsset('usdsui')).toMatchObject({ kind: 'gasless-stable', symbol: 'USDsui' });
+    expect(classifySendAsset('SUI')).toMatchObject({ kind: 'sui' });
+    expect(classifySendAsset('MANIFEST')).toMatchObject({ kind: 'coin', symbol: 'MANIFEST' });
+    expect(classifySendAsset(SUPPORTED_ASSETS.USDC.type)).toMatchObject({
+      kind: 'gasless-stable',
+      symbol: 'USDC',
+    });
+  });
+
+  it('returns null for unresolvable symbols and malformed types', () => {
+    expect(classifySendAsset('FOOBAR_NOT_A_TOKEN')).toBeNull();
+    expect(classifySendAsset('0xnot::a')).toBeNull();
   });
 });
 

--- a/packages/sdk/src/wallet/send.ts
+++ b/packages/sdk/src/wallet/send.ts
@@ -1,17 +1,23 @@
 import {
   Transaction,
+  coinWithBalance,
   type TransactionObjectArgument,
 } from '@mysten/sui/transactions';
+import { normalizeStructTag } from '@mysten/sui/utils';
 import {
   GASLESS_MIN_STABLE_AMOUNT,
   GASLESS_STABLE_TYPES,
   SUPPORTED_ASSETS,
-  assertAllowedAsset,
-  type SendableAsset,
 } from '../constants.js';
 import { T2000Error } from '../errors.js';
 import { validateAddress, type SuiCoreClient } from '../utils/sui.js';
 import { displayToRaw } from '../utils/format.js';
+import {
+  SUI_TYPE,
+  resolveCoinDecimals,
+  resolveSymbol,
+  resolveTokenType,
+} from '../token-registry.js';
 import {
   type PreflightResult,
   PREFLIGHT_OK,
@@ -21,35 +27,82 @@ import {
 } from '../preflight.js';
 
 /**
- * Synchronous, network-free preflight for `send`. Validates asset membership,
- * amount sanity, the gasless stable floor, and recipient address shape — the
- * cheap checks the v3 host runs before the LLM round-trip / tap-to-confirm.
- * Returns a `PreflightResult`; never throws. `buildSendTx` calls this first,
- * then layers the network balance read on top.
+ * [S.957 — 2026-08-08] What a send `asset` string resolves to. The rule:
+ * **if it resolves to a Sui coin type, it's sendable** (given balance) —
+ * registry symbol (`USDC`, `MANIFEST`) or full `0x…::module::TYPE` both
+ * work. The kind decides the build path:
+ * - `gasless-stable` — USDC / USDsui via `0x2::balance::send_funds`
+ *   (Sui mainnet protocol allowlist; the ONLY gasless sends).
+ * - `sui` — split from `tx.gas`, gas-paid.
+ * - `coin` — any other coin type via `coinWithBalance` + transferObjects,
+ *   gas-paid. `symbol` is display-only (registry or last `::` segment).
+ */
+export type SendAssetClass =
+  | { kind: 'gasless-stable'; symbol: 'USDC' | 'USDsui'; coinType: string }
+  | { kind: 'sui'; symbol: 'SUI'; coinType: string }
+  | { kind: 'coin'; symbol: string; coinType: string };
+
+/**
+ * Pure, network-free asset resolution for `send`. Returns `null` for
+ * anything that doesn't resolve to a coin type — unknown bare symbols
+ * (`FOOBAR`) and malformed `::` strings stay hard errors upstream.
+ */
+export function classifySendAsset(asset: string): SendAssetClass | null {
+  const coinType = resolveTokenType(asset.trim());
+  if (!coinType) return null;
+  let normalized: string;
+  try {
+    normalized = normalizeStructTag(coinType);
+  } catch {
+    return null;
+  }
+  if (normalized === normalizeStructTag(GASLESS_STABLE_TYPES.USDC)) {
+    return { kind: 'gasless-stable', symbol: 'USDC', coinType: GASLESS_STABLE_TYPES.USDC };
+  }
+  if (normalized === normalizeStructTag(GASLESS_STABLE_TYPES.USDsui)) {
+    return { kind: 'gasless-stable', symbol: 'USDsui', coinType: GASLESS_STABLE_TYPES.USDsui };
+  }
+  if (normalized === normalizeStructTag(SUI_TYPE)) {
+    return { kind: 'sui', symbol: 'SUI', coinType: SUI_TYPE };
+  }
+  return { kind: 'coin', symbol: resolveSymbol(coinType), coinType };
+}
+
+/** The canonical INVALID_ASSET message for an unresolvable send asset. */
+export function invalidSendAssetMessage(asset: string): string {
+  return (
+    `Unknown asset "${asset}". Use a registry symbol (USDC, USDsui, SUI, ` +
+    `MANIFEST, …) or a full coin type (0x…::module::TYPE).`
+  );
+}
+
+/**
+ * Synchronous, network-free preflight for `send`. Validates asset
+ * resolvability, amount sanity, the gasless stable floor, and recipient
+ * address shape — the cheap checks the v3 host runs before the LLM
+ * round-trip / tap-to-confirm. Returns a `PreflightResult`; never throws.
+ * `buildSendTx` calls this first, then layers the network balance read on top.
  */
 export function preflightSend(input: {
   to: string;
   amount: number;
   asset: string;
 }): PreflightResult {
-  // Asset membership — reuse the canonical message (single source of truth).
-  try {
-    assertAllowedAsset('send', input.asset);
-  } catch (e) {
-    return preflightFail('INVALID_ASSET', (e as T2000Error).message);
+  // [S.957] Resolvability replaces the old 3-asset membership gate —
+  // any coin type is sendable; nonsense symbols still fail here.
+  const cls = classifySendAsset(input.asset);
+  if (!cls) {
+    return preflightFail('INVALID_ASSET', invalidSendAssetMessage(input.asset));
   }
 
   const amountCheck = checkPositiveAmount(input.amount);
   if (!amountCheck.valid) return amountCheck;
 
   // Gasless protocol allowlist enforces a 0.01 minimum on the stables.
-  if (
-    (input.asset === 'USDC' || input.asset === 'USDsui') &&
-    input.amount < GASLESS_MIN_STABLE_AMOUNT
-  ) {
+  if (cls.kind === 'gasless-stable' && input.amount < GASLESS_MIN_STABLE_AMOUNT) {
     return preflightFail(
       'INVALID_AMOUNT',
-      `Minimum gasless transfer is ${GASLESS_MIN_STABLE_AMOUNT} ${input.asset}. Got ${input.amount}.`,
+      `Minimum gasless transfer is ${GASLESS_MIN_STABLE_AMOUNT} ${cls.symbol}. Got ${input.amount}.`,
     );
   }
 
@@ -62,25 +115,25 @@ export function preflightSend(input: {
 /**
  * Build a PTB that sends `amount` of `asset` from `address` to `to`.
  *
- * [v4.0 Phase A Day 2 — SPEC_AGENT_WALLET_GREENFIELD §A]
+ * [S.957 — 2026-08-08] Widened from the v4 3-asset whitelist to **any held
+ * coin type**: `asset` is a registry symbol (`USDC`, `MANIFEST`) or a full
+ * `0x…::module::TYPE`. Unresolvable strings throw `INVALID_ASSET`.
  *
- * Asset constraint: `'USDC' | 'USDsui' | 'SUI'` only. Other assets throw
- * `INVALID_ASSET` via `assertAllowedAsset('send', asset)`. The constrained
- * set matches Sui mainnet's gasless allowlist (USDC + USDsui) plus SUI
- * for users who want a gas-native transfer.
- *
- * Build paths:
+ * Build paths (`classifySendAsset`):
  * - **USDC / USDsui** — `0x2::balance::send_funds` Move call with a
  *   `tx.balance({ type, balance })` input. When built via `SuiGrpcClient`,
  *   the gRPC resolver auto-detects gasless eligibility and zeros gas.
- *   When built via `SuiJsonRpcClient`, the same PTB still executes but
- *   the caller pays normal gas. Minimum 0.01 (protocol allowlist floor).
+ *   Minimum 0.01 (protocol allowlist floor). Still the ONLY gasless sends.
  * - **SUI** — `tx.splitCoins(tx.gas, [amount]) → tx.transferObjects()`.
  *   Standard gas-native transfer. No minimum.
+ * - **Any other coin type** — `coinWithBalance({ type, balance })` +
+ *   `transferObjects`. Gas-paid (sender needs SUI). The resolver sources
+ *   coins + address balance together, so post-swap alts held either way
+ *   move. Decimals resolve via the registry or on-chain coin metadata
+ *   (`resolveCoinDecimals`) — never a silent 9-default guess.
  *
- * Pre-flight balance check stays on JSON-RPC (`client.getBalance`) — it
- * sums coin objects + address balance so the legacy `getCoins` page miss
- * doesn't break for users whose stables landed via gasless deposits.
+ * Pre-flight balance check uses `core.getBalance` (sums coin objects +
+ * address balance) for every path.
  *
  * `asset` is REQUIRED (no implicit USDC default — pre-v4 hid LLM intent
  * errors). Callers passing the wrong asset get an explicit error rather
@@ -97,7 +150,7 @@ export async function buildSendTx({
   address: string;
   to: string;
   amount: number;
-  asset: SendableAsset;
+  asset: string;
 }): Promise<Transaction> {
   // Layer 2 — cheap synchronous preflight (asset / amount / gasless floor /
   // recipient shape). Rethrow the precise code+message verbatim.
@@ -105,23 +158,49 @@ export async function buildSendTx({
   if (!pf.valid) throw new T2000Error(pf.code, pf.error);
 
   const recipient = validateAddress(to);
-  const assetInfo = SUPPORTED_ASSETS[asset];
-  if (!assetInfo) throw new T2000Error('ASSET_NOT_SUPPORTED', `Asset ${asset} is not supported`);
+  // Preflight passed, so the asset classifies — TS just can't see it.
+  const cls = classifySendAsset(asset) as SendAssetClass;
 
-  const rawAmount = displayToRaw(amount, assetInfo.decimals);
+  // Decimals: registry / gasless stables are known offline; a coin type
+  // outside the registry is read from on-chain metadata (financial-amounts
+  // rule — a wrong decimal corrupts the raw amount).
+  const decimals =
+    cls.kind === 'gasless-stable' || cls.kind === 'sui'
+      ? SUPPORTED_ASSETS[cls.symbol].decimals
+      : await resolveCoinDecimals(client, cls.coinType);
+
+  const rawAmount = displayToRaw(amount, decimals);
   const tx = new Transaction();
   tx.setSender(address);
 
   // Balance pre-flight against `core.getBalance().balance.balance` (sums
   // coins + address balance). The legacy `getCoins` page miss broke for
   // users whose stables had drifted into address balance via earlier pay flows.
-  const balanceResp = await client.core.getBalance({ owner: address, coinType: assetInfo.type });
+  const balanceResp = await client.core.getBalance({ owner: address, coinType: cls.coinType });
   const totalBalance = BigInt(balanceResp.balance.balance);
   if (totalBalance < rawAmount) {
-    throw new T2000Error('INSUFFICIENT_BALANCE', `Insufficient ${asset} balance`, {
-      available: Number(totalBalance) / 10 ** assetInfo.decimals,
+    throw new T2000Error('INSUFFICIENT_BALANCE', `Insufficient ${cls.symbol} balance`, {
+      available: Number(totalBalance) / 10 ** decimals,
       required: amount,
     });
+  }
+
+  if (cls.kind === 'sui') {
+    // Standard gas-native transfer — split from the gas coin, transfer
+    // the resulting object. NOT gasless (SUI is not on the protocol
+    // allowlist for `balance::send_funds`).
+    const [sendCoin] = tx.splitCoins(tx.gas, [rawAmount]);
+    tx.transferObjects([sendCoin], recipient);
+    return tx;
+  }
+
+  if (cls.kind === 'coin') {
+    // [S.957] Generic held-token transfer — gas-paid. `coinWithBalance`
+    // resolves coins + address balance at build time (same helper as the
+    // wallet-mode appenders), so no hand-rolled getCoins-only selection.
+    const sendCoin = coinWithBalance({ type: cls.coinType, balance: rawAmount })(tx);
+    tx.transferObjects([sendCoin], recipient);
+    return tx;
   }
 
   // Gasless dust floor — the protocol validator rejects a gasless stable
@@ -131,28 +210,17 @@ export async function buildSendTx({
   // "Unable to perform gas selection") — verified live 2026-07-19. Auto-clip
   // is intentionally NOT done here: silently sending more than asked is
   // worse than a clear error (financial-amounts discipline).
-  if (asset === 'USDC' || asset === 'USDsui') {
-    const rawFloor = displayToRaw(GASLESS_MIN_STABLE_AMOUNT, assetInfo.decimals);
-    const remainder = totalBalance - rawAmount;
-    if (remainder > 0n && remainder < rawFloor) {
-      const total = Number(totalBalance) / 10 ** assetInfo.decimals;
-      throw new T2000Error(
-        'INVALID_AMOUNT',
-        `Gasless ${asset} transfers must send the entire balance or leave at least ${GASLESS_MIN_STABLE_AMOUNT} ${asset}. ` +
-          `Sending ${amount} of ${total} leaves ${(total - amount).toFixed(assetInfo.decimals)}. ` +
-          `Send ${total} (everything) or at most ${(total - GASLESS_MIN_STABLE_AMOUNT).toFixed(assetInfo.decimals)}.`,
-        { available: total, required: amount },
-      );
-    }
-  }
-
-  if (asset === 'SUI') {
-    // Standard gas-native transfer — split from the gas coin, transfer
-    // the resulting object. NOT gasless (SUI is not on the protocol
-    // allowlist for `balance::send_funds`).
-    const [sendCoin] = tx.splitCoins(tx.gas, [rawAmount]);
-    tx.transferObjects([sendCoin], recipient);
-    return tx;
+  const rawFloor = displayToRaw(GASLESS_MIN_STABLE_AMOUNT, decimals);
+  const remainder = totalBalance - rawAmount;
+  if (remainder > 0n && remainder < rawFloor) {
+    const total = Number(totalBalance) / 10 ** decimals;
+    throw new T2000Error(
+      'INVALID_AMOUNT',
+      `Gasless ${cls.symbol} transfers must send the entire balance or leave at least ${GASLESS_MIN_STABLE_AMOUNT} ${cls.symbol}. ` +
+        `Sending ${amount} of ${total} leaves ${(total - amount).toFixed(decimals)}. ` +
+        `Send ${total} (everything) or at most ${(total - GASLESS_MIN_STABLE_AMOUNT).toFixed(decimals)}.`,
+      { available: total, required: amount },
+    );
   }
 
   // USDC / USDsui — gasless via `0x2::balance::send_funds`. The gRPC
@@ -162,12 +230,11 @@ export async function buildSendTx({
   //   public fun send_funds<T>(balance: Balance<T>, recipient: address)
   // `tx.balance({ type, balance })` produces a Balance<T> input sourced
   // from the sender's address balance + coin objects (auto-merged).
-  const coinType = GASLESS_STABLE_TYPES[asset];
   tx.moveCall({
     target: '0x2::balance::send_funds',
-    typeArguments: [coinType],
+    typeArguments: [cls.coinType],
     arguments: [
-      tx.balance({ type: coinType, balance: rawAmount }),
+      tx.balance({ type: cls.coinType, balance: rawAmount }),
       tx.pure.address(recipient),
     ],
   });


### PR DESCRIPTION
## S.957 — Send any held token (SDK + CLI), not stables-only

Dogfood 2026-08-08: post-swap MANIFEST sits in the Passport but can't be
transferred out without "swap back to USDC first" — half a wallet. This widens
**send** to any asset resolvable to a Sui coin type (registry symbol or full
`0x…::module::TYPE`), held with sufficient balance.

### SDK
- New pure `classifySendAsset(asset)` in wallet/send.ts — the single
  resolvability rule (`resolveTokenType` + `normalizeStructTag`):
  `gasless-stable` (USDC/USDsui) · `sui` · `coin` (anything else). Exported
  (index + browser) so CLI/MCP share it — no second type map anywhere.
- `buildSendTx` branches on the class:
  - USDC/USDsui: unchanged gasless `0x2::balance::send_funds` (+ 0.01 floor
    + dust-remainder guard). **Still the only gasless sends** — passing the
    full USDC coin type classifies back to the gasless path (no gate bypass).
  - SUI: unchanged gas split.
  - Generic coin: `coinWithBalance` + `transferObjects` (same resolver as the
    wallet-mode appenders — sources coins + address balance; no hand-rolled
    getCoins-only path). Decimals via `resolveCoinDecimals` (registry offline,
    on-chain metadata otherwise — never a silent 9-default).
- `T2000.send({ asset: string })` — classifies before the limit gate so
  nonsense symbols fail as `INVALID_ASSET` and stables-passed-as-types still
  price 1:1 at the spend gate (`approxUsdValue(cls.symbol, …)`); alts stay
  ungated-USD (no invented MANIFEST price, same as SUI today).
- `OPERATION_ASSETS.send` → `'*'` (real gate = resolvability + balance).
- **composeTx `send_transfer` deliberately keeps the narrow stables+SUI
  list** — sponsored bundles carry Enoki coin-object-only constraints the
  generic path doesn't satisfy; widening it is its own slice.

### CLI
- `t2 send 10 MANIFEST 0x…` and full-coin-type forms parse; validation
  delegates to `classifySendAsset`. Unresolvable symbols still exit 1.
- Receipt: stables render `$` (1:1), SUI keeps 4dp, alts render plain
  `<amount> <symbol>` — never an invented dollar figure.
- Help/description: gasless USDC/USDsui; everything else needs SUI for gas.

### Tests (all green — SDK 557, CLI suites)
- buildSendTx: MANIFEST symbol + full type build gas-paid TransferObjects
  (0 MoveCalls — provably not the gasless shape); non-registry type reads
  on-chain metadata decimals; `FOOBAR_NOT_A_TOKEN` → INVALID_ASSET;
  insufficient MANIFEST → INSUFFICIENT_BALANCE; USDC-by-full-type stays
  gasless `send_funds`.
- Old whitelist pins (send USDT/USDe/WAL throws) replaced per the slice:
  unresolvable-throws + zero-balance-fails.
- classifySendAsset unit block; constants + preflight pins updated.

### Docs (factual lines only)
cli-reference, agent-wallet, passport-connect: "send any held token; USDC +
USDsui gasless, rest gas-paid". fund-and-send's "only USDC/USDsui are
gasless" was already still true.

### Follow-ups (after release)
1. Release bump via the normal process (`gh workflow run release.yml`).
2. audric MCP: `t2000_send` `asset: z.string()`, spend-summary + card wiring,
   route instructions — `✨ feat(mcp): t2000_send any held token (S.957)`.