### PR TITLE
✨ feat(sdk,cli): open reject 100/0 — v5 package pin + preflight (S.1019)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -116,7 +116,9 @@ a funded Job on the spot and work starts immediately; then it's `t2 job`
 from there. No claim by the open window → the escrow refunds in full,
 fee-free (cancel any time before a claim, or anyone may crank the refund
 after expiry). Titles and job text are public: every ASP on the board reads
-exactly what you write.
+exactly what you write. Rejecting a bad open-board delivery returns **100%**
+to the buyer (contract-locked on new openings) — hires from listings keep the
+listing's own split.
 
 | Command | Who | What it does |
 | --- | --- | --- |

--- a/contracts/a2a_escrow/Published.toml
+++ b/contracts/a2a_escrow/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0x83f02c59575b7daa4576eeccc22542f8a5679520e4edd02feeeee2daae16b819"
+published-at = "0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7"
 original-id = "0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd"
-version = 4
+version = 5
 toolchain-version = "1.76.0"
 build-config = { flavor = "sui", edition = "2024" }
 upgrade-capability = "0x404975a0e2061b47704ffc71241b9f5c6068cb4a474d78015f84a50737be9b46"

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -98,7 +98,7 @@ function resolveCreated(
 export function registerOpenVerbs(group: Command) {
   group
     .command('open')
-    .description('Open — post the job to the public board with no ASP picked (buyer); ESCROWS the budget on-chain now, first claim starts work')
+    .description('Open — post the job to the public board with no ASP picked (buyer); ESCROWS the budget on-chain now, first claim starts work. Reject on open work returns 100% to you (contract-locked) — junk delivery earns the seller nothing.')
     .requiredOption('--title <text>', "The job's public name (up to 80 chars)")
     .requiredOption('--brief <file-or-text>', 'What you want delivered — PUBLIC, every ASP on the board reads it')
     .requiredOption('--max <usdc>', `Budget escrowed AT POST (max ${MAX_JOB_USDC})`)

--- a/packages/sdk/src/wallet/opening.test.ts
+++ b/packages/sdk/src/wallet/opening.test.ts
@@ -9,7 +9,7 @@ function terms(overrides: Partial<OpeningTerms> = {}): OpeningTerms {
     openUntilMs: Date.now() + 3_600_000,
     slaMs: 86_400_000,
     reviewWindowMs: 600_000,
-    rejectSplitBps: 8000,
+    rejectSplitBps: 10_000,
     ...overrides,
   };
 }
@@ -31,5 +31,18 @@ describe('preflightCreateOpening amount bounds (S.981)', () => {
 
   it('rejects a budget over the cap', () => {
     expect(preflightCreateOpening(terms({ amountUsdc: MAX_JOB_USDC + 1 })).valid).toBe(false);
+  });
+});
+
+
+describe('preflightCreateOpening reject split (S.1019 v5)', () => {
+  it('refuses anything but 10000 — open reject is 100% buyer', () => {
+    const pf = preflightCreateOpening(terms({ rejectSplitBps: 8000 }));
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/100% buyer.*10000/s);
+  });
+
+  it('10000 passes', () => {
+    expect(preflightCreateOpening(terms({ rejectSplitBps: 10_000 })).valid).toBe(true);
   });
 });

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -25,8 +25,10 @@ import {
  * unchanged.
  */
 
-/** The LATEST published `a2a_escrow` package id on MAINNET (v3 upgrade
- *  2026-07-28 — added `escrow::decline`; v2 added the `opening` module).
+/** The LATEST published `a2a_escrow` package id on MAINNET (v5 upgrade
+ *  2026-08-12, S.1019 — create_open requires reject_split 10000; v4 added
+ *  amount bounds (S.981); v3 added `escrow::decline`; v2 the `opening`
+ *  module).
  *  A literal, never an env read, so it can serve as a signature-time trust
  *  anchor (S.930). Must match the Move upgrade publish notes.
  *
@@ -36,7 +38,7 @@ import {
  *  (`MAINNET_A2A_ESCROW_PACKAGE_ID` in job.ts) remains the anchor for type
  *  strings, event filters, and object-type queries — those never move. */
 export const MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID =
-  '0x83f02c59575b7daa4576eeccc22542f8a5679520e4edd02feeeee2daae16b819';
+  '0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7';
 
 /** Back-compat name for the latest id (pre-S.981 consumers import this). */
 export const MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID =
@@ -107,8 +109,14 @@ export interface OpeningTerms {
   /** Delivery window the claiming ASP gets: deliver_by = claim + sla. */
   slaMs: number;
   reviewWindowMs: number;
+  /** v5 (S.1019): MUST be 10000 — open-board reject pays the buyer in
+   *  full (contract-asserted; a partial split made junk delivery +EV over
+   *  an honest decline). Hire/`escrow::create` keeps the 0–10000 range. */
   rejectSplitBps: number;
 }
+
+/** The only reject split `create_open` accepts since v5 (S.1019). */
+export const OPEN_REJECT_SPLIT_BPS = 10_000;
 
 /** Client-side preflight — mirrors the contract's `create_open` bounds plus
  *  the $50 client cap (the contract is value-neutral, same as Job). */
@@ -146,6 +154,15 @@ export function preflightCreateOpening(terms: OpeningTerms): {
   }
   if (terms.slaMs <= 0) {
     return { valid: false, code: 'INVALID_INPUT', error: 'Delivery window must be positive.' };
+  }
+  if (terms.rejectSplitBps !== OPEN_REJECT_SPLIT_BPS) {
+    return {
+      valid: false,
+      code: 'INVALID_INPUT',
+      error:
+        'Open postings lock reject at 100% buyer / 0% seller (rejectSplitBps must be 10000, ' +
+        'contract-enforced since v5) — reject is economically a decline, so junk delivery has no edge.',
+    };
   }
   return { valid: true };
 }


### PR DESCRIPTION
## Summary
S.1019 **Phase 2** (t2000 half). Mainnet upgrade is DONE: package **v5** `0xc84fc8a6…2c56a7` (digest `6kZrPyEybRmsAnK8qQVyu9nJtuXyzyq4Y51YDfwancsx`), **`escrow::migrate` cut FeeConfig to VERSION 3** (digest `J2jjYiYm3E8QgfzF1SSu3JSD3MtjXUVqhaNe55s5Cj6m` — verified on-chain: `version: 3`). Old package entrypoints now abort `EWrongVersion`; companion audric PR restores the sponsored rail on the new id.

- **Pin:** `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` → v5 (ONLY value changed — the original + V2/V3 event-filter anchors untouched per the went-dark-once lesson); `Published.toml` committed (version 5). tx-guard families flow through the LATEST alias.
- **SDK preflight:** new `OPEN_REJECT_SPLIT_BPS = 10_000`; `preflightCreateOpening` refuses any other split in English before signing/sponsoring (mirrors the new `create_open` assert). `OpeningTerms.rejectSplitBps` documents the v5 lock. Hire/`escrow::create` untouched (0–10000 stays).
- **CLI:** `t2 job open` description states reject returns 100% to the buyer (contract-locked). `cli-reference.mdx` open section gains the factual line (hires keep the listing's split).
- Tests: opening fixture → 10_000; +2 preflight pins (8000 refused with the 100%-buyer message; 10000 passes). SDK 569/569 · CLI 280/280 · builds green.

Companion audric PR: prepare `open-create` forces 10000, Connect open copy, SDK bump to the patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)