### PR TITLE
✨ feat(sdk,cli): CLI custom hire writes t2-acp-custom@1 envelope (S.978)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -74,7 +74,7 @@ Instant request/response calls don't need this — that's `t2 pay`.
 
 | Command | Who | What it does |
 | --- | --- | --- |
-| `t2 job hire <usdc> <seller>` | buyer | Create + fund in one transaction. `--spec <file-or-text>` uploads the job text (sha256 pinned on-chain); a bare `0x…` sha256 pins without uploading (confidential). `--deadline 24h` · `--review 24h` · `--split 8000`. |
+| `t2 job hire <usdc> <seller>` | buyer | Create + fund in one transaction. `--spec <file-or-text>` uploads the brief as the public `t2-acp-custom@1` title+brief envelope (sha256 pinned on-chain; `--title` sets the public title, else it derives from the brief's first line); a bare `0x…` sha256 pins without uploading (confidential, no envelope). `--deadline 24h` · `--review 24h` · `--split 8000`. |
 | `t2 job hire --agent <address> --service <slug>` | buyer | Hire a **listed service** — price, deadline, terms from the listing. `--requirements` fills what the seller asked; required keys are enforced non-empty before funding ([how hiring works](/how-to/hire)). Stored content-addressed, sha256 pinned as the job's spec hash. |
 | `t2 job verify <jobId> --price <usdc>` | seller | Before starting work: the job is funded, pays YOUR wallet, covers the price. Exit 1 = don't start. |
 | `t2 job spec <jobId>` | seller | Fetch the buyer's spec/requirements by the on-chain hash — content is verified against the commitment before it prints. |

--- a/packages/cli/src/commands/job.test.ts
+++ b/packages/cli/src/commands/job.test.ts
@@ -2,7 +2,12 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchSellerJobs, parseDuration, resolveSpecUpload } from './job.js';
+import {
+  fetchSellerJobs,
+  parseDuration,
+  resolveHireSpecUpload,
+  resolveSpecUpload,
+} from './job.js';
 
 describe('parseDuration', () => {
   it('parses minutes, hours, days', () => {
@@ -117,5 +122,81 @@ describe('fetchSellerJobs (the provider inbox read)', () => {
     await expect(fetchSellerJobs('https://api.example/v1', '')).rejects.toThrow(
       /Provide \?seller=/,
     );
+  });
+});
+
+describe('resolveHireSpecUpload (S.978 — CLI writes the t2-acp-custom@1 envelope)', () => {
+  const BASE = 'https://api.example.test/v1';
+  const HASH64 = `0x${'a'.repeat(64)}`;
+
+  function mockPutSpec(hash = 'b'.repeat(64)) {
+    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ hash }) }));
+    vi.stubGlobal('fetch', fn);
+    return { fn, hash };
+  }
+  afterEach(() => vi.unstubAllGlobals());
+
+  function uploadedBody(fn: ReturnType<typeof vi.fn>): Record<string, unknown> {
+    const init = (fn.mock.calls[0] as unknown[])?.[1] as
+      | { body?: string }
+      | undefined;
+    const outer = JSON.parse(init?.body ?? '{}') as { content?: string };
+    return JSON.parse(outer.content ?? '{}') as Record<string, unknown>;
+  }
+
+  it('wraps an inline brief: envelope type, derived title, lossless brief', async () => {
+    const { fn } = mockPutSpec();
+    await resolveHireSpecUpload(BASE, 'Write one short OK note.\nMore detail.', undefined);
+    const body = uploadedBody(fn);
+    expect(body.type).toBe('t2-acp-custom@1');
+    expect(body.title).toBe('Write one short OK note.');
+    expect(body.brief).toBe('Write one short OK note.\nMore detail.');
+    expect(typeof body.createdAtMs).toBe('number');
+  });
+
+  it('--title wins; Title: prefix in a file strips for the title only', async () => {
+    const { fn } = mockPutSpec();
+    await resolveHireSpecUpload(BASE, 'Long brief body.', 'My title');
+    expect(uploadedBody(fn).title).toBe('My title');
+
+    vi.unstubAllGlobals();
+    const second = mockPutSpec();
+    const dir = await mkdtemp(join(tmpdir(), 't2-job-'));
+    const file = join(dir, 'brief.md');
+    await writeFile(file, 'Title: smoke CLI envelope\nWrite one short OK note.');
+    await resolveHireSpecUpload(BASE, file, undefined);
+    const body = uploadedBody(second.fn);
+    expect(body.title).toBe('smoke CLI envelope');
+    expect(String(body.brief).startsWith('Title: smoke CLI envelope')).toBe(true);
+  });
+
+  it('idempotent: an input that already IS the envelope uploads as-is, never nested', async () => {
+    const { fn } = mockPutSpec();
+    const envelope = JSON.stringify({
+      type: 't2-acp-custom@1',
+      title: 'Pre-wrapped',
+      brief: 'Already an envelope.',
+      createdAtMs: 1,
+    });
+    await resolveHireSpecUpload(BASE, envelope, undefined);
+    const body = uploadedBody(fn);
+    expect(body.title).toBe('Pre-wrapped');
+    expect(body.createdAtMs).toBe(1);
+    expect(typeof body.brief).toBe('string'); // not a nested envelope string
+  });
+
+  it('bare 0x… sha256 stays confidential — no upload, no wrap', async () => {
+    const { fn } = mockPutSpec();
+    const result = await resolveHireSpecUpload(BASE, HASH64, undefined);
+    expect(result).toEqual({ hash: HASH64, uploaded: false });
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('deliver path contrast: resolveSpecUpload still uploads RAW text, no envelope', async () => {
+    const { fn } = mockPutSpec();
+    await resolveSpecUpload(BASE, 'plain delivery proof text');
+    const init = (fn.mock.calls[0] as unknown[])?.[1] as { body?: string };
+    const outer = JSON.parse(init?.body ?? '{}') as { content?: string };
+    expect(outer.content).toBe('plain delivery proof text');
   });
 });

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -41,6 +41,8 @@ import {
   verifyJobForSeller,
   MAX_JOB_USDC,
   preflightCreateJob,
+  customHireEnvelope,
+  isCustomHireEnvelope,
   type Job,
 } from '@t2000/sdk';
 import { runSponsoredTx } from '../lib/agent-register.js';
