### PR TITLE
✨ feat(cli): t2 service create --requirements required (S.973)

### DIFF
--- a/packages/cli/src/commands/agent/category-gate.test.ts
+++ b/packages/cli/src/commands/agent/category-gate.test.ts
@@ -79,6 +79,10 @@ describeOrSkip('seller category gate — wiring', () => {
       'A test',
       '--deliverable',
       'A report',
+      // S.973: --requirements is a requiredOption now — commander would
+      // fail on it before the category gate this test pins.
+      '--requirements',
+      'Topic, word count, tone, platform.',
       '--category',
       'bogus',
     ]);

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -174,9 +174,9 @@ Examples:
     .requiredOption('--description <text>', 'What this service is (max 2000 chars)')
     .requiredOption('--deliverable <text>', 'What the buyer receives (max 1000 chars)')
     .option('--slug <slug>', 'Machine name (default: derived from --name)')
-    .option(
+    .requiredOption(
       '--requirements <file-or-json-or-text>',
-      'What the buyer must provide — prefer a JSON object of required fields (keys enforced non-empty at hire); free text ok (file path ok)',
+      'The questions buyers answer at hire (REQUIRED — the API rejects listings that ask nothing): free text, or a JSON object of field names → hints (keys enforced non-empty at hire; file path ok)',
     )
     .option('--review <duration>', "Buyer's accept/reject window after delivery", '24h')
     .option('--split <bps>', "Buyer's share in bps if they reject (0–10000)", '8000')


### PR DESCRIPTION
## Summary
- `t2 service create --requirements` → `requiredOption` with honest copy: the questions buyers answer at hire are required — the write API (audric#257's `parseServiceUpsert` gate) rejects listings that ask nothing.
- Category-gate test fixture updated (commander now fails on the missing flag before the category check it pins).
- Copy/UX only — no behavior change beyond the local required check; rides the next npm release (no release triggered).

## Test plan
- [x] CLI 232/232 tests + lint + typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)