### PR TITLE
🐛 fix(cli): tx-guard accepts the coinWithBalance framework prelude on funded creates (S.980)

### DIFF
--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -20,9 +20,11 @@ import {
 
 const EVIL_PACKAGE = `0x${'e'.repeat(64)}`;
 
-async function buildTxB64(target: string): Promise<string> {
+const SENDER = `0x${'1'.repeat(64)}`;
+
+function baseTx(): Transaction {
   const tx = new Transaction();
-  tx.setSender(`0x${'1'.repeat(64)}`);
+  tx.setSender(SENDER);
   tx.setGasPrice(1000);
   tx.setGasBudget(10_000_000);
   tx.setGasPayment([
@@ -32,7 +34,23 @@ async function buildTxB64(target: string): Promise<string> {
       digest: '11111111111111111111111111111111',
     },
   ]);
+  return tx;
+}
+
+async function buildTxB64(target: string): Promise<string> {
+  const tx = baseTx();
   tx.moveCall({ target, arguments: [] });
+  return Buffer.from(await tx.build()).toString('base64');
+}
+
+/** Multi-call fixture — same offline build as `buildTxB64`, caller adds the
+ *  commands. Mirrors the shape `coinWithBalance` resolves to on a real
+ *  address-balance-funded create (S.980). */
+async function buildMultiTxB64(
+  add: (tx: Transaction) => void,
+): Promise<string> {
+  const tx = baseTx();
+  add(tx);
   return Buffer.from(await tx.build()).toString('base64');
 }
 
@@ -230,6 +248,131 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
       );
     });
   }