@@ -90,19 +92,21 @@ const SHA256_HEX_RE = /^0x[0-9a-fA-F]{64}$/;
  *  fails with guidance BEFORE any network call. */
 const SPEC_STORE_MAX_BYTES = 16 * 1024;
 
-/** Spec/delivery commitment (SPEC_ACP_JOB_SPEC_V1 §4.2): the body UPLOADS by
- *  default so the counterparty can actually read it — a bare `0x…` sha256
- *  passes through untouched (the confidential path: nothing leaves your
- *  machine). Anything else is read (file path, else literal text), guarded
- *  to UTF-8 text under the store's 16 KiB cap, uploaded via `putJobSpec`,
- *  and the store's hash pinned on-chain. */
-export async function resolveSpecUpload(
-  base: string,
+// Spec/delivery commitment (SPEC_ACP_JOB_SPEC_V1 §4.2): bodies UPLOAD by
+// default so the counterparty can actually read them; a bare `0x…` sha256
+// is the confidential path (nothing leaves your machine).
+
+/** Read + guard the spec/delivery input WITHOUT uploading: a bare `0x…`
+ *  sha256 passes through as the confidential hash; anything else resolves
+ *  (file path, else literal text) to UTF-8 text under the store's 16 KiB
+ *  cap. Shared by hire (which wraps text in the custom envelope, S.978)
+ *  and deliver (which uploads raw — proofs are never wrapped). */
+export async function loadSpecText(
   input: string,
-): Promise<{ hash: string; uploaded: boolean }> {
+): Promise<{ kind: 'hash'; hash: string } | { kind: 'text'; text: string }> {
   const trimmed = input.trim();
   if (SHA256_HEX_RE.test(trimmed)) {
-    return { hash: trimmed.toLowerCase(), uploaded: false };
+    return { kind: 'hash', hash: trimmed.toLowerCase() };
   }
   let bytes: Buffer;
   try {
@@ -127,7 +131,44 @@ export async function resolveSpecUpload(
         'commitment with --hash-only 0x<sha256>.',
     );
   }
-  return { hash: `0x${await putJobSpec(base, text)}`, uploaded: true };
+  return { kind: 'text', text };
+}
+
+export async function resolveSpecUpload(
+  base: string,
+  input: string,
+): Promise<{ hash: string; uploaded: boolean }> {
+  const loaded = await loadSpecText(input);
+  if (loaded.kind === 'hash') {
+    return { hash: loaded.hash, uploaded: false };
+  }
+  return { hash: `0x${await putJobSpec(base, loaded.text)}`, uploaded: true };
+}
+
+/** Direct-hire spec upload (S.978): text briefs wrap in the SDK's
+ *  `t2-acp-custom@1` envelope — the same write shape as console + Connect —
+ *  so manage / the public page / the feed title the job without derive
+ *  fallbacks. Idempotent (an input that already IS the envelope uploads
+ *  as-is); a bare 0x… sha stays the confidential path, never wrapped. */
+export async function resolveHireSpecUpload(
+  base: string,
+  input: string,
+  title: string | undefined,
+): Promise<{ hash: string; uploaded: boolean }> {
+  const loaded = await loadSpecText(input);
+  if (loaded.kind === 'hash') {
+    return { hash: loaded.hash, uploaded: false };
+  }
+  const body = isCustomHireEnvelope(loaded.text)
+    ? loaded.text
+    : customHireEnvelope(loaded.text, title, Date.now());
+  if (Buffer.byteLength(body, 'utf8') > SPEC_STORE_MAX_BYTES) {
+    throw new Error(
+      'The brief plus its envelope exceeds the 16 KiB job-spec store cap — ' +
+        'shorten the brief, or link the long artifact (URL / IPFS).',
+    );
+  }
+  return { hash: `0x${await putJobSpec(base, body)}`, uploaded: true };
 }
 
 function stateColor(state: Job['state']): string {
@@ -279,7 +320,8 @@ no fund step; unclaimed openings refund fee-free):
     .argument('[amount]', `USDC to escrow (max ${MAX_JOB_USDC}; omit when hiring a --service listing)`)
     .argument('[seller]', "The ASP's Sui address (omit when hiring a --service listing)")
     .description('Hire — fund an escrow job in one transaction (buyer): a listing (--agent + --service) or your own terms (amount + seller + --spec)')
-    .option('--spec <file-or-text>', 'Job spec — a file path or inline text (UPLOADED so the seller can read it; sha256 pinned on-chain), or a bare 0x… sha256 (confidential: pins without uploading)')
+    .option('--spec <file-or-text>', 'Job spec — a file path or inline text (UPLOADED as the public t2-acp-custom@1 title+brief envelope so the seller and the store can read it; sha256 pinned on-chain), or a bare 0x… sha256 (confidential: pins without uploading, no envelope)')
+    .option('--title <text>', 'Public job title (≤80 chars). Custom/direct hire only; derived from the brief\'s first line if omitted')
     .option(
       '--agent <address|#id|@handle>',
       "Hire a listing: the ASP's agent address, #id, or @handle",
@@ -297,6 +339,7 @@ no fund step; unclaimed openings refund fee-free):
         sellerArg: string | undefined,
         opts: {
           spec?: string;
+          title?: string;
           agent?: string;
           service?: string;
           requirements?: string;
@@ -402,9 +445,14 @@ no fund step; unclaimed openings refund fee-free):
             seller = validateAddress(
               (await resolveAgentRef(base, sellerArg)).address,
             );
-            // Uploads unless the input is already a 0x… sha256 — the bare
-            // hash stays the confidential path (nothing leaves the machine).
-            ({ hash: specHash } = await resolveSpecUpload(base, opts.spec));
+            // Uploads as the t2-acp-custom@1 envelope (S.978) unless the
+            // input is already a 0x… sha256 — the bare hash stays the
+            // confidential path (nothing leaves the machine).
+            ({ hash: specHash } = await resolveHireSpecUpload(
+              base,
+              opts.spec,
+              opts.title,
+            ));
             deliverByMs = Date.now() + parseDuration(opts.deadline);
             reviewWindowMs = opts.review
               ? parseDuration(opts.review)

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -191,6 +191,10 @@ export {
 } from './commerce.js';
 export type { ServiceListing } from './commerce.js';
 export {
+  customHireEnvelope,
+  isCustomHireEnvelope,
+} from './job-spec-envelope.js';
+export {
   cancelOpenJob,
   claimOpenJob,
   getOpenJob,

--- a/packages/sdk/src/job-spec-envelope.test.ts
+++ b/packages/sdk/src/job-spec-envelope.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  customHireEnvelope,
+  isCustomHireEnvelope,
+} from './job-spec-envelope.js';
+
+// S.978 — the ONE write shape for buyer custom jobs. These pins mirror the
+// S.977 mcp suite so the SDK builder stays byte-stable with what Connect
+// already ships; the CLI wraps through this exact function.
+
+describe('customHireEnvelope', () => {
+  it('derives the title from the first non-empty line; brief is lossless', () => {
+    const brief =
+      '\nWrite a launch tweet thread for my Sui project.\nAudience: degens.';
+    const parsed = JSON.parse(customHireEnvelope(brief, undefined, 1_700_000_000_000));
+    expect(parsed.type).toBe('t2-acp-custom@1');
+    expect(parsed.title).toBe('Write a launch tweet thread for my Sui project.');
+    expect(parsed.brief).toBe(brief.trim());
+    expect(parsed.createdAtMs).toBe(1_700_000_000_000);
+  });
+
+  it('explicit title wins; Title: prefix strips; 80 cap holds; empty → Custom job', () => {
+    expect(JSON.parse(customHireEnvelope('body', 'Name my boat', 1)).title).toBe(
+      'Name my boat',
+    );
+    const prefixed = JSON.parse(
+      customHireEnvelope('Title: Naming ceremony\nFive candidates.', undefined, 1),
+    );
+    expect(prefixed.title).toBe('Naming ceremony');
+    expect(prefixed.brief.startsWith('Title: Naming ceremony')).toBe(true);
+    const long = JSON.parse(
+      customHireEnvelope(`${'x'.repeat(200)} end`, undefined, 1),
+    );
+    expect(long.title.length).toBe(80);
+    expect(long.title.endsWith('…')).toBe(true);
+    expect(JSON.parse(customHireEnvelope('   ', undefined, 1)).title).toBe(
+      'Custom job',
+    );
+  });
+});
+
+describe('isCustomHireEnvelope', () => {
+  it('accepts current + legacy envelopes with a usable brief; rejects the rest', () => {
+    expect(
+      isCustomHireEnvelope(
+        JSON.stringify({ type: 't2-acp-custom@1', title: 'T', brief: 'B' }),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomHireEnvelope(
+        JSON.stringify({ type: 't2-acp-invite@1', title: 'T', brief: 'B' }),
+      ),
+    ).toBe(true);
+    expect(
+      isCustomHireEnvelope(
+        JSON.stringify({ type: 't2-acp-custom@1', brief: '  ' }),
+      ),
+    ).toBe(false);
+    expect(
+      isCustomHireEnvelope(JSON.stringify({ type: 't2-acp-job-spec@1' })),
+    ).toBe(false);
+    expect(isCustomHireEnvelope('plain text brief')).toBe(false);
+  });
+
+  it('round-trip: the builder output never double-wraps', () => {
+    expect(isCustomHireEnvelope(customHireEnvelope('a real brief', undefined, 1))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/sdk/src/job-spec-envelope.ts
+++ b/packages/sdk/src/job-spec-envelope.ts
@@ -1,0 +1,55 @@
+// Buyer custom-hire spec envelope (S.978) — the ONE write shape for
+// buyer-authored jobs across every surface: console hire-custom-prepare,
+// Connect t2000_job_hire (S.977) and `t2 job hire` all upload
+// `t2-acp-custom@1` {type, title, brief, createdAtMs}. Raw-text READ
+// fallbacks stay forever for history; nothing should EMIT raw anymore.
+// Behavior is byte-stable with the S.977 mcp builder it canonicalizes
+// (audric apps/mcp/lib/hire-order.ts imports this once the version bumps).
+//
+// Deliveries are NOT wrapped — this envelope is for hire specs only.
+
+const TITLE_PREFIX_RE = /^title\s*:\s*(.+)$/i;
+const ENVELOPE_TITLE_MAX = 80;
+
+/** Title rules: an explicit title wins; otherwise the brief's first
+ *  non-empty line (a leading "Title: …" prefix is stripped for the title
+ *  field — the FULL text always stays in the brief, lossless), hard-capped
+ *  at 80 chars. Empty derive → "Custom job". */
+export function customHireEnvelope(
+  brief: string,
+  title: string | undefined,
+  now: number,
+): string {
+  const body = brief.trim();
+  let t = title?.trim() ?? '';
+  if (!t) {
+    const first = body.split('\n').find((l) => l.trim())?.trim() ?? '';
+    const prefixed = TITLE_PREFIX_RE.exec(first);
+    t = (prefixed ? prefixed[1] : first).trim();
+  }
+  if (t.length > ENVELOPE_TITLE_MAX) {
+    t = `${t.slice(0, ENVELOPE_TITLE_MAX - 1).trimEnd()}…`;
+  }
+  return JSON.stringify({
+    type: 't2-acp-custom@1',
+    title: t || 'Custom job',
+    brief: body,
+    createdAtMs: now,
+  });
+}
+
+/** Idempotency guard: text that already IS a custom envelope (current or
+ *  legacy name) with a usable brief must upload as-is, never double-wrap. */
+export function isCustomHireEnvelope(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text) as { type?: unknown; brief?: unknown };
+    return (
+      (parsed.type === 't2-acp-custom@1' ||
+        parsed.type === 't2-acp-invite@1') &&
+      typeof parsed.brief === 'string' &&
+      parsed.brief.trim().length > 0
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Write SSOT in `@t2000/sdk`: new pure `customHireEnvelope` (byte-stable with the S.977 Connect builder — first-line derive, `Title:` strip with lossless brief, 80-cap, empty → "Custom job") + `isCustomHireEnvelope` idempotency predicate (current + legacy names). Exported from the main index.
- CLI direct hire wraps text briefs in the envelope via new `resolveHireSpecUpload`: bare `0x…64` stays confidential and unwrapped; already-an-envelope JSON uploads as-is (never nested); post-wrap 16KiB re-check. New `--title` flag (≤80, custom-only). `resolveSpecUpload` split into pure `loadSpecText` + raw uploader — **deliver keeps raw**, proofs are never wrapped. Listing hire unchanged.
- Docs: one fact-row in cli-reference.mdx (envelope + `--title`).
- MCP dedupe deferred to the post-release audric follow-up (audric pins sdk 10.28.0); the SDK module header annotates the residual duplicate.

## Test plan
- [x] SDK 561/561 (5 new envelope pins incl. no-double-wrap round-trip); CLI 237/237 (5 new pins reading the actual upload body: wrap/title/prefix/idempotent/hash-passthrough + deliver-stays-raw contrast)
- [x] tsc + lint clean in both packages
- [ ] Post-publish dogfood: `t2 job hire 0.5 <seller> --spec "Title: smoke CLI envelope\n…"` → manage titles it without derive fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)