### PR TITLE
♻️ refactor(skills,docs,cli): skills doctrine — playbooks not registries; purge install writer + dead refs (S.998)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -13,7 +13,7 @@ apply to this slice. Don't silently skip.
 - [ ] SDK implementation + tests (`packages/sdk/src/`)
 - [ ] CLI command + tests (`packages/cli/src/commands/`)
 - [ ] MCP tool + tests (Connect — `audric/apps/mcp/lib/tools.ts`)
-- [ ] Agent Skill (`t2000-skills/skills/`)
+- [ ] Agent Skill (`t2000-skills/skills/`) — only on lifecycle/policy/money-rule changes; never for Connect card/`next` polish (tools/list is the inventory SSOT)
 - [ ] Mintlify docs (`apps/docs/*.mdx`) — auto-deploys to developers.t2000.ai
 - [ ] Root `README.md`
 - [ ] Package `README.md`s

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,15 +196,17 @@ keeps the directory read-model authoritative.
 **Passport Connect** (`audric/apps/mcp`, `https://mcp.t2000.ai/mcp` + OAuth)
 is THE MCP surface — no install, no client-side key; delegated spend sessions
 are server-held, bounded (per-job / daily / ask-above limits, revocable,
-expiring), and every money verb is `authorizeSpend`-gated. The tool registry
-is `audric/apps/mcp/lib/tools.ts` — read it for the live list; `t2000_send`
-to external addresses is absent by design.
+expiring), and every money verb is `authorizeSpend`-gated — `t2000_send` included
+(external transfers run under the same session limits as every spend). The
+tool inventory SSOT is Connect `tools/list` (`audric/apps/mcp/lib/tools.ts`) —
+skills are playbooks, never a second registry.
 
 **Skills** (`t2000-skills/`, auto-synced to the public
 [`mission69b/t2000-skills`](https://github.com/mission69b/t2000-skills) repo on
 every push) are markdown playbooks any skill-reading agent can follow. They
 install locally via `npx skills add mission69b/t2000-skills` — optional; Connect
-needs no skills, and serves each one live as a `skill-<name>` prompt.
+needs no skills. Skills are playbooks (when/why + CLI sequences); the tool
+inventory is always Connect `tools/list`, never a skill.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,7 @@ When shipping a feature, update these files:
 - [ ] SDK implementation + tests (`packages/sdk/src/`)
 - [ ] CLI command + tests (`packages/cli/src/commands/`)
 - [ ] MCP tool + tests (Connect — `audric/apps/mcp/lib/tools.ts`)
-- [ ] Agent Skill (`t2000-skills/skills/`)
+- [ ] Agent Skill (`t2000-skills/skills/`) — ONLY when lifecycle/policy/money rules changed; skills are playbooks, never a tool inventory (Connect `tools/list` is the SSOT), so Connect card/`next` polish never touches them
 - [ ] Mintlify docs (`apps/docs/*.mdx`) — auto-deploys to `docs.t2000.ai`
 - [ ] Root README (`README.md`)
 - [ ] Package READMEs (`packages/*/README.md`)

--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -176,7 +176,7 @@ import {
   // Sui clients
   getSuiClient, getSuiGrpcClient, DEFAULT_GRPC_URL,
 
-  // Chat against api.audric.ai (standalone — used by t2 models + the MCP chat tool)
+  // Chat against api.audric.ai (standalone — used by t2 models; there is no chat tool on Passport Connect)
   chatCompletion, chatCompletionStream, listModels, DEFAULT_API_BASE,
 
   // Confidential-receipt verifier (signed receipt + trustless Sui anchor)

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -5,7 +5,7 @@ description: What's new in the t2000 stack — the notable changes, newest first
 
 The highlights, newest first. For the exhaustive per-version log, see
 [GitHub Releases](https://github.com/mission69b/t2000/releases). The `@t2000/sdk`,
-`@t2000/cli`, `@t2000/mcp`, and `@t2000/id` packages ship together on one version.
+`@t2000/cli`, `@t2000/id`, `@t2000/serve`, `@t2000/sui-x402`, and `@t2000/discovery` packages ship together on one version (six packages; the stdio `@t2000/mcp` was deleted 2026-08-03 — Passport Connect is the MCP surface).
 
 <Update label="One MCP URL — local stdio retired" description="August 2, 2026">
   **The local stdio MCP server is retired** (`t2 mcp` / `t2 mcp install` are

--- a/packages/cli/src/commands/mcp/platforms.test.ts
+++ b/packages/cli/src/commands/mcp/platforms.test.ts
@@ -4,24 +4,10 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  MCP_SERVER_ENTRY,
   MCP_SERVER_KEY,
   hasMcpEntry,
-  withMcpEntry,
   withoutMcpEntry,
 } from './platforms.js';
-
-describe('MCP_SERVER_ENTRY', () => {
-  it('uses the t2000 bin (the only exposed binary until Phase C)', () => {
-    // Pre-Phase-C: t2 isn't on PATH; AI client must launch via t2000.
-    expect(MCP_SERVER_ENTRY.command).toBe('t2000');
-    expect(MCP_SERVER_ENTRY.args).toEqual(['mcp', 'start']);
-  });
-
-  it('uses the t2000 key (canonical install identifier)', () => {
-    expect(MCP_SERVER_KEY).toBe('t2000');
-  });
-});
 
 describe('hasMcpEntry', () => {
   it('returns false for empty config', () => {
@@ -36,31 +22,6 @@ describe('hasMcpEntry', () => {
     expect(hasMcpEntry({ mcpServers: { t2000: { command: 't2', args: ['mcp', 'start'] } } })).toBe(
       true,
     );
-  });
-});
-
-describe('withMcpEntry', () => {
-  it('adds the entry when none exists', () => {
-    const result = withMcpEntry({});
-    expect(hasMcpEntry(result)).toBe(true);
-    expect((result.mcpServers as Record<string, unknown>).t2000).toEqual(MCP_SERVER_ENTRY);
-  });
-
-  it('preserves other servers in mcpServers', () => {
-    const result = withMcpEntry({ mcpServers: { other: { command: 'foo' } } });
-    expect((result.mcpServers as Record<string, unknown>).other).toEqual({ command: 'foo' });
-    expect((result.mcpServers as Record<string, unknown>).t2000).toEqual(MCP_SERVER_ENTRY);
-  });
-
-  it('is idempotent — overwrites a stale (Day 5 t2-bin) entry', () => {
-    const stale = { mcpServers: { t2000: { command: 't2', args: ['mcp', 'start'] } } };
-    const result = withMcpEntry(stale);
-    expect((result.mcpServers as Record<string, unknown>).t2000).toEqual(MCP_SERVER_ENTRY);
-  });
-
-  it('preserves unknown top-level keys (does not nuke user config)', () => {
-    const result = withMcpEntry({ mcpServers: {}, customField: 'preserved' });
-    expect(result.customField).toBe('preserved');
   });
 });
 

--- a/packages/cli/src/commands/mcp/platforms.ts
+++ b/packages/cli/src/commands/mcp/platforms.ts
@@ -1,8 +1,9 @@
-// [SPEC_AGENT_WALLET_GREENFIELD Phase A Day 5 — 2026-05-26]
-// Shared MCP platform descriptors + low-level JSON config helpers.
-// Used by `t2 mcp install` + `t2 mcp uninstall`. Kept separate from the
-// command files so unit tests can exercise the data layer without
-// spinning up commander.
+// [SPEC_AGENT_WALLET_GREENFIELD Phase A Day 5 — 2026-05-26; S.998 purge]
+// Shared MCP platform descriptors + low-level JSON config helpers for
+// `t2 mcp uninstall` — LEGACY STDIO CLEANUP ONLY. The install writer
+// (MCP_SERVER_ENTRY / withMcpEntry) was deleted in S.998: there is no
+// local t2000 MCP server; Passport Connect (https://mcp.t2000.ai/mcp) is
+// the only MCP surface and `t2 mcp install` hard-errors pointing at it.
 //
 // Codex coverage NOTE: `~/.codex/config.json` doesn't exist in this
 // helper today — adding it is gated on confirming Codex's settled
@@ -24,23 +25,6 @@ export interface McpPlatform {
   /** Absolute path to the platform's JSON config file. */
   path: string;
 }
-
-/**
- * The MCP server entry that gets written into each platform's
- * `mcpServers.<key>` map. Uses `t2000` — the only bin currently
- * exposed by `packages/cli/package.json`. Phase C will rename the
- * primary bin to `t2` and keep `t2000` as a permanent alias; at that
- * point new installs MAY switch to `command: 't2'` but existing
- * installs continue working because `t2000` stays valid.
- *
- * Day 6 finding: shipped with `command: 't2'` during the Day 5 refactor,
- * which broke any user who ran `t2 mcp install` since `t2` isn't on
- * PATH until Phase C lands. Day 6 audit caught it; reverted here.
- */
-export const MCP_SERVER_ENTRY = {
-  command: 't2000',
-  args: ['mcp', 'start'],
-} as const;
 
 /**
  * Key under `mcpServers` in each platform's config. Stays `t2000` so
@@ -97,20 +81,6 @@ export async function writeJsonFile(path: string, data: McpConfigFile): Promise<
   await writeFile(path, JSON.stringify(data, null, 2) + '\n', 'utf-8');
 }
 
-/**
- * Pure mutator: returns the new config object with the t2000 MCP
- * entry merged in. Idempotent — calling twice produces the same
- * result. Caller decides whether to write it back to disk.
- */
-export function withMcpEntry(config: McpConfigFile): McpConfigFile {
-  return {
-    ...config,
-    mcpServers: {
-      ...(config.mcpServers ?? {}),
-      [MCP_SERVER_KEY]: { ...MCP_SERVER_ENTRY },
-    },
-  };
-}
 
 export function hasMcpEntry(config: McpConfigFile): boolean {
   return (

--- a/packages/sdk/src/commerce.ts
+++ b/packages/sdk/src/commerce.ts
@@ -1,6 +1,6 @@
 // Commerce API client (t2 ACP) — agent services + the content-addressed
 // job-spec store on api.t2000.ai. Shared by `@t2000/cli` (`t2 service` /
-// `t2 browse` / `t2 job`) and `@t2000/mcp` (the t2000_service_* / t2000_job_*
+// `t2 browse` / `t2 job`) and Passport Connect (audric/apps/mcp — the t2000_service_* / t2000_job_*
 // tools) so the tamper-verify logic exists exactly once.
 //
 // Browser-safe: hashing uses WebCrypto (`crypto.subtle`), available in every

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -5,7 +5,7 @@
 // a2a_escrow Job, and an unclaimed opening refunds fee-free (buyer cancel
 // any time, or the permissionless crank after `open_until`).
 //
-// Shared by `@t2000/cli` (the `t2 job` open verbs) and `@t2000/mcp` (the
+// Shared by `@t2000/cli` (the `t2 job` open verbs) and Passport Connect (audric/apps/mcp — the
 // t2000_job_* tools). Reads are public (`/v1/open-jobs`, the indexer
 // read-model of chain events). Mutations are ALL on-chain transactions via
 // the sponsored rail: `/v1/job/prepare` (actions open-create / open-claim /

--- a/t2000-skills/.claude-plugin/marketplace.json
+++ b/t2000-skills/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
         "./skills/t2000-swap",
         "./skills/t2000-services",
         "./skills/t2000-pay",
-    "./skills/t2000-mcp",
+    "./skills/t2000-connect",
     "./skills/t2000-verify"
       ]
     }

--- a/t2000-skills/AGENTS.md
+++ b/t2000-skills/AGENTS.md
@@ -114,7 +114,7 @@ that API."
 Read `skills/<slug>/SKILL.md` in this repo (or the public
 [`mission69b/t2000-skills`](https://github.com/mission69b/t2000-skills) mirror).
 Slugs: `t2000-setup`, `t2000-send`, `t2000-swap`, `t2000-pay`, `t2000-receive`,
-`t2000-services`, `t2000-check-balance`, `t2000-job`, `t2000-mcp`. Local
+`t2000-services`, `t2000-check-balance`, `t2000-job`, `t2000-connect`. Local
 install: `npx skills add mission69b/t2000-skills` (add `-s <slug>` for one).
 This file is the cross-cutting ops layer they all assume; the skills are the
 step-by-step recipes.
@@ -122,4 +122,4 @@ step-by-step recipes.
 **Copied skills drift.** If skills were installed to disk (`.agents/skills/`,
 `.cursor/rules/`, `.claude/skills/`), refresh them with `npx skills update`
 (or re-run `npx skills add mission69b/t2000-skills`).
-(MCP clients skip this: connecting to `https://mcp.t2000.ai/mcp` serves every skill live as a `skill-<name>` prompt, no files.)
+(MCP clients connecting to `https://mcp.t2000.ai/mcp` get the live TOOLS — skills stay optional local playbooks; Connect does not serve skills as prompts.)

--- a/t2000-skills/README.md
+++ b/t2000-skills/README.md
@@ -1,6 +1,6 @@
 # t2000 Agent Skills
 
-Ship USDC apps on Sui faster with **t2000 Skills** — best-practice guidance for the t2000 Agent Wallet (sponsored sends, swaps, x402 API payments) — plus the **t2000 MCP server** for live wallet tools in your AI client.
+Ship USDC apps on Sui faster with **t2000 Skills** — best-practice PLAYBOOKS for the t2000 Agent Wallet (sponsored sends, swaps, x402 API payments). Skills teach when/why + CLI sequences; the live tool inventory is always Passport Connect `tools/list` (`https://mcp.t2000.ai/mcp`) — never a skill.
 
 [![npm @t2000/cli](https://img.shields.io/npm/v/@t2000/cli?label=%40t2000%2Fcli)](https://www.npmjs.com/package/@t2000/cli)
 [![docs](https://img.shields.io/badge/docs-docs.t2000.ai-00D395)](https://docs.t2000.ai)
@@ -41,7 +41,7 @@ Installs all ten wallet skills (the `t2000-agent-wallet` plugin) via Claude Code
 | [`t2000-swap`](skills/t2000-swap/SKILL.md) | Best-route swaps via Cetus Aggregator across 20+ Sui DEXs (SUI, USDC, USDsui, USDT, USDe, ETH, GOLD, NAVX, WAL, vSUI, …). Covers `--quote`, slippage, asset selection, and the "swap needs SUI for gas" gotcha. |
 | [`t2000-services`](skills/t2000-services/SKILL.md) | Discover x402 services (paid AI / search / image-gen / mail / TTS APIs) payable via `t2 pay`. Pairs with `t2000-pay` — always discover first, then pay. |
 | [`t2000-pay`](skills/t2000-pay/SKILL.md) | Pay for an x402-protected API service via the wallet. Handles the HTTP 402 challenge → quote → USDC payment → retry loop automatically. Use whenever a task needs a paid API (chat, search, image, mail, weather, code execution, …). |
-| [`t2000-mcp`](skills/t2000-mcp/SKILL.md) | Connect Claude, Cursor, ChatGPT, Cline, Continue, or any MCP client to the hosted Passport Connect MCP (`https://mcp.t2000.ai/mcp` + OAuth). Covers setup, session spend limits, and the tool surface. |
+| [`t2000-connect`](skills/t2000-connect/SKILL.md) | Connect Claude, Cursor, ChatGPT, Cline, Continue, or any MCP client to the hosted Passport Connect MCP (`https://mcp.t2000.ai/mcp` + OAuth). Covers setup and session spend limits — the tool inventory is Connect `tools/list`, never a skill. |
 
 ### Sui ecosystem skills
 
@@ -74,7 +74,7 @@ The per-task skills above assume a shared **agent-ops layer**: payment-error rec
 
 ## t2000 MCP (Passport Connect)
 
-Skills tell your agent *how* to use the wallet. The hosted MCP gives it the actual *tools* — reads, marketplace verbs, and spend-gated money verbs. Every skill is also auto-registered as a `skill-<name>` prompt your client can invoke directly. One config for every MCP client:
+Skills tell your agent *how* to use the wallet. The hosted MCP gives it the actual *tools* — reads, marketplace verbs, and spend-gated money verbs (discover them via the connector's `tools/list`; skills never list tools). One config for every MCP client:
 
 ```json
 {
@@ -90,7 +90,7 @@ OAuth (Google → Passport) + per-session spend limits set in the console.
 
 The `t2000` command must be on `PATH` — install globally with `npm install -g @t2000/cli` (the CLI ships with the MCP entry point).
 
-Full setup walkthrough + troubleshooting: see [`t2000-mcp/SKILL.md`](skills/t2000-mcp/SKILL.md).
+Full setup walkthrough + troubleshooting: see [`t2000-connect/SKILL.md`](skills/t2000-connect/SKILL.md).
 
 ## Prerequisites
 

--- a/t2000-skills/skills/t2000-connect/SKILL.md
+++ b/t2000-skills/skills/t2000-connect/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: t2000-mcp
+name: t2000-connect
 description: >-
   Connect a t2000 Passport to Claude, Cursor, ChatGPT, Cline, Continue, or any
   MCP-compatible client. Use when asked to set up MCP, add the t2000
@@ -8,11 +8,11 @@ description: >-
 license: MIT
 metadata:
   author: t2000
-  version: "4.0"
+  version: "5.0"
   requires: nothing local — a Google account becomes the Passport
 ---
 
-# t2000: MCP (Passport Connect)
+# t2000: Passport Connect
 
 ## Purpose
 
@@ -54,41 +54,31 @@ it as the connector's auth header — same session, same limits.
 Per-job / daily / ask-above limits are set at
 [t2000.ai/manage/connections](https://t2000.ai/manage/connections) (also where
 you revoke). A session expires on its own within **7 days**; **Revoke** stops
-new spends immediately. A spend over the ask-above threshold pauses and emails
-you — approve it in the console and the agent retries.
-
-**External sends are blocked by design** on Connect sessions — moving USDC out
-of the Passport happens in Audric or the console, never through a session.
+new spends immediately. A spend **at or above the ask-above threshold is
+refused** until you raise the limit in the console — there is no one-shot
+approve; edit the limit, then the agent retries.
 
 Earn-first: a Passport with **$0** can still work — registering an Agent ID is
 free, and claiming an Open job costs nothing because the buyer's budget is
 already escrowed.
 
-## Available tools
+## Tools
 
-Read (free): `t2000_balance` · `t2000_address` · `t2000_receive` ·
-`t2000_services` · `t2000_agents` · `t2000_jobs` · `t2000_job_board` ·
-`t2000_limit` (read-only — an agent may read its leash, never lengthen it) ·
-`t2000_swap_quote`
+> **Connect's `tools/list` is the only tool inventory. Never invent tools
+> from this skill — or any skill.**
 
-Earn (free): `t2000_agent_register` · `t2000_agent_sell` (origin-aware — pass
-your API origin to list every paid route) · `t2000_service_create` ·
-`t2000_service_retire` · `t2000_job_claim` · `t2000_job_deliver` ·
-`t2000_job_decline` · `t2000_job_review`
+Three families, discovered live from the connector:
 
-Spend (gated by the session limits): `t2000_pay` (x402) · `t2000_swap` ·
-`t2000_job_hire` · `t2000_job_open` (budget escrows at post; unclaimed
-postings refund fee-free via `t2000_job_cancel`) · `t2000_job_settle`
+- **Free reads** — balance, catalog, job board, your inbox, status, limits
+  (read-only: an agent may read its leash, never lengthen it).
+- **Free earn** — register an Agent ID, list services, claim Open work,
+  deliver, review.
+- **Limit-gated spends** — hire, post Open jobs, settle, pay x402, swap, and
+  send, all checked against the session's per-job / daily / ask-above
+  ceilings before anything moves.
 
-Every skill in `t2000-skills/skills/` is also exposed as a `skill-<name>`
-prompt.
-
-### Not on Connect — deliberate
-
-- `t2000_send` — external transfers are a human action (Audric / console).
-- `t2000_chat` / `t2000_models` — Private Inference is an **Audric** product
-  (`api.audric.ai`, OpenAI-compatible; key from audric.ai).
-- `t2000_history` — read it in the console Activity page or `t2 history`.
+External `send` runs on Connect under those same session limits — like every
+spend, an amount at or above ask-above is refused until the limit is raised.
 
 ## Troubleshooting
 
@@ -96,13 +86,14 @@ prompt.
 |---------|-------|-----|
 | Client shows no `t2000_*` tools | Connector not approved | Re-add `https://mcp.t2000.ai/mcp`, complete the Google sign-in |
 | `401` from mcp.t2000.ai | No/expired session — fail-closed by design | Reconnect (OAuth), or mint a fresh token under Connections |
-| A spend returns "waiting on you" | Amount is over the session's ask-above threshold | Approve it at t2000.ai/manage/connections, then retry |
+| A spend is refused naming ask-above | Amount at or above the session threshold | Raise Ask-above (and Per-job if needed) at t2000.ai/manage/connections, then retry — there is no approve flow |
 | A spend is refused with a limit message | Per-job or daily cap hit | Raise limits in the console (the agent cannot) |
-| Old config still spawns a local t2000 MCP command | Stale entry — the hosted URL is the only transport | Replace it with the URL block above (or `npx @t2000/cli mcp uninstall` cleans all clients) |
+| Old config still spawns a local t2000 MCP command | Stale stdio entry from the deleted local server | Replace it with the URL block above; `npx @t2000/cli mcp uninstall` cleans stale stdio configs from all clients (legacy cleanup only) |
 
 ## Security
 
 - The wallet key never exists client-side — sessions are zkLogin-backed and
   server-held, scoped by the limits you set.
 - Sessions expire within 7 days; revocation is immediate.
-- External sends are impossible from a session, whatever the prompt says.
+- Every spend — send included — is checked against the session limits; the
+  agent cannot raise them.

--- a/t2000-skills/skills/t2000-setup/SKILL.md
+++ b/t2000-skills/skills/t2000-setup/SKILL.md
@@ -14,18 +14,33 @@ metadata:
   requires: Node.js 18+ and a terminal
 ---
 
-# t2000: Agent Wallet — One-Prompt Setup
+# t2000: Agent Wallet — Setup
+
+## First: do they even need the CLI?
+
+**Marketplace from Claude (or any MCP client) only?** Skip everything below.
+Add `https://mcp.t2000.ai/mcp` as a custom connector, approve with Google —
+that IS the Passport. No CLI, no skills, nothing local; limits live at
+[t2000.ai/manage/connections](https://t2000.ai/manage/connections). Details:
+the `t2000-connect` skill.
+
+The steps below are for the **optional terminal Agent Wallet** (funnel B):
+a local `t2` CLI + key file for terminal workflows. Connect remains an
+optional add-on afterwards.
 
 ## Purpose
 
-Get a fresh user from "nothing installed" to "Agent Wallet ready" in under 5 minutes. This is the canonical entry point for the **one-prompt install** UX:
+Get a fresh user from "nothing installed" to "Agent Wallet ready" in under 5
+minutes, via this skill:
 
 ```
 Run `npx skills add mission69b/t2000-skills -s t2000-setup` and follow the
 installed skill to set up my Agent Wallet.
 ```
 
-When invoked through that prompt, the LLM installs and reads this file, then executes the steps below in order.
+The skill is the playbook the LLM follows — there is no hosted installer
+script at any URL. When invoked, read this file, then execute the steps
+below in order.
 
 ## Rules
 
@@ -126,7 +141,7 @@ other MCP client takes the same URL as JSON:
 ```
 
 Session spend limits (per-job / daily / ask-above) are set at
-t2000.ai/manage/connections. Details + per-client notes: the `t2000-mcp`
+t2000.ai/manage/connections. Details + per-client notes: the `t2000-connect`
 skill. After adding the connector, the user may need to **restart the AI
 client** for the `t2000_*` tools to appear.
 
@@ -148,22 +163,6 @@ What's my t2000 balance?
 ```
 
 Should invoke the `t2000_balance` MCP tool and return the same numbers.
-
-**6c — AI client prompt smoke**:
-
-The MCP server doesn't just expose tools — it also exposes one `skill-<name>` prompt per t2000 skill (auto-registered from `t2000-skills/skills/*/SKILL.md`). Type `/` in the AI client's chat input to open the prompt picker. You should see:
-
-- `skill-setup` — this skill
-- `skill-send` — sending USDC / USDsui / SUI
-- `skill-swap` — swapping via Cetus
-- `skill-pay` — paying for x402 services
-- `skill-receive` — generating payment requests
-- `skill-services` — discovering ASP Services in the marketplace
-- `skill-check-balance` — reading the wallet
-- `skill-job` — hiring agents / selling services over escrowed A2A jobs
-- `skill-mcp` — MCP integration deep-dive
-
-Run `/skill-check-balance` (or just type and accept the autocomplete). The skill markdown loads as a prompt and the assistant returns a structured balance breakdown.
 
 > **Tip — triggering the wallet in a *fresh* session.** In a brand-new chat, lead with **"use t2 services"** — e.g. *"Use t2 services to find someone who writes market briefs, then hire them."* That tells the client to load the `t2000_*` tools instead of answering from its own sandbox. Name what you want DONE, not a provider: t2000 sells what ASPs list, and nothing else.
 
@@ -191,7 +190,7 @@ After verify succeeds, surface a short menu of natural next moves:
 - "Generate a payment request" → `t2000-receive`
 - "See available paid services" → `t2000-services`
 - "Hire an agent (or sell your own services)" → `t2000-job` — **Hire**: browse with `t2 services`, hire a listing with `t2 job hire --agent <seller> --service <slug>`, or hire custom when nothing fits: `t2 job hire <usdc> <seller> --spec <brief>` — never invent a listing. **Open**: post to the board with `t2 job open`; sellers claim with `t2 job claim`. Sell with `t2 service create`
-- "Connect more AI clients" → `t2000-mcp`
+- "Connect more AI clients" → `t2000-connect`
 - "See what else t2 can do" → run `t2 --help` or browse https://docs.t2000.ai/agent-wallet#skills
 
 ## Troubleshooting
@@ -201,5 +200,5 @@ After verify succeeds, surface a short menu of natural next moves:
 | `t2: command not found` after npm install | npm's global bin dir isn't on `PATH`. Find it with `npm prefix -g` (bins live in `$(npm prefix -g)/bin`), then add that dir to your shell profile — or `npm config set prefix ~/.npm-global` for a durable user-level prefix. Both `t2` and `t2000` ship in every install. |
 | `t2 init` fails with permission error | Don't run with `sudo`; npm global may need a user-level prefix (`npm config set prefix ~/.npm-global`) |
 | `t2 init` fails with `WALLET_EXISTS` | A file already lives at `~/.t2000/wallet.key`. If it's a v3 file you no longer need, move/delete it. If you still need it, point v3 + v4 at separate paths via `--key`. v4 does not auto-migrate v3 wallets — see the v3 upgrade note in Step 2. |
-| AI client doesn't see `t2000_*` tools after connecting | Restart the client; re-approve the `https://mcp.t2000.ai/mcp` connector (OAuth). See the `t2000-mcp` skill. |
+| AI client doesn't see `t2000_*` tools after connecting | Restart the client; re-approve the `https://mcp.t2000.ai/mcp` connector (OAuth). See the `t2000-connect` skill. |
 | Old config spawns a local t2000 MCP command | Stale entry — the hosted URL is the only transport | Replace with the hosted URL block (Step 5); clean old entries with `t2 mcp uninstall` |

--- a/t2000-skills/validate.ts
+++ b/t2000-skills/validate.ts
@@ -193,7 +193,7 @@ function main() {
     'sui-grpc',
     'suins',
     't2000-check-balance',
-    't2000-mcp',
+    't2000-connect',
     't2000-pay',
     't2000-receive',
     't2000-send',


### PR DESCRIPTION
## Summary
t2000 half of S.998 (audric half — install.sh death + t2000_history fix — landed as audric#283 `1af78693`).

**Track A — skills doctrine:**
- `t2000-mcp` skill renamed **`t2000-connect`** (dir + frontmatter + validate.ts + marketplace.json + README/AGENTS + t2000-setup cross-refs; validate green, 14 skills).
- Rewritten SKILL.md: leads with Connect OAuth; the exhaustive tool inventory is GONE — three families only (free reads / free earn / limit-gated spends) plus the mandate line *"Connect `tools/list` is the only tool inventory. Never invent tools from this skill."* Falsehoods fixed: `t2000_send` IS on Connect (limits-gated, was "blocked by design"); ask-above is a **hard refuse until limits are raised** (was "pauses and emails you — approve and retry"); the `skill-<name>` prompts claim deleted (Connect serves no skill prompts — also purged from setup's 6c smoke, AGENTS.md, ARCHITECTURE, skills README).
- `t2000-setup` now leads with funnel A: *marketplace from Claude only? Connect OAuth, skip the CLI* — then the terminal-wallet steps; no hosted-installer language.
- Ship checklist (CLAUDE.md + /ship): skills update ONLY on lifecycle/policy/money-rule changes, never Connect card polish.

**Track B — dead refs:** SDK `commerce.ts`/`open-jobs.ts` comments now cite Passport Connect (audric/apps/mcp), not `@t2000/mcp`; changelog intro lists the six live lockstep packages with the stdio deletion as history; agent-sdk.mdx no longer implies an MCP chat tool. Deprecation notes in SECURITY/CLAUDE/rules stay (correct history). Quickstart already clean (Track D verified).

**Track F — CLI install-writer purge:** `MCP_SERVER_ENTRY` + `withMcpEntry` deleted from `platforms.ts` (only their own tests consumed them); header now states this file is legacy stdio CLEANUP only. `t2 mcp uninstall` + the install hard-error stay. 6 dead tests dropped — CLI 241/241.

**Track G:** grepped clean across product surfaces (`install.sh`, `curl|bash`, `@t2000/mcp`-as-live, `t2 skills install`, `t2000_history`, `skill-<name>`, send-absent fiction); remaining hits are changelog history + deprecation tombstones, kept deliberately.

## Verification
- [x] skills validate 14/0 · CLI 241 tests + tsc + lint · SDK suite · monorepo typecheck 10/10.
- [ ] Post-merge (audric half already deployed): prod `curl -sS t2000.ai/install.sh` = `# 404 — not found.` once cache rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)