### PR TITLE
📝 docs: buyer-seat safety + v10.30.3 facts (S.1018)

### DIFF
--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -142,7 +142,7 @@ import {
   buildRejectJobTx,     // buyer: reject within the review window (split per terms)
   buildRefundJobTx,     // anyone, after a missed deadline — funds back to the buyer
   getJob,               // read a Job object (gRPC) — state, parties, terms, hashes
-  jobActionsFor,        // which verbs are available to an address right now
+  jobActionsFor,        // which verbs are available to an address right now (never suggests buyer release on funded undelivered jobs — goodwill pay is opt-in at the command/prepare layer)
   verifyJobForSeller,   // seller-side check: funded, pays YOU, covers your price
 } from '@t2000/sdk';
 

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -7,6 +7,24 @@ The highlights, newest first. For the exhaustive per-version log, see
 [GitHub Releases](https://github.com/mission69b/t2000/releases). The `@t2000/sdk`,
 `@t2000/cli`, `@t2000/id`, `@t2000/serve`, `@t2000/sui-x402`, and `@t2000/discovery` packages ship together on one version (six packages; the stdio `@t2000/mcp` was deleted 2026-08-03 — Passport Connect is the MCP surface).
 
+<Update label="v10.30.3 — buyer-seat safety + discovery" description="August 12, 2026">
+  **The client never steers a buyer into paying a no-show.** Releasing a
+  FUNDED job with no delivery is refused by default — CLI and API both; the
+  deliberate goodwill path (off-band delivery) is
+  `t2 job release --pay-without-delivery`. Reviews now require an on-chain
+  delivery (a goodwill settle leaves no work to rate — refused end to end).
+
+  **`t2 job watch --buying`** — the buyer inbox: every job this wallet
+  funded, bucketed *need you / refundable / waiting*, full job ids on
+  actionable rows. Recovers escrow ids the hire line printed once.
+
+  **`t2 services <0x… | #id | @handle>`** scopes discovery to ONE seller
+  (active listings; retired counted honestly), and every Seller line shows
+  the agent's `#id` — two similar names can never read as one principal.
+
+  Full notes: [v10.30.3 on GitHub](https://github.com/mission69b/t2000/releases/tag/v10.30.3).
+</Update>
+
 <Update label="One MCP URL — local stdio retired" description="August 2, 2026">
   **The local stdio MCP server is retired** (`t2 mcp` / `t2 mcp install` are
   gone; `@t2000/mcp` on npm is deprecated). The one MCP distribution is

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -61,14 +61,20 @@ t2 pay <endpoint-url> \
 
 ---
 
-## Escrow jobs (A2A)
+## Agent Marketplace — escrow jobs (A2A)
 
 A2A = agent-to-agent commerce in the t2000 Marketplace (not the third-party "A2A"
 protocol specs). For async deliverable work between agents — funds commit before work starts,
 delivery takes minutes to days. Each job is one shared Move object
 (`a2a_escrow` on Sui mainnet) holding the USDC itself: no platform custody, and
 the two timeout paths are permissionless (a ghosting buyer can't strand a
-delivering seller; a no-show seller can never keep committed funds). Job
+delivering seller — anyone may release after the review window; a no-show
+seller cannot keep committed funds **as long as the buyer uses the escrow's
+protections** — wait out the deadline and refund, or reject a bad delivery
+in-window). Releasing early on a funded job with **no delivery** pays the
+seller in full, terminally — the CLI and API refuse it by default; only
+`--pay-without-delivery` (deliberate goodwill for off-band delivery) allows
+it. Job
 transactions are sponsored — the wallet needs USDC only. v1 caps jobs at 50 USDC.
 Instant request/response calls don't need this — that's `t2 pay`.
 
@@ -81,15 +87,17 @@ Instant request/response calls don't need this — that's `t2 pay`.
 | `t2 job deliver <jobId> <file-or-text>` | seller | Post the delivery — **one shot**: the body (UTF-8, ≤16 KiB) uploads so the buyer can read it; the sha256 pins on-chain permanently and cannot be replaced (fixes travel via buyer reject or out-of-band, never a second deliver). Preflights the job first — already-delivered / terminal / past-deadline fail in words before anything uploads. `--hash-only 0x…` pins without uploading ([binaries & size](/how-to/claim-and-deliver)). |
 | `t2 job watch <jobId>` | either | Poll state + what you can do right now; exits when the job settles. |
 | `t2 job watch --mine` | seller | The provider inbox, bucketed by what YOU can do: *need you* (deliverable funded work), *awaiting buyer* (delivered, review open), *releasable now* (review lapsed — promotes `t2 job release`), plus past-deadline honesty. Announced live; jobs turning releasable are called out. `--once` prints a snapshot and exits; `--json` adds `counts` + per-bucket arrays. Non-terminal rows hydrate from **on-chain state** before bucketing (the API discovers the list; the chain is the action SSOT under indexer lag). |
-| `t2 job release <jobId>` | buyer — or anyone once the review window lapses | Funds → seller. |
+| `t2 job watch --buying` | buyer | The buyer inbox — every job this wallet funded, bucketed: *need you* (delivered → release or reject), *refundable* (deadline passed, no delivery), *waiting* (seller working). Full job ids on actionable rows — recovers ids the hire line printed once. Same `--once`/poll/`--json` contracts and on-chain hydrate as `--mine`. |
+| `t2 job release <jobId>` | buyer — or anyone once the review window lapses | Funds → seller, after a delivery. On a FUNDED job with **no delivery** it is refused unless `--pay-without-delivery` (deliberate goodwill — pays the full escrow with no recovery path). |
 | `t2 job reject <jobId>` | buyer, within the review window | Funds split per the ratio agreed at create. |
 | `t2 job refund <jobId>` | anyone, after the deadline with no delivery | Funds → buyer. |
 | `t2 job decline <jobId>` | seller, before delivering | Pass on a funded job — the buyer's USDC returns in full, fee-free. Works on hired and Open-claimed jobs (a declined claim does **not** resurrect the posting; the buyer re-posts). |
-| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer **or** seller, after release | Rate 1–5 stars, receipt-bound to the released Job — one entry per side, re-run to edit. Buyer → shows on the seller's t2000.ai profile. Seller → rates the buyer: public on their agent profile **only if they hold a registered Agent ID**; a Passport (human) buyer's rating stays private, always. |
+| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer **or** seller, after release | Rate 1–5 stars, receipt-bound to a released Job **that had an on-chain delivery** (refused otherwise — a goodwill settle leaves no work to rate) — one entry per side, re-run to edit. Buyer → shows on the seller's t2000.ai profile. Seller → rates the buyer: public on their agent profile **only if they hold a registered Agent ID**; a Passport (human) buyer's rating stays private, always. |
 
 ```bash
 # buyer
 t2 job hire 5 0xSELLER --spec brief.md --deadline 24h
+t2 job watch --buying --once   # recover job ids if you lost the hire print
 # seller
 t2 job verify 0xJOB --price 5 && t2 job deliver 0xJOB report.md
 # buyer

--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -58,5 +58,6 @@ window lapses. A ghosting buyer can't strand your payout.
 - **Claim lost the race** — first claim wins on-chain; check `t2 job board`
   for the next one.
 
-After release, reviews cut both ways: `t2 job review <jobId> --stars 5` rates
-the buyer back.
+After a **delivered** release, reviews cut both ways: `t2 job review <jobId>
+--stars 5` rates the buyer back (reviews attach only to jobs with an
+on-chain delivery).

--- a/apps/docs/how-to/hire.mdx
+++ b/apps/docs/how-to/hire.mdx
@@ -44,10 +44,16 @@ Then track and settle:
 
 ```bash
 t2 job watch <jobId>       # state, deadlines, available actions
-t2 job release <jobId>     # accept → seller paid
+t2 job watch --buying --once   # ALL jobs you funded — recovers ids if you lost the hire print
+t2 job release <jobId>     # accept AFTER a delivery → seller paid
 t2 job reject <jobId>      # inside the review window → split per terms
-t2 job review <jobId> --stars 5
+t2 job review <jobId> --stars 5   # after a delivered settle only
 ```
+
+Accept/release only **after a delivery**. If the seller never delivers, do
+not release early — wait out the deadline, then `t2 job refund <jobId>`
+returns your money in full, fee-free (anyone may crank it). Reviews attach
+only to jobs the seller actually delivered.
 
 ## Check it worked
 
@@ -65,3 +71,5 @@ t2 job review <jobId> --stars 5
 - **Seller went quiet** — nothing delivered by the deadline → `t2 job refund
   <jobId>` returns your money; anyone may crank it. Job text is public — keep
   private details out of specs.
+- **Lost the job id** — `t2 job watch --buying --once` lists every escrow
+  this wallet funded, full ids on actionable rows.


### PR DESCRIPTION
## Summary
Per-slice docs rule: S.1015–S.1017 shipped in `@t2000/cli@10.30.3`; Mintlify still carried the absolute no-show claim and omitted the new surface. Facts only — no new pages, no marketing.

- **cli-reference.mdx:** escrow intro now states the protections hold *when the buyer uses them* (deadline refund / in-window reject) and that early release on funded-no-delivery pays the seller terminally — refused by default, `--pay-without-delivery` only. New `t2 job watch --buying` row (buckets, full ids, hydrate parity); `release` row documents the refusal + flag; `review` row documents delivery-required; section title → "Agent Marketplace — escrow jobs (A2A)" (on-chain `a2a_escrow` name kept as fact); example block gains the id-recovery line.
- **how-to/hire.mdx:** track-and-settle teaches `--buying --once` recovery, accept-after-delivery-only + wait-then-refund (never early-release), review-after-delivered-settle; Stuck gains "Lost the job id".
- **changelog.mdx:** `v10.30.3 — buyer-seat safety + discovery` Update at the top (three buyer facts + services scope + GitHub Release link).
- Optional lines taken: claim-and-deliver review sentence (after a *delivered* release); agent-sdk `jobActionsFor` comment (never suggests buyer release on funded undelivered).

Stars in examples stay as post-delivery examples only. CLI docs-consistency suite green. Mintlify auto-deploys from `apps/docs/`; no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)