### PR TITLE
✨ feat(cli): t2 services scope by 0x / #id + seller #id paint (S.1017)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -51,7 +51,7 @@ t2 swap 100 USDC SUI --quote
 | Command | What it does |
 | --- | --- |
 | `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
-| `t2 services [query]` | Discover Services in the A2A Marketplace — escrow work + ASP x402 endpoints. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | Discover Services in the Agent Marketplace — escrow work + ASP x402 endpoints. Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller (active listings only); free text searches market-wide. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 t2 services "chat"
@@ -142,7 +142,7 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service create` | seller | List (or update — same slug overwrites). Required: `--name` · `--price <usdc>` · `--sla <duration>` · `--description` · `--deliverable`. Optional: `--slug` · `--requirements` (prefer a JSON object of required buyer fields — enforced at hire) · `--review 24h` · `--split 8000` · `--category <cat>` (required once unless set on your profile). |
 | `t2 service list [agent]` | anyone | An agent's services — your own wallet's by default (retired included). |
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
-| `t2 services [query]` | buyer | Search Services across every agent. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | buyer | Search Services across every agent — or scope to one seller with `0x…` / `#id` / `@handle`. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 # seller — one command, listed

--- a/packages/cli/src/commands/service.test.ts
+++ b/packages/cli/src/commands/service.test.ts
@@ -1,0 +1,62 @@
+// [S.1017 — beta #93 round five] `t2 services` principal routing: a 0x /
+// #id / @handle query scopes to `?agent=` (free-text `?q=` never matches
+// hex — the old path answered "No services match 0x…" for a live seller),
+// and every printed row names the principal (#id + address).
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { truncateAddress } from '@t2000/sdk';
+import { resolveServicesQuery, serviceSellerLabel } from './service.js';
+
+const BASE = 'https://api.t2000.ai/v1';
+const ADDR = `0x${'a'.repeat(63)}1`;
+
+describe('resolveServicesQuery (S.1017)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('valid 0x address → ?agent=, never ?q=', async () => {
+    const { url, scope } = await resolveServicesQuery(BASE, ADDR);
+    expect(url).toBe(`${BASE}/services?agent=${encodeURIComponent(ADDR)}`);
+    expect(url).not.toContain('q=');
+    expect(scope).toEqual({ kind: 'agent', agent: ADDR });
+  });
+
+  it('#N resolves via the directory then scopes to that agent', async () => {
+    const fn = vi.fn(async () =>
+      new Response(JSON.stringify({ address: ADDR, numericId: 16, name: 'funkii@audric' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fn);
+    const { url, scope } = await resolveServicesQuery(BASE, '#16');
+    expect(String((fn.mock.calls[0] as unknown[])[0])).toContain('/agents/resolve?q=%2316');
+    expect(url).toBe(`${BASE}/services?agent=${encodeURIComponent(ADDR)}`);
+    expect(scope).toEqual({ kind: 'agent', agent: ADDR, numericId: 16 });
+  });
+
+  it('free text stays a ?q= search; empty = everything', async () => {
+    const search = await resolveServicesQuery(BASE, 'crypto analysis');
+    expect(search.url).toBe(`${BASE}/services?q=crypto%20analysis`);
+    expect(search.scope).toEqual({ kind: 'search', q: 'crypto analysis' });
+    const all = await resolveServicesQuery(BASE, undefined);
+    expect(all.url).toBe(`${BASE}/services`);
+    expect(all.scope).toEqual({ kind: 'all' });
+  });
+
+  it('malformed 0x falls back to text search (honest zero-match, not a crash)', async () => {
+    const { url, scope } = await resolveServicesQuery(BASE, '0xnothex');
+    expect(scope.kind).toBe('search');
+    expect(url).toContain('q=0xnothex');
+  });
+});
+
+describe('serviceSellerLabel (S.1017)', () => {
+  it('paints #numericId so near-identical names read as two principals', () => {
+    expect(serviceSellerLabel({ agentName: 'Funkii AI', agentNumericId: 2, agent: ADDR })).toBe(
+      `Funkii AI #2 ${truncateAddress(ADDR)}`,
+    );
+  });
+
+  it('honest omit when the id is unknown; unnamed fallback', () => {
+    const label = serviceSellerLabel({ agentName: null, agentNumericId: null, agent: ADDR });
+    expect(label).toBe(`unnamed ${truncateAddress(ADDR)}`);
+    expect(label).not.toContain('#');
+  });
+});

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -29,6 +29,7 @@ import {
   ensureSellerCategory,
   parseCategory,
 } from '../lib/agent-category.js';
+import { looksLikeAgentRefValue, resolveAgentRef } from '../lib/agent-ref.js';
 import { fetchJson, type ServiceListing } from '../lib/services.js';
 import { withAgent } from '../lib/with-agent.js';
 import {
@@ -115,6 +116,14 @@ function formatSla(minutes: number): string {
   return `${minutes}m`;
 }
 
+/** The principal line (S.1017): name + #numericId + address. Two sellers
+ *  with near-identical names must never look like one principal — the #id
+ *  and 0x are the marketplace's identity facts, the name is just brand. */
+export function serviceSellerLabel(o: Pick<ServiceListing, 'agentName' | 'agentNumericId' | 'agent'>): string {
+  const id = o.agentNumericId != null ? ` #${o.agentNumericId}` : '';
+  return `${o.agentName ?? 'unnamed'}${id} ${truncateAddress(o.agent)}`;
+}
+
 function printService(o: ServiceListing) {
   const flag = o.retired ? pc.dim(' (retired)') : '';
   printLine(`${pc.bold(o.name)} ${pc.dim(`· ${o.slug}`)}${flag}`);
@@ -123,10 +132,13 @@ function printService(o: ServiceListing) {
     `$${o.priceUsdc.toFixed(2)} USDC ${pc.dim(`· seller receives ${settlementSplit(o.priceUsdc).payout}`)}`,
   );
   printKeyValue('Delivery', `within ${formatSla(o.slaMinutes)}`);
-  printKeyValue(
-    'Seller',
-    `${o.agentName ?? 'unnamed'} ${pc.dim(truncateAddress(o.agent))}`,
-  );
+  {
+    const id = o.agentNumericId != null ? ` #${o.agentNumericId}` : '';
+    printKeyValue(
+      'Seller',
+      `${o.agentName ?? 'unnamed'}${pc.bold(id)} ${pc.dim(truncateAddress(o.agent))}`,
+    );
+  }
   printKeyValue('You get', o.deliverable);
   if (o.requirements != null) {
     printKeyValue(
@@ -351,18 +363,82 @@ Examples:
 // third-party APIs, so there is no second catalog and no `search` /
 // `inspect` subcommand any more. Fulfillment is escrow (`t2 job hire`) or
 // per-call x402 (`t2 pay <url>`) — same listing, two shapes.
+export type ServicesScope =
+  | { kind: 'all' }
+  | { kind: 'search'; q: string }
+  | { kind: 'agent'; agent: string; numericId?: number | null };
+
+/** Route the discovery query onto the API that already answers it (S.1017,
+ *  beta #93): a 0x address or agent ref (#N / @handle) is a PRINCIPAL scope
+ *  and goes to `?agent=` — free-text `?q=` never matches hex, so the old
+ *  path answered "No services match 0x…" for a seller with live listings.
+ *  Anything else stays a text search. Pure except the one resolver hop for
+ *  #N / @handle (the same endpoint the site uses). */
+export async function resolveServicesQuery(
+  base: string,
+  query: string | undefined,
+): Promise<{ url: string; scope: ServicesScope }> {
+  const q = query?.trim();
+  if (!q) {
+    return { url: `${base}/services`, scope: { kind: 'all' } };
+  }
+  if (q.startsWith('0x')) {
+    // One address check for the whole CLI — validateAddress; invalid hex
+    // falls through to text search (where it will honestly match nothing).
+    try {
+      const agent = validateAddress(q);
+      return {
+        url: `${base}/services?agent=${encodeURIComponent(agent)}`,
+        scope: { kind: 'agent', agent },
+      };
+    } catch {
+      // not a valid address — treat as text below
+    }
+  } else if (looksLikeAgentRefValue(q)) {
+    const ref = await resolveAgentRef(base, q);
+    return {
+      url: `${base}/services?agent=${encodeURIComponent(ref.address)}`,
+      scope: { kind: 'agent', agent: ref.address, numericId: ref.numericId },
+    };
+  }
+  return {
+    url: `${base}/services?q=${encodeURIComponent(q)}`,
+    scope: { kind: 'search', q },
+  };
+}
+
+function scopeLabel(scope: ServicesScope): string {
+  if (scope.kind !== 'agent') {
+    return '';
+  }
+  return scope.numericId != null
+    ? `#${scope.numericId} (${truncateAddress(scope.agent)})`
+    : truncateAddress(scope.agent);
+}
+
 function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
   command
-    .argument('[query]', 'What you need — free-text search (empty = everything)')
+    .argument('[query]', 'What you need — free text, or a SELLER scope: 0x… address, #id, or @handle (empty = everything)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(async (query: string | undefined, cmdOpts: { api?: string }) => {
       try {
         const base = cmdOpts.api ?? DEFAULT_API_BASE;
-        const params = query ? `?q=${encodeURIComponent(query)}` : '';
-        const json = await fetchJson(`${base}/services${params}`);
-        const rows = (json.services ?? []) as ServiceListing[];
+        const { url, scope } = await resolveServicesQuery(base, query);
+        const json = await fetchJson(url);
+        const all = (json.services ?? []) as ServiceListing[];
+        // Buyer discovery is the ACTIVE board: `?agent=` serves the seller's
+        // management view retired-included — hide retired here with an
+        // honest note (`t2 service list` keeps the full management dump).
+        const rows = scope.kind === 'agent' ? all.filter((o) => !o.retired) : all;
+        const retiredHidden = all.length - rows.length;
         if (isJsonMode()) {
-          printJson({ query: query ?? null, total: json.total ?? rows.length, services: rows });
+          printJson({
+            query: query ?? null,
+            scope,
+            total: scope.kind === 'agent' ? rows.length : (json.total ?? rows.length),
+            ...(retiredHidden > 0 ? { retiredHidden } : {}),
+            services: rows,
+          });
           return;
         }
         printBlank();
@@ -371,13 +447,32 @@ function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
           printBlank();
         }
         if (rows.length === 0) {
-          printInfo(query ? `No services match "${query}".` : 'No services listed yet.');
+          printInfo(
+            scope.kind === 'agent'
+              ? `No active services for ${scopeLabel(scope)}.`
+              : scope.kind === 'search'
+                ? `No services match "${scope.q}".`
+                : 'No services listed yet.',
+          );
           printBlank();
           return;
         }
         for (const o of rows) {
           printService(o);
           printBlank();
+        }
+        if (retiredHidden > 0) {
+          printInfo(pc.dim(`${retiredHidden} retired omitted — t2 service list ${scope.kind === 'agent' ? scope.agent : ''}`));
+          printBlank();
+        }
+        // Name collisions (S.1017): a text search spanning sellers must say
+        // so — two near-identical names are two principals.
+        if (scope.kind === 'search') {
+          const sellers = new Set(rows.map((o) => o.agent)).size;
+          if (sellers >= 2) {
+            printInfo(pc.dim(`Results span ${sellers} sellers — scope to one with t2 services 0x… or #id.`));
+            printBlank();
+          }
         }
       } catch (error) {
         handleError(error);


### PR DESCRIPTION
## Summary
Beta #93 round five Medium: `t2 services 0x<seller>` went through free-text `?q=` and returned nothing for a seller with live listings; a name search interleaved two near-identical agents with no way to tell the principals apart. Marketplace defence is "check the address" — the tool now accepts one.

**Routing (`resolveServicesQuery`, exported + pinned):** valid `0x…` → `?agent=<normalized>` directly (no directory dependency, `validateAddress` is the one address check); `#N` / `@handle` → `resolveAgentRef` (the same endpoint the site uses) → `?agent=`; malformed 0x falls back to text (honest zero-match, not a crash); free text / empty unchanged on `?q=` / unfiltered.

**Active board vs management:** `?agent=` serves the seller's retired-included management view — the `t2 services` path filters `!retired` client-side and prints the dim honesty note (`N retired omitted — t2 service list 0x…`). `t2 service list` untouched.

**Principal clarity:** every Seller line paints `#numericId` when known (`funkii@audric #16 0x7f20…f6dc`) — pure `serviceSellerLabel` exported + pinned, honest omit when the id is null. Scoped empty says `No active services for #N (0x…)`, never "No services match <hex>". Text searches spanning ≥2 sellers get a dim footer suggesting the scope. JSON adds `scope: {kind, agent?, numericId?, q?}` + `retiredHidden` so agents don't guess which path ran.

Help + `cli-reference.mdx` document the seller-scope forms. No `servicesSearchCondition` change, no publish (founder patches after 1016+1017).

## Tests / verification
+6 unit (routing matrix incl. resolver-hop URL + malformed-0x fallback; label with/without id against the real `truncateAddress`). Suite 280/280, build green. Live smoke (mainnet): `t2 services 0x7f2059…` returns #16's 2 active services with `#16` on each Seller line + "2 retired omitted" note; `t2 services "#16" --json` shows `scope {kind: agent, numericId: 16}, total 2, retiredHidden 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)