+});
+
+// S.980 — the S.930 check was written against pure single-MoveCall fixtures,
+// but a real funded create sources its USDC through `coinWithBalance`
+// (packages/sdk/src/wallet/coinSelection.ts), which prepends/appends `0x2`
+// framework calls: redeem_funds from the sender's address balance before the
+// escrow call, send_funds returning the remainder to the sender after it. The
+// old "every call === expected" loop refused every such PTB — any wallet whose
+// USDC sat in address balance (i.e. received gaslessly) could not hire at all.
+describe('B — framework coin prelude around a funded create (S.980)', () => {
+  it('signs the founder-bug shape: redeem_funds then escrow::create', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({ target: '0x2::coin::redeem_funds', arguments: [] });
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).not.toThrow();
+  });
+
+  it('signs the full resolver shape: redeem_funds, create, send_funds(remainder → sender)', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      const [coin] = tx.moveCall({
+        target: '0x2::coin::redeem_funds',
+        arguments: [],
+      });
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+      tx.moveCall({
+        target: '0x2::coin::send_funds',
+        arguments: [coin, tx.pure.address(SENDER)],
+      });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).not.toThrow();
+  });
+
+  it('signs open-create with the same prelude (opening funds from AB too)', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({ target: '0x2::coin::redeem_funds', arguments: [] });
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open`,
+        arguments: [],
+      });
+    });
+    expect(() =>
+      assertTxMatchesIntent(b64, { action: 'open-create' }),
+    ).not.toThrow();
+  });
+
+  it('refuses a prelude-only PTB that never calls the escrow', async () => {
+    // redeem_funds + send_funds with no create is a signature over nothing
+    // the user asked for.
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({ target: '0x2::coin::redeem_funds', arguments: [] });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      /never does/,
+    );
+  });
+
+  it('refuses create followed by a call into an evil package', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+      tx.moveCall({ target: `${EVIL_PACKAGE}::escrow::create`, arguments: [] });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      /targets package/,
+    );
+  });
+
+  it('refuses send_funds to anyone but the sender — that is a drain, not a remainder', async () => {
+    const thirdParty = `0x${'d'.repeat(64)}`;
+    const b64 = await buildMultiTxB64((tx) => {
+      const [coin] = tx.moveCall({
+        target: '0x2::coin::redeem_funds',
+        arguments: [],
+      });
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+      tx.moveCall({
+        target: '0x2::coin::send_funds',
+        arguments: [coin, tx.pure.address(thirdParty)],
+      });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      IntentMismatchError,
+    );
+  });
+
+  it('refuses a 0x2 call outside the allowlist (framework != carte blanche)', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+      tx.moveCall({
+        target: '0x2::transfer::public_transfer',
+        arguments: [],
+      });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).toThrow(
+      IntentMismatchError,
+    );
+  });
+
+  it('accepts the balance-module prelude variants the resolver can emit', async () => {
+    const b64 = await buildMultiTxB64((tx) => {
+      tx.moveCall({ target: '0x2::balance::redeem_funds', arguments: [] });
+      tx.moveCall({ target: '0x2::coin::into_balance', arguments: [] });
+      tx.moveCall({
+        target: `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+        arguments: [],
+      });
+      tx.moveCall({ target: '0x2::coin::destroy_zero', arguments: [] });
+    });
+    expect(() => assertTxMatchesIntent(b64, { action: 'create' })).not.toThrow();
+  });
 });
 
 describe('the funnel never signs what it refused', () => {

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -1,4 +1,6 @@
+import { bcs } from '@mysten/sui/bcs';
 import { Transaction } from '@mysten/sui/transactions';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
 import { setSponsoredTxGuard } from '@t2000/sdk';
 import {
   MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
@@ -118,6 +120,39 @@ const ACTION_TARGETS: Record<
   },
 };
 
+/** The Sui framework package, in the padded form decoded PTBs report. */
+const SUI_FRAMEWORK_PACKAGE = normalizeSuiAddress('0x2');
+
+/** Framework calls a funded create may legitimately emit BEFORE/AFTER the
+ *  escrow call — the coin-sourcing prelude (S.980).
+ *
+ *  When a wallet's USDC sits in its address balance (SIP-58 — where gasless
+ *  transfers land it), the SDK's `selectAndSplitCoin` funds the PTB through
+ *  `coinWithBalance` (`packages/sdk/src/wallet/coinSelection.ts`), whose
+ *  build-time resolver emits `0x2` MoveCalls around the escrow call. The
+ *  original "every MoveCall === the escrow target" check therefore refused
+ *  every real funded `create`/`open-create` for every address-balance wallet.
+ *
+ *  Transcribed from `@mysten/sui` `transactions/intents/CoinWithBalance.ts` —
+ *  the COMPLETE set that resolver can emit, nothing more:
+ *
+ *    coin::redeem_funds / balance::redeem_funds — withdraw from the SENDER's
+ *      own address balance (`withdrawFrom: Sender` by construction)
+ *    coin::into_balance — Coin→Balance conversion of a split result
+ *    coin::zero / balance::zero — zero-value intents
+ *    coin::destroy_zero — burn the zero-value dust coin
+ *
+ *  `coin::send_funds` (the remainder-return) is deliberately NOT here: it
+ *  sends a coin to an arbitrary address, so it is only allowed when its
+ *  recipient argument decodes to the transaction sender — see
+ *  `isSenderRemainderReturn`. Nothing else from `0x2` (transfer, pay, …)
+ *  is allowed: an unexpected module or function still refuses, fail closed.
+ */
+const FRAMEWORK_PRELUDE: Record<string, ReadonlySet<string>> = {
+  coin: new Set(['redeem_funds', 'into_balance', 'zero', 'destroy_zero']),
+  balance: new Set(['redeem_funds', 'zero']),
+};
+
 /** Verbs that are NOT marketplace escrow calls and are verified by host pin
  *  alone — the registry package is not in the escrow allowlist, and its args
  *  aren't extractable here. Narrow and named rather than a silent fallthrough. */
@@ -212,24 +247,28 @@ export function assertTxMatchesIntent(
     );
   }
 
