### PR TITLE
✨ feat(contracts): create_open requires reject_split 10000 (S.1019)

### DIFF
--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -56,7 +56,9 @@ use sui::event;
 /// v2 (S.981): on-chain job amount bounds. The bump is what makes the floor
 /// real — without the cutover, builders still calling the old package's
 /// `create` (amount > 0 only) would bypass it.
-const VERSION: u64 = 2;
+// v3 (S.1019): open-board reject must be 100% buyer (create_open asserts
+// reject_split_bps == BPS_DENOMINATOR); v2 (S.981) added job amount bounds.
+const VERSION: u64 = 3;
 
 // === States ===
 const STATE_FUNDED: u8 = 0;

--- a/contracts/a2a_escrow/sources/opening.move
+++ b/contracts/a2a_escrow/sources/opening.move
@@ -62,6 +62,10 @@ const EClaimerIsBuyer: u64 = 8;
 const ENotActiveAgent: u64 = 9;
 const ENotBuyer: u64 = 10;
 const ENotExpired: u64 = 11;
+/// v3 (S.1019): open-board reject must return 100% to the buyer — an
+/// 80/20 default made garbage-deliver-then-eat-reject (+EV) beat an
+/// honest decline ($0) on FCFS work.
+const EOpenRejectMustBeFullBuyer: u64 = 12;
 
 // === Objects ===
 
@@ -164,6 +168,14 @@ public fun create_open<T>(
         EReviewWindowTooLong,
     );
     assert!(reject_split_bps <= escrow::bps_denominator_pkg(), EBadSplit);
+    // v3 (S.1019): OPEN postings lock 10000 — reject pays the buyer in
+    // full, seller 0 (economically = decline, so junk delivery has no
+    // edge over honesty). Hire/`escrow::create` keeps the free 0–10000
+    // range; existing on-chain openings are grandfathered.
+    assert!(
+        reject_split_bps == escrow::bps_denominator_pkg(),
+        EOpenRejectMustBeFullBuyer,
+    );
     let opening = Opening<T> {
         id: object::new(ctx),
         buyer: ctx.sender(),

--- a/contracts/a2a_escrow/tests/opening_tests.move
+++ b/contracts/a2a_escrow/tests/opening_tests.move
@@ -19,7 +19,9 @@ const AMOUNT: u64 = 1_000_000; // 1 USDC-equivalent (6dp)
 const OPEN_UNTIL: u64 = 500_000; // ms
 const SLA_MS: u64 = 400_000; // ms
 const REVIEW_WINDOW: u64 = 100_000; // ms
-const SPLIT_BPS: u64 = 8_000;
+// v3 (S.1019): create_open accepts ONLY 10_000 — reject pays the buyer
+// in full on open work. 8_000 aborts (pinned below).
+const SPLIT_BPS: u64 = 10_000;
 const POLICY_ANY: u8 = 0;
 
 // 2.5% (test-init FeeConfig default) of AMOUNT.
@@ -406,6 +408,50 @@ fun claimed_opening_job_can_be_declined() {
         let mut job = ts::take_shared<Job<SUI>>(&sc);
         escrow::decline(&mut job, &cfg, &clk, ts::ctx(&mut sc));
         assert!(escrow::state(&job) == escrow::state_refunded(), 0);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    assert_received(&mut sc, BUYER, AMOUNT);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+
+// === v3 (S.1019): open reject must be 100% buyer ===
+
+#[test]
+#[expected_failure(abort_code = opening::EOpenRejectMustBeFullBuyer)]
+fun create_open_partial_split_aborts() {
+    let (mut sc, clk) = setup();
+    // The old 80/20 default is exactly what made junk delivery +EV — a
+    // partial split can no longer be posted on the open board.
+    post_open_with(&mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, 8_000, POLICY_ANY);
+    abort 0
+}
+
+#[test]
+fun open_claim_deliver_reject_pays_buyer_full() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, ASP, &clk);
+    // ASP delivers junk; buyer rejects in-window → at 10_000 bps the buyer
+    // takes the FULL escrow back, seller share 0, protocol fee 0 (the fee
+    // comes only from the seller-bound payout).
+    ts::next_tx(&mut sc, ASP);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared<Job<SUI>>(&sc);
+        escrow::deliver(&mut job, b"junk".to_string().into_bytes(), &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared<Job<SUI>>(&sc);
+        escrow::reject(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(escrow::state(&job) == escrow::state_rejected(), 0);
         ts::return_shared(job);
         ts::return_shared(cfg);
     };


### PR DESCRIPTION
## Summary
QA #16 finding #1: on open FCFS jobs the default 80/20 reject split made garbage-deliver-then-eat-reject (+~20%) strictly beat an honest decline ($0) — rational ASPs deliver junk. **Phase 1 of 2** (Move only; the mainnet upgrade + migrate + client sweep land next as the S.981-style ritual).

- `opening.move::create_open`: after the existing `<= BPS_DENOMINATOR` bound, assert `reject_split_bps == escrow::bps_denominator_pkg()` (new `EOpenRejectMustBeFullBuyer = 12`) — open postings lock 100% buyer / 0% seller on reject, making reject economically equal to decline so junk has no edge. Hire/`escrow::create` keeps the free 0–10000 range; existing on-chain openings are grandfathered (no migration).
- `escrow.move`: `VERSION 2 → 3` with the v3 comment — the bump is what makes the assert real; without the FeeConfig cutover, callers still hit the previous package's `create_open(8000)`.
- Tests: fixture `SPLIT_BPS` → 10_000 (the only accepted open split); new pins — `create_open(8_000)` aborts `EOpenRejectMustBeFullBuyer`; full open→claim→deliver→reject at 10_000 pays the buyer the FULL escrow (seller 0, protocol fee 0 — fee only ever comes from the seller-bound payout); existing `>10_000 → EBadSplit` + migrate tests hold. **65/65 green.**

No struct layout changes, no signature changes — compatible upgrade like S.981. Agent ID package untouched (opening only reads Registry).

## Phase 2 (after merge, same session)
`sui client upgrade` → immediately `escrow::migrate` (AdminCap) → pin ONLY `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` + Published.toml (V2/V3 event-filter anchors untouched) → SDK preflight, prepare force-10000, CLI default, Connect copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)