### PR TITLE
🐛 fix(cli): deliver/hire spec put→verify durability gate (S.1020a)

### DIFF
--- a/packages/cli/src/commands/job.test.ts
+++ b/packages/cli/src/commands/job.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -36,10 +37,19 @@ describe('resolveSpecUpload (SPEC_ACP_JOB_SPEC_V1 §4.2 — upload by default)',
   const BASE = 'https://api.example.test/v1';
   const HASH64 = `0x${'a'.repeat(64)}`;
 
-  function mockPutSpec(hash = 'b'.repeat(64)) {
-    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ hash }) }));
+  function mockPutSpec() {
+    let stored = '';
+    let hash = '';
+    const fn = vi.fn(async (_url: unknown, init?: { body?: string }) => {
+      if (init?.body) {
+        stored = (JSON.parse(init.body) as { content: string }).content;
+        hash = createHash('sha256').update(stored, 'utf8').digest('hex');
+        return { ok: true, status: 200, json: async () => ({ hash }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ content: stored }) };
+    });
     vi.stubGlobal('fetch', fn);
-    return { fn, hash };
+    return { fn, hashOf: () => hash };
   }
   afterEach(() => vi.unstubAllGlobals());
 
@@ -50,20 +60,32 @@ describe('resolveSpecUpload (SPEC_ACP_JOB_SPEC_V1 §4.2 — upload by default)',
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('uploads file contents and pins the store hash', async () => {
-    const { fn, hash } = mockPutSpec();
+  it('uploads file contents, pins the store hash, and READ-BACK verifies (S.1020a)', async () => {
+    const { fn, hashOf } = mockPutSpec();
     const dir = await mkdtemp(join(tmpdir(), 't2-job-'));
     const file = join(dir, 'delivery.md');
     await writeFile(file, '# The report\n\nDone.');
     const result = await resolveSpecUpload(BASE, file);
-    expect(result).toEqual({ hash: `0x${hash}`, uploaded: true });
-    expect(fn).toHaveBeenCalledOnce();
+    expect(result).toEqual({ hash: `0x${hashOf()}`, uploaded: true });
+    expect(fn).toHaveBeenCalledTimes(2); // put + durability GET
+  });
+
+  it('S.1020a: a put the store cannot serve back pins NOTHING', async () => {
+    const fn = vi.fn(async (_url: unknown, init?: { body?: string }) =>
+      init?.body
+        ? { ok: true, status: 200, json: async () => ({ hash: 'b'.repeat(64) }) }
+        : { ok: false, status: 404, json: async () => ({ error: { message: 'No spec stored for this hash.' } }) },
+    );
+    vi.stubGlobal('fetch', fn);
+    await expect(resolveSpecUpload(BASE, 'inline delivery text')).rejects.toThrow(
+      /could not serve it back.*nothing was pinned/is,
+    );
   });
 
   it('uploads literal text when the arg is not a file', async () => {
-    const { hash } = mockPutSpec();
+    const { hashOf } = mockPutSpec();
     const result = await resolveSpecUpload(BASE, 'inline delivery text');
-    expect(result).toEqual({ hash: `0x${hash}`, uploaded: true });
+    expect(result).toEqual({ hash: `0x${hashOf()}`, uploaded: true });
   });
 
   it('rejects oversize content BEFORE any network call (16 KiB cap)', async () => {
@@ -134,10 +156,19 @@ describe('resolveHireSpecUpload (S.978 — CLI writes the t2-acp-custom@1 envelo
   const BASE = 'https://api.example.test/v1';
   const HASH64 = `0x${'a'.repeat(64)}`;
 
-  function mockPutSpec(hash = 'b'.repeat(64)) {
-    const fn = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ hash }) }));
+  function mockPutSpec() {
+    let stored = '';
+    let hash = '';
+    const fn = vi.fn(async (_url: unknown, init?: { body?: string }) => {
+      if (init?.body) {
+        stored = (JSON.parse(init.body) as { content: string }).content;
+        hash = createHash('sha256').update(stored, 'utf8').digest('hex');
+        return { ok: true, status: 200, json: async () => ({ hash }) };
+      }
+      return { ok: true, status: 200, json: async () => ({ content: stored }) };
+    });
     vi.stubGlobal('fetch', fn);
-    return { fn, hash };
+    return { fn, hashOf: () => hash };
   }
   afterEach(() => vi.unstubAllGlobals());
 

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -134,6 +134,31 @@ export async function loadSpecText(
   return { kind: 'text', text };
 }
 
+/** Put→GET→byte-equal durability gate (S.1020a — parity with Connect
+ *  S.991): a put is NOT durable until the same public read path serves the
+ *  same bytes. ~16%% of dogfood delivers had the hash pinned on-chain while
+ *  the body never loaded for the buyer. On any miss NOTHING reaches a chain
+ *  verb — the store can be retried; an on-chain pin cannot. */
+async function putAndVerifySpec(base: string, content: string): Promise<string> {
+  const hash = await putJobSpec(base, content);
+  let roundTrip: string;
+  try {
+    roundTrip = await getJobSpec(base, hash);
+  } catch (e) {
+    throw new Error(
+      `The content store accepted the upload but could not serve it back (${
+        e instanceof Error ? e.message : 'read failed'
+      }) — nothing was pinned on-chain. Retry in a moment.`,
+    );
+  }
+  if (roundTrip !== content) {
+    throw new Error(
+      'The content store returned different bytes than were uploaded — nothing was pinned on-chain. Retry in a moment.',
+    );
+  }
+  return hash;
+}
+
 export async function resolveSpecUpload(
   base: string,
   input: string,
@@ -142,7 +167,7 @@ export async function resolveSpecUpload(
   if (loaded.kind === 'hash') {
     return { hash: loaded.hash, uploaded: false };
   }
-  return { hash: `0x${await putJobSpec(base, loaded.text)}`, uploaded: true };
+  return { hash: `0x${await putAndVerifySpec(base, loaded.text)}`, uploaded: true };
 }
 
 /** Direct-hire spec upload (S.978): text briefs wrap in the SDK's
@@ -168,7 +193,7 @@ export async function resolveHireSpecUpload(
         'shorten the brief, or link the long artifact (URL / IPFS).',
     );
   }
-  return { hash: `0x${await putJobSpec(base, body)}`, uploaded: true };
+  return { hash: `0x${await putAndVerifySpec(base, body)}`, uploaded: true };
 }
 
 function stateColor(state: Job['state']): string {
@@ -673,7 +698,7 @@ no fund step; unclaimed openings refund fee-free):
               buyer,
               createdAtMs: Date.now(),
             });
-            specHash = `0x${await putJobSpec(base, spec)}`;
+            specHash = `0x${await putAndVerifySpec(base, spec)}`;
 
             amountUsdc = service.priceUsdc;
             seller = service.agent;


### PR DESCRIPTION
## Summary
QA #16 #2 (t2000 half — parity with Connect's S.991 gate; companion audric PR #301 lands the Connect/send/cancel/rank/settle tracks): the CLI pinned spec/delivery hashes on-chain on the strength of the PUT response alone — ~16% of dogfood delivers had the hash on-chain while the body never loaded for the buyer, who then graded blind.

New `putAndVerifySpec` (put → GET through the same public read path → byte-equal, `getJobSpec`'s sha256 verification riding along): on any miss **nothing reaches a chain verb** — the store can be retried, an on-chain pin cannot. Wired into all three CLI upload sites: `resolveSpecUpload` (deliver), `resolveHireSpecUpload` (custom hire envelope), and the listing-hire spec compose. Bare `0x…` confidential hashes pass through untouched.

Tests: upload mocks upgraded to a durable-store fake (PUT stores + returns the REAL sha256, GET serves the bytes — the verifying reader is exercised, not bypassed); new pin: a put the store can't serve back throws `nothing was pinned` with no chain call. job.test.ts 43/43, full CLI suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)