-  let calls: { pkg: string; module: string; fn: string }[];
+  let sender: string | null | undefined;
+  let inputs: DecodedInput[];
+  let calls: DecodedCall[];
   try {
     const tx = Transaction.from(
       new Uint8Array(Buffer.from(txBytes, 'base64')),
     );
-    calls = tx
-      .getData()
-      .commands.flatMap((c) =>
-        c.$kind === 'MoveCall' && c.MoveCall
-          ? [
-              {
-                pkg: c.MoveCall.package,
-                module: c.MoveCall.module,
-                fn: c.MoveCall.function,
-              },
-            ]
-          : [],
-      );
+    const data = tx.getData();
+    sender = data.sender;
+    inputs = data.inputs as DecodedInput[];
+    calls = data.commands.flatMap((c) =>
+      c.$kind === 'MoveCall' && c.MoveCall
+        ? [
+            {
+              pkg: c.MoveCall.package,
+              module: c.MoveCall.module,
+              fn: c.MoveCall.function,
+              args: (c.MoveCall.arguments ?? []) as DecodedCall['args'],
+            },
+          ]
+        : [],
+    );
   } catch (e) {
     throw new IntentMismatchError(
       `Refusing to sign: could not decode the prepared transaction (${
@@ -244,22 +283,100 @@ export function assertTxMatchesIntent(
     );
   }
 
+  // Decoded packages come back zero-padded (`0x000…0002`), the allowlist
+  // literals may not be — compare normalized on both sides.
+  const expectedPkg = normalizeSuiAddress(expected.pkg);
+
+  let foundIntent = false;
   for (const call of calls) {
-    if (call.pkg !== expected.pkg) {
-      throw new IntentMismatchError(
-        `Refusing to sign: "${intent.action}" targets package ${expected.pkg}, but the transaction calls ${call.pkg}.`,
-      );
+    if (normalizeSuiAddress(call.pkg) === expectedPkg) {
+      if (call.module !== expected.module) {
+        throw new IntentMismatchError(
+          `Refusing to sign: "${intent.action}" should call ${expected.module}, but the transaction calls ${call.module}.`,
+        );
+      }
+      if (!expected.functions.includes(call.fn)) {
+        throw new IntentMismatchError(
+          `Refusing to sign: "${intent.action}" should call ${expected.module}::${expected.functions.join('|')}, but the transaction calls ${call.module}::${call.fn}.`,
+        );
+      }
+      foundIntent = true;
+      continue;
     }
-    if (call.module !== expected.module) {
-      throw new IntentMismatchError(
-        `Refusing to sign: "${intent.action}" should call ${expected.module}, but the transaction calls ${call.module}.`,
-      );
+    if (isAllowedCoinPrelude(call, sender, inputs)) {
+      continue;
     }
-    if (!expected.functions.includes(call.fn)) {
-      throw new IntentMismatchError(
-        `Refusing to sign: "${intent.action}" should call ${expected.module}::${expected.functions.join('|')}, but the transaction calls ${call.module}::${call.fn}.`,
-      );
-    }
+    throw new IntentMismatchError(
+      `Refusing to sign: "${intent.action}" targets package ${expected.pkg}, but the transaction calls ${call.pkg}::${call.module}::${call.fn}.`,
+    );
+  }
+
+  // A PTB made ONLY of allowed prelude calls never touches the escrow — a
+  // redeem_funds+send_funds pair with no create is a signature over nothing
+  // the user asked for. Refuse it.
+  if (!foundIntent) {
+    throw new IntentMismatchError(
+      `Refusing to sign: "${intent.action}" should call ${expected.module}::${expected.functions.join('|')}, but the transaction never does.`,
+    );
+  }
+}
+
+type DecodedCall = {
+  pkg: string;
+  module: string;
+  fn: string;
+  args: { $kind?: string; Input?: number }[];
+};
+
+type DecodedInput = { $kind?: string; Pure?: { bytes?: string } };
+
+function isAllowedCoinPrelude(
+  call: DecodedCall,
+  sender: string | null | undefined,
+  inputs: DecodedInput[],
+): boolean {
+  if (normalizeSuiAddress(call.pkg) !== SUI_FRAMEWORK_PACKAGE) {
+    return false;
+  }
+  if (FRAMEWORK_PRELUDE[call.module]?.has(call.fn)) {
+    return true;
+  }
+  if (call.module === 'coin' && call.fn === 'send_funds') {
+    return isSenderRemainderReturn(call, sender, inputs);
+  }
+  return false;
+}
+
+/** `coin::send_funds(coin, recipient)` is allowed ONLY as the remainder
+ *  return the `coinWithBalance` resolver appends — recipient must be a Pure
+ *  address input that decodes to the transaction sender. Any other shape
+ *  (a different address, a non-Pure argument, no sender on the tx) refuses:
+ *  send_funds to anyone else is a drain, not a prelude. */
+function isSenderRemainderReturn(
+  call: DecodedCall,
+  sender: string | null | undefined,
+  inputs: DecodedInput[],
+): boolean {
+  if (!sender) {
+    return false;
+  }
+  const recipientArg = call.args[1];
+  if (
+    !recipientArg ||
+    recipientArg.$kind !== 'Input' ||
+    typeof recipientArg.Input !== 'number'
+  ) {
+    return false;
+  }
+  const input = inputs[recipientArg.Input];
+  if (!input || input.$kind !== 'Pure' || !input.Pure?.bytes) {
+    return false;
+  }
+  try {
+    const recipient = bcs.Address.fromBase64(input.Pure.bytes);
+    return normalizeSuiAddress(recipient) === normalizeSuiAddress(sender);
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- **Bug (live 2026-08-09):** `t2 job hire` refused before sign for any wallet whose USDC sits in address balance — `assertTxMatchesIntent` (S.930) required *every* MoveCall to equal the escrow target, but a real funded create sources its USDC through `coinWithBalance` (`packages/sdk/src/wallet/coinSelection.ts`), which emits `0x2` framework calls around `escrow::create`. Since gasless transfers land funds in address balance, this blocked essentially every real buyer wallet on `create` (and `open-create`, same prelude).
- **Fix:** the guard now requires ≥1 MoveCall matching the pinned verb target and allows *only* an explicit framework prelude allowlist beside it — transcribed from `@mysten/sui@2.17.0` `CoinWithBalance.ts`, the complete set that resolver can emit: `coin/balance::redeem_funds` (withdraws from the **sender's own** AB by construction), `coin::into_balance`, `coin/balance::zero`, `coin::destroy_zero`. `coin::send_funds` (the remainder return) is allowed **only when its recipient Pure-decodes to the tx sender** — to anyone else it's a drain and refuses. Any other package, any other `0x2` module/fn, or a prelude-only PTB with no escrow call: refuse, fail closed. Package comparison normalized via `normalizeSuiAddress` (decoded PTBs report `0x000…0002`).
- Host pin (A) untouched; escrow check still uses MAINNET literals, never env-overridable ids.

## Verification
- 245/245 CLI tests (8 new S.980 cases: founder-bug shape accepts, full resolver shape with sender remainder accepts, open-create prelude accepts, balance-module variants accept; prelude-only refuses, create+evil-package refuses, send_funds-to-third-party refuses, non-allowlisted `0x2` call refuses). Typecheck + lint clean.
- **Live replay (prepare-only, nothing signed):** replayed the founder's failing hire against `api.t2000.ai/v1/job/prepare` with the real AB-funded wallet — returned PTB is `0x2::coin::redeem_funds → SplitCoins → escrow::create → 0x2::coin::send_funds(remainder→sender)`; new guard accepts it, old guard's first-call mismatch was the exact reported error.

## Ship
- Patch release (user-blocking bugfix) via `gh workflow run release.yml --field bump=patch` after merge.
- Tracker: t2000-internal S.980 once live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)