### PR TITLE
📦 build(sdk,contracts): pin a2a_escrow LATEST package after S.981 v4 upgrade

### DIFF
--- a/contracts/a2a_escrow/Published.toml
+++ b/contracts/a2a_escrow/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x69ad93c555519de520a5c7f7f2963ad6f8b91cefc098fc2eed75942dcb5bcbe7"
+published-at = "0x83f02c59575b7daa4576eeccc22542f8a5679520e4edd02feeeee2daae16b819"
 original-id = "0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd"
-version = 3
+version = 4
 toolchain-version = "1.76.0"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0x404975a0e2061b47704ffc71241b9f5c6068cb4a474d78015f84a50737be9b46"

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -36,7 +36,7 @@ import {
  *  (`MAINNET_A2A_ESCROW_PACKAGE_ID` in job.ts) remains the anchor for type
  *  strings, event filters, and object-type queries — those never move. */
 export const MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID =
-  '0x69ad93c555519de520a5c7f7f2963ad6f8b91cefc098fc2eed75942dcb5bcbe7';
+  '0x83f02c59575b7daa4576eeccc22542f8a5679520e4edd02feeeee2daae16b819';
 
 /** Back-compat name for the latest id (pre-S.981 consumers import this). */
 export const MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID =


### PR DESCRIPTION
## Summary
S.981 chain cutover executed on mainnet (this PR is the immediate client-side pin):
- **Upgrade**: v4 package `0x83f02c59575b7daa4576eeccc22542f8a5679520e4edd02feeeee2daae16b819` — digest `EEvV9MJnMjDDFyy5iiTAbKpqaZTUJdDSSRd8nETnNq9Z`
- **Migrate**: FeeConfig.version 1→2 — digest `A7AJxWgn9c7CpZbzeVH7tkSWtQfcKrW44v4iPdEWLaSA`; initialSharedVersion unchanged (931861903)

Changes (one-value pin, per the S.981 runbook):
- `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` → the v4 id (OPENING alias + CLI tx-guard family pick it up via the same constant)
- `Published.toml` as rewritten by `sui client upgrade` (published-at = v4, version = 4)
- Untouched by design: `MAINNET_A2A_ESCROW_PACKAGE_ID` (type/event anchor), V2/V3 event pins, FeeConfig id/version constants

Old-package escrow entries now abort `EWrongVersion` on-chain — release must follow this merge immediately (bump=minor) so clients land on v4.

## Test plan
- [x] SDK 567 · CLI 247 · monorepo typecheck 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)