### PR TITLE
🐛 fix(serve,cli): WWW-Auth currency string + pay --estimate non-zero exit (S.1002)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -50,7 +50,7 @@ t2 swap 100 USDC SUI --quote
 
 | Command | What it does |
 | --- | --- |
-| `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying. |
+| `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
 | `t2 services [query]` | Discover Services in the A2A Marketplace — escrow work + ASP x402 endpoints. (`t2 browse` is a deprecated alias.) |
 
 ```bash

--- a/packages/cli/src/commands/pay.test.ts
+++ b/packages/cli/src/commands/pay.test.ts
@@ -4,7 +4,7 @@
 // lock down the pure parser semantics.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { collectHeaders, describeSchemaFields, fetchInputSchema } from './pay.js';
+import { collectHeaders, describeSchemaFields, fetchInputSchema, runEstimate, truncatePreview } from './pay.js';
 
 describe('collectHeaders', () => {
   it('parses key=value into the accumulator', () => {
@@ -103,5 +103,88 @@ describe('fetchInputSchema (2.13)', () => {
   it('returns null when the endpoint has no schema in the doc', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ paths: {} }), { status: 200 })));
     expect(await fetchInputSchema('https://paid.example/unknown/path', 'POST')).toBeNull();
+  });
+});
+
+describe('truncatePreview (S.1002)', () => {
+  it('returns short bodies unchanged', () => {
+    expect(truncatePreview('hello')).toBe('hello');
+    expect(truncatePreview('a'.repeat(512))).toBe('a'.repeat(512));
+  });
+
+  it('truncates long bodies with an honest size note', () => {
+    const body = 'x'.repeat(2048);
+    const out = truncatePreview(body);
+    expect(out).toBe(`${'x'.repeat(512)}… (truncated, 2048 total bytes)`);
+  });
+});
+
+describe('runEstimate exit contract (S.1002)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('throws on a 2xx response — "no payment required" must not exit 0', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('<html>welcome</html>', { status: 200 })));
+    await expect(runEstimate('https://example.com/', { method: 'GET', maxPrice: '1.00', header: {} })).rejects.toThrow(
+      /exits 0 only for a payable 402/,
+    );
+  });
+
+  it('throws on 404/dead URLs and truncates the body preview in the JSON payload', async () => {
+    const hugeBody = '<html>' + 'z'.repeat(4096) + '</html>';
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(hugeBody, { status: 404 })));
+    const failure = await runEstimate('https://example.com/typo', { method: 'GET', maxPrice: '1.00', header: {} }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(failure).toBeInstanceOf(Error);
+    const payload = (failure as { toJSON(): Record<string, unknown> }).toJSON();
+    expect(payload.ok).toBe(false);
+    expect(payload.status).toBe(404);
+    expect(payload.estimate).toBeNull();
+    const preview = payload.bodyPreview as string;
+    expect(preview.length).toBeLessThan(600); // 512 + truncation note, never the 4KB dump
+    expect(preview).toContain('total bytes)');
+  });
+
+  it('resolves (exit 0 path) on a payable 402 x402 accepts[] challenge', async () => {
+    const challenge = {
+      x402Version: 1,
+      error: 'Payment required',
+      accepts: [
+        {
+          scheme: 'exact',
+          network: 'sui:mainnet',
+          asset: '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC',
+          maxAmountRequired: '10000',
+          payTo: '0x' + 'a'.repeat(64),
+          resource: 'https://paid.example/search',
+        },
+      ],
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL) =>
+        String(input).includes('/search')
+          ? new Response(JSON.stringify(challenge), { status: 402 })
+          : new Response('nope', { status: 404 }), // best-effort openapi probe
+      ),
+    );
+    await expect(runEstimate('https://paid.example/search', { method: 'GET', maxPrice: '1.00', header: {} })).resolves.toBeUndefined();
+  });
+
+  it('still throws on a 402 with no payable accepts[] (header-only)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response('payment required', {
+            status: 402,
+            headers: { 'WWW-Authenticate': 'Payment realm="x", recipient="0xabc"' },
+          }),
+      ),
+    );
+    await expect(runEstimate('https://paid.example/hdr', { method: 'GET', maxPrice: '1.00', header: {} })).rejects.toThrow(
+      /header-only 402/,
+    );
   });
 });

--- a/packages/cli/src/commands/pay.ts
+++ b/packages/cli/src/commands/pay.ts
@@ -52,7 +52,7 @@ export function registerPay(program: Command) {
     .option('--max-price <amount>', 'Max USDC price to auto-approve', '1.00')
     .option(
       '--estimate',
-      'Preview the price + service info (no signing, no payment). Exits 0 if the service responds with a 402 challenge.',
+      'Preview the price + service info (no signing, no payment). Exits 0 ONLY if the service answers a payable 402 x402 challenge; any other response (including 2xx "no payment required") exits 1.',
     )
     .option('--force', 'Override spending limits for this call (see `t2 limit`)')
     .addHelpText(
@@ -141,13 +141,44 @@ Examples:
     });
 }
 
+/** Cap on body previews for non-402 estimate responses — operators piping
+ *  `--estimate` must never get a multi-KB HTML dump on stdout (S.1002). */
+const ESTIMATE_PREVIEW_MAX = 512;
+
+/** Truncate a response body for display: full text under the cap, else the
+ *  first `max` chars + an honest truncation note with the real size. */
+export function truncatePreview(body: string, max = ESTIMATE_PREVIEW_MAX): string {
+  if (body.length <= max) {
+    return body;
+  }
+  return `${body.slice(0, max)}… (truncated, ${body.length} total bytes)`;
+}
+
+/** Estimate failure that exits 1 with ONE structured JSON object in --json
+ *  mode (handleError prefers toJSON) and a short reason line otherwise. */
+class EstimateFailure extends Error {
+  constructor(
+    message: string,
+    private readonly payload: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = 'EstimateFailure';
+  }
+  toJSON(): Record<string, unknown> {
+    return this.payload;
+  }
+}
+
 /**
- * `--estimate` path. Issues the request with no Payment header, expects
- * a 402, parses the WWW-Authenticate challenge, prints the relevant
- * fields. Exits 0 on success — this is a discovery / pricing flow, not
- * an error path.
+ * `--estimate` path. Issues the request with no Payment header, expects a
+ * 402, parses the x402 `accepts[]` body envelope — the primary dialect
+ * (the WWW-Authenticate header is belt-and-suspenders only; S.880) — and
+ * prints the relevant fields. Exit contract (S.1002, founder-locked):
+ * 0 ONLY when the response proves a payable 402 x402 challenge. Any other
+ * status — including 2xx "no payment required" — throws, because operators
+ * script estimate as "may I pay this URL"; friendly copy, non-zero exit.
  */
-async function runEstimate(url: string, opts: PayOptions): Promise<void> {
+export async function runEstimate(url: string, opts: PayOptions): Promise<void> {
   const method = opts.data && opts.method === 'GET' ? 'POST' : opts.method;
   const canHaveBody = method !== 'GET' && method !== 'HEAD';
 
@@ -175,35 +206,40 @@ async function runEstimate(url: string, opts: PayOptions): Promise<void> {
   });
 
   if (response.status !== 402) {
-    // The endpoint is either open (no payment needed) or returned a
-    // non-MPP error. Either way, surface the status + body so the user
-    // can act on it.
+    // Not a payment challenge — the endpoint is open (2xx), dead, or
+    // erroring. Surface the status + a TRUNCATED preview, then fail:
+    // exit 0 here would let "estimate before pay" scripts treat mistyped
+    // or dead URLs as verified payable services (S.1002).
     const body = await response.text().catch(() => '');
-    if (isJsonMode()) {
-      printJson({
+    const preview = truncatePreview(body);
+    const open = response.status >= 200 && response.status < 300;
+    const note = open
+      ? `Endpoint responded ${response.status} without a 402 challenge — no payment required.`
+      : `Endpoint responded ${response.status} (not a 402 payment challenge).`;
+    if (!isJsonMode()) {
+      if (open) {
+        printInfo(`No payment required (status ${response.status}).`);
+      } else {
+        printInfo(`Status ${response.status} — not a 402 payment challenge.`);
+      }
+      if (preview) {
+        printBlank();
+        console.log(preview);
+        printBlank();
+      }
+    }
+    throw new EstimateFailure(
+      `${note} --estimate exits 0 only for a payable 402 x402 challenge.`,
+      {
         url,
         method,
         status: response.status,
+        ok: false,
         estimate: null,
-        note:
-          response.status >= 200 && response.status < 300
-            ? 'Endpoint responded without a 402 challenge — no payment required.'
-            : `Endpoint responded with ${response.status} (not a 402 payment challenge).`,
-        body,
-      });
-      return;
-    }
-    if (response.status >= 200 && response.status < 300) {
-      printSuccess(`No payment required (status ${response.status}).`);
-    } else {
-      printInfo(`Status ${response.status} — not a 402 payment challenge.`);
-    }
-    if (body) {
-      printBlank();
-      console.log(body);
-      printBlank();
-    }
-    return;
+        note,
+        ...(preview ? { bodyPreview: preview } : {}),
+      },
+    );
   }
 
   // Read the x402 `accepts[]` envelope from the 402 body — the ONE dialect

--- a/packages/serve/src/route.test.ts
+++ b/packages/serve/src/route.test.ts
@@ -115,6 +115,11 @@ describe('402 challenge (unpaid)', () => {
     expect(header).toContain('Payment realm="seller.example"');
     expect(header).toContain(`recipient="${PAY_TO}"`);
     expect(header).toContain('amount="0.01"'); // decimal — the header dialect's unit
+    // currency is the coin TYPE STRING — the same identity accepts[].asset
+    // carries. Object interpolation shipped "[object Object]" (beta #93).
+    expect(header).not.toContain('[object Object]');
+    const body = (await res.json()) as { accepts: Array<{ asset: string }> };
+    expect(header).toContain(`currency="${body.accepts[0]?.asset}"`);
   });
 
   it('fires the 402 BEFORE body validation — the probe POSTs {} and must see the challenge', async () => {

--- a/packages/serve/src/route.ts
+++ b/packages/serve/src/route.ts
@@ -424,6 +424,9 @@ async function respond402(
     // consumers: mirror the challenge into the MPP WWW-Authenticate shape.
     // The accepts[] body stays the authoritative envelope — the header carries
     // the same recipient/currency and the DECIMAL amount that dialect uses.
+    // currency must be the coin TYPE STRING (the same identity the x402
+    // asset field uses) — `Currency` is { type, decimals }, and object
+    // interpolation shipped currency="[object Object]" (beta #93, S.1002).
     const host = (() => {
       try {
         return new URL(args.resource).hostname;
@@ -431,7 +434,7 @@ async function respond402(
         return undefined;
       }
     })();
-    const wwwAuth = `Payment realm="${host ?? 'x402'}", recipient="${runtime.payTo}", currency="${runtime.currency}", amount="${args.priceUsdc}"`;
+    const wwwAuth = `Payment realm="${host ?? 'x402'}", recipient="${runtime.payTo}", currency="${runtime.currency.type}", amount="${args.priceUsdc}"`;
     return json(
       402,
       {


### PR DESCRIPTION
## Summary
Beta tester Agent ID #93, Sections B–C — the two P0s, nothing else.

**A — `@t2000/serve` emitted `currency="[object Object]"` on WWW-Authenticate.** `respond402` interpolated the `Currency` object (`{ type, decimals }`) into the header template. Now `runtime.currency.type` — the same coin-type identity `accepts[].asset` carries (`createX402Requirements` sets `asset: options.currency.type`). The body envelope (`createX402Requirements({ currency: runtime.currency, … })`) is untouched. Comment documents the string-not-object rule.

**B — `t2 pay --estimate` exited 0 on any non-402 and dumped full HTML.** Founder-locked contract: exit 0 ONLY when the response proves a payable 402 x402 `accepts[]` challenge.
- Non-402 (incl. 2xx "no payment required") now throws → `handleError` → exit 1. Friendly copy retained; the exit code is the script contract.
- Body previews truncated at 512 chars + `… (truncated, N total bytes)` — human and JSON mode both.
- JSON mode emits exactly ONE structured object (`{url, method, status, ok:false, estimate:null, note, bodyPreview}`) via a `toJSON`-carrying error — `handleError` already prefers `toJSON`.
- Stale `runEstimate` doc comment fixed (primary dialect is the x402 body `accepts[]`; header is belt-and-suspenders — S.880). `--estimate` help text states the contract explicitly.
- Header-only 402 / connection failures keep their existing throw paths.

## Tests
- serve `route.test.ts`: header asserts `not.toContain('[object Object]')` + `currency="<accepts[0].asset>"` (same-response identity, no hardcoded type). 45/45 green.
- cli `pay.test.ts` (+5, mocked fetch, no network): 2xx throws; 404 throws with truncated `bodyPreview` in the payload; payable 402 resolves; header-only 402 still throws; `truncatePreview` unit-pinned. 247/247 green.
- Manual AC (built dist): `t2 pay https://example.com/ --estimate` → exit **1**, 512-char preview; `--json` → one object, `ok:false`.
- Docs: `cli-reference.mdx` `--estimate` line now states the exit contract.

Both packages build + typecheck. (Pre-existing unrelated lint warning in `mcp/platforms.test.ts` from S.998 left alone.)

## Release
No publish in this PR — `@t2000/serve` + `@t2000/cli` ship on the next lockstep release (`gh workflow run release.yml --field bump=patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)