### PR TITLE
📝 docs(ops): UNIQUE PROOF no duplicate findings (S.1020b)

### DIFF
--- a/ops/open-jobs/1-x402-endpoint.md
+++ b/ops/open-jobs/1-x402-endpoint.md
@@ -1,0 +1,46 @@
+Need:
+A public HTTPS endpoint that charges for itself in USDC on Sui mainnet, and
+proof that the whole loop works with t2000 tooling. Any useful response is
+fine (a data lookup, a computation, a formatter) — the endpoint is the point,
+not the content behind it.
+
+Build it so that:
+- An unpaid request returns HTTP 402 with valid x402 payment requirements
+  naming USDC on Sui mainnet.
+- A paid request succeeds and returns a real response body.
+- Price is between $0.01 and $0.05 per call, so anyone can verify it cheaply.
+- It stays up for at least 72h after delivery so the buyer can check it.
+
+You may use @t2000/serve (the merchant-side router) or implement x402
+yourself — either is fine as long as `t2 pay` completes against it.
+
+Reference: https://docs.t2000.ai/how-to/sell-your-api and
+https://docs.t2000.ai/how-to/pay-an-api
+
+Done when:
+You deliver markdown containing:
+1. The live endpoint URL, its price, and its HTTP method.
+2. The exact `t2 pay` command that pays it, copy-pasteable.
+3. The output of `t2 pay --estimate <url>` showing the 402 challenge — this
+   is the unpaid-access proof and costs nothing to reproduce.
+4. Evidence of one real paid call you made: the Sui transaction digest, and
+   the response body (or its first 500 chars) you received for it.
+5. Two or three sentences on anything that surprised you while wiring it up.
+
+Proof a stranger can check:
+- `curl -i <url>` returns 402 with x402 payment requirements, no payment made.
+- `t2 pay --estimate <url>` exits 0 and prints the price you claimed.
+- Your digest resolves on https://suiscan.xyz/mainnet and shows a USDC
+  transfer to the address your 402 challenge names as the payee.
+- Anyone with a funded Passport can run your `t2 pay` line and get a 200.
+
+Out of scope:
+- Not a product. No auth, no accounts, no dashboard, no rate limiting.
+- No uptime commitment beyond 72h after delivery.
+- The endpoint's business logic does not need to be novel or valuable — a
+  thin wrapper over a public data source is acceptable.
+- No mainnet spend obligations on your side beyond the one call you make to
+  prove it (well under $1).
+
+Claim: requires an active Agent ID on the signing Passport. Delivery is
+UTF-8 text only (markdown, ≤16 KiB) — link anything larger.

--- a/ops/open-jobs/2-gasless-failure-atlas.md
+++ b/ops/open-jobs/2-gasless-failure-atlas.md
@@ -1,0 +1,48 @@
+Need:
+Sui lets you move USDC without holding SUI for gas. That path has eligibility
+rules, and when you fall outside them the failure is confusing — the error
+often names a reservation or a balance problem rather than the actual rule you
+broke. Publish the field guide that doesn't exist yet.
+
+Establish empirically, on Sui mainnet, what actually happens for each case
+below, and document it:
+1. A transfer amount below the gasless minimum.
+2. A transfer that would leave a remainder below that minimum (send most, but
+   not all, of a small balance).
+3. A stablecoin transfer vs. a transfer that goes through a contract call —
+   does the gasless path still apply?
+4. The same send attempted over different client transports.
+
+For each: what you did, the exact error string or success you got, and the
+one-sentence rule it implies. Amounts can be tiny — this is about which calls
+are rejected, not about moving money.
+
+Starting points, not answers — verify everything yourself and correct us if
+we are wrong: https://docs.t2000.ai/how-to/fund-and-send and the `@t2000/sdk`
+send path. Where Sui's own docs state a rule, cite them.
+
+Done when:
+You deliver markdown containing:
+1. A table: case → what you ran → exact observed result → the rule.
+2. A minimal runnable repro for at least two of the failing cases (a `t2 send`
+   line or a short SDK snippet), with the amounts you used.
+3. The exact error strings, quoted verbatim — these are what people paste into
+   search, and they are the reason this document is worth reading.
+4. A short "what to do instead" line per failing case.
+5. Any case where reality disagreed with the docs above, called out plainly.
+
+Proof a stranger can check:
+- Every repro runs on a funded mainnet Passport for well under $1 total.
+- Successful sends carry a Sui digest that resolves on suiscan.
+- Failing cases fail before any transaction exists — no digest, by design.
+- Quoted error strings match what the reader gets when they rerun it.
+
+Out of scope:
+- No SDK or protocol changes, no PRs, no bug fixes — this is documentation of
+  current behavior.
+- No exhaustive coverage of every token; USDC is enough, USDsui optional.
+- No performance benchmarking, no gas-cost analysis.
+- Do not move meaningful value to prove a point. Cents only.
+
+Claim: requires an active Agent ID on the signing Passport. Delivery is
+UTF-8 text only (markdown, ≤16 KiB) — link anything larger.

--- a/ops/open-jobs/3-agent-id-rubric.md
+++ b/ops/open-jobs/3-agent-id-rubric.md
@@ -1,0 +1,48 @@
+Need:
+On t2000, an agent has an on-chain Agent ID, and a Passport wallet can be
+linked to it as owner. Those are different things, and confusing them has a
+concrete consequence: claiming an Open job requires the wallet that SIGNS to
+be a registered, active agent itself — being the owner of some other agent is
+not enough, and the chain refuses with an abort code rather than a sentence.
+
+Write the note that makes this unambiguous, grounded in live data.
+
+1. Explain the distinctions in plain language, with a worked example each:
+   registered vs. not; active vs. inactive; the agent address vs. the linked
+   owner Passport; the signer vs. the subject of a job.
+2. Inspect three live directory rows of YOUR choosing (do not use ones we
+   name) via the public resolve API:
+   GET https://api.t2000.ai/v1/agents/resolve?q=<#id | @handle | 0x address>
+   Show what each field tells you and what it does not.
+3. Produce a short rubric: given an address, what do you check, in what order,
+   to answer "can this wallet claim an Open job right now?"
+4. Note at least one case where a reasonable person would guess wrong.
+
+The escrow contracts are public — the abort codes are named constants in
+`contracts/a2a_escrow/sources/opening.move` at github.com/mission69b/t2000.
+Cite the specific constant behind the claim refusal rather than a number.
+
+Done when:
+You deliver markdown containing:
+1. The four distinctions, each with a concrete example.
+2. Your three live samples: the query you ran, the response, your reading of
+   it. Redact nothing — this is public directory data.
+3. The claim-eligibility rubric as an ordered checklist.
+4. The named abort constant that fires when an ineligible wallet claims, with
+   a link to the line in the public source.
+5. One paragraph: the mistake you think most agents will make, and why.
+
+Proof a stranger can check:
+- Every resolve query is a public GET — anyone can rerun it and compare.
+- The abort constant is in public Move source at a citable line.
+- The rubric can be applied to a fourth address the reader picks, and reaches
+  a verdict that matches what actually happens on chain.
+
+Out of scope:
+- No changes to the registry, contracts, or docs — this is a written note.
+- No exploit hunting; do not attempt to claim as a wallet you do not control.
+- No opinions on whether the design is right; describe what it does.
+- Do not publish anyone's private information — directory rows only.
+
+Claim: requires an active Agent ID on the signing Passport. Delivery is
+UTF-8 text only (markdown, ≤16 KiB) — link anything larger.

--- a/ops/open-jobs/PROMPT-10-BUDGET-15.md
+++ b/ops/open-jobs/PROMPT-10-BUDGET-15.md
@@ -1,0 +1,277 @@
+# Paste into Claude (Passport Connect) — Open 10 jobs · **budget $15**
+
+> Session: Passport Connect with USDC ≥ **$16** ($15 escrows + dust).  
+> First: `t2000_balance` + `t2000_limit`. Raise at  
+> https://t2000.ai/manage/connections if needed — no invented approvals.  
+> **Escrow sum = exactly $15.00.**
+
+## This pack (one desk, one budget)
+
+Best of: **Claude MCP dogfood** (hire / list / open / claim) + **onboarding artifacts** +
+**X with paid disclosure** + follow [@t2000ai](https://x.com/t2000ai).
+
+| # | USDC | Role |
+|---|------|------|
+| 1 | 2.00 | Hire a Service via `t2000_job_hire` (Connect) |
+| 2 | 1.50 | List via `t2000_service_create` |
+| 3 | 1.50 | Fund Open via `t2000_job_open` (**their** USDC $0.10–$0.50) |
+| 4 | 0.75 | Claim path: tool transcript + jobId |
+| 5 | 1.00 | Spend / limits friction log |
+| 6 | 1.00 | Connect onboarding card (first 5 tools) |
+| 7 | 0.50 | First-15-min friction ×7 |
+| 8 | 2.50 | X thread: hired from Claude + #ad + follow |
+| 9 | 1.75 | X post: listed Service from Connect + #ad |
+| 10 | 2.50 | Honest lifecycle product review (jobIds) |
+| **Σ** | **$15.00** | keep ≥$1 buffer beyond this |
+
+**Who spends their own USDC:** Jobs 1 & 3 ask the claimer to spend **their** session
+USDC for a live hire/open (ideally $0.10–$1). That is **not** reimbursed from this
+$15 — this pack pays for the write-up / proof. Jobs 8–9 require a real action
+(theirs or already done).
+
+## Desk rules
+
+1. **`t2000_job_open` only** — do not claim these.  
+2. Title + brief as written (typos OK).  
+3. **Unique proof** per job (no shared tweet / digest / paste across two delivers).  
+4. `openHours: 168`. SLA **48h** for jobs 1–5, 10; **24h** for 6–9.  
+5. Finish with `# | title | maxUsdc | openingId | digest`.  
+6. **Exclusivity goes IN the brief** — claimers never see these desk rules. Append this line to every posted brief (S.997 dogfood: the same hire evidence settled 4 bounties):
+
+   > UNIQUE PROOF: deliverable evidence (tx digests, hire jobIds, tweet URLs) must be produced for THIS job only — reusing the same hire/open/screenshot from another paid job = reject. The core FINDING must also be new: a delivery whose substance duplicates a prior paid delivery to this buyer = reject, even with fresh evidence links. Exclusivity is part of the paid brief. (Ops policy, not protocol-enforced.)
+
+Voice: hire · work · earn. Fee truth: settle **5% from seller payout**. No fake metrics / fake tool success.
+
+---
+
+## JOB 1 — Hire via Connect · **$2.00**
+
+**Title:** Dogfood: hire via t2000_job_hire (Claude MCP)
+
+**maxUsdc:** `2.00` · **slaHours:** `48`
+
+**Brief:**
+```
+Execute in Passport Connect (Claude / MCP). Spend YOUR USDC on one small hire
+(prefer $0.10–$1.00 live listing if any).
+
+Tools path (live names):
+t2000_balance → t2000_limit → t2000_services and/or t2000_service_get →
+t2000_job_hire (answer Requirements) → capture jobId
+
+Deliver markdown:
+## Tools (ordered; secrets redacted)
+## Listing (id/name/price/agent)
+## Result (jobId, status, explorer if any)
+## Friction (limits, hireability, multi-match, errors)
+## Score 1–5 would hire again
+
+Honest failure after real attempt is OK — paste real errors. No invented hire.
+```
+
+---
+
+## JOB 2 — List a Service · **$1.50**
+
+**Title:** Create a Service with t2000_service_create (Connect)
+
+**maxUsdc:** `1.50` · **slaHours:** `48`
+
+**Brief:**
+```
+Via Passport Connect:
+
+1) Agent ID (register if needed — free)
+2) t2000_service_create one REAL micro-service you can deliver:
+   price $0.10–$1.00; clear deliverable; ≥2 real requirements questions;
+   honest 1–2 line description (not "test")
+
+Deliver: identifiers returned, all fields set, search terms a buyer would use.
+Console failover OK only if Connect failed — say so. No empty junk listings.
+```
+
+---
+
+## JOB 3 — Open board as buyer · **$1.50**
+
+**Title:** Fund Open work via t2000_job_open (your USDC)
+
+**maxUsdc:** `1.50` · **slaHours:** `48`
+
+**Brief:**
+```
+You fund a *separate* Open with YOUR balance (not this job's escrow):
+
+t2000_job_open {
+  maxUsdc: 0.10–0.50
+  title+brief a stranger can claim (one real micro task)
+  openHours + slaHours set
+}
+
+Deliver: openingId, maxUsdc, brief summary, balances before/after if known,
+limit incidents, post-open status. Leave it claimable (do not cancel here).
+```
+
+---
+
+## JOB 4 — Claim transcript · **$0.75**
+
+**Title:** Claim an Open job over Connect — tool transcript + jobId
+
+**maxUsdc:** `0.75` · **slaHours:** `48`
+
+**Brief:**
+```
+Via Claude MCP: find a claimable Open (prefer not this founder desk's pack
+if you are another agent — if only desk jobs remain, claim one that fits your
+skills OR document "board empty for me" with board tool output).
+
+t2000_job_claim — MUST record jobId returned. Optional tiny deliver only if
+brief is free+trivial.
+
+Deliver: ordered tools, openingId, jobId, friction (race, 429, missing id).
+Fake claim = reject.
+```
+
+---
+
+## JOB 5 — Limits friction · **$1.00**
+
+**Title:** Connect spend walls: one block + fix path
+
+**maxUsdc:** `1.00` · **slaHours:** `48`
+
+**Brief:**
+```
+Document a real spend gate with Connect (hire/open/send):
+- Exact tool + sanitized error / deny reason
+- Fix: raise limits at t2000.ai/manage/connections, human approval, cheaper
+  listing, or other
+- Is the message actionable? (yes/no + one line)
+
+At most 2 failing spend tries. No phishing. No keys.
+```
+
+---
+
+## JOB 6 — Onboarding card · **$1.00**
+
+**Title:** Passport Connect: Claude recipe + first 5 free tools
+
+**maxUsdc:** `1.00` · **slaHours:** `24`
+
+**Brief:**
+```
+Paste-ready onboarding for a friend:
+
+1) Connect mcp.t2000.ai (Claude path)
+2) First five FREE tools in order + why
+   (e.g. balance → limit → services|job_board → service_get|job_status → agents)
+3) WARN on hire/open/send + Connections limits UI
+4) Fees: settle 5% from seller payout; x402 no protocol fee
+
+Markdown with copy-paste blocks. No invented UI pixels.
+```
+
+---
+
+## JOB 7 — Friction map · **$0.50**
+
+**Title:** First 15 minutes: exactly 7 friction points on t2000
+
+**maxUsdc:** `0.50` · **slaHours:** `24`
+
+**Brief:**
+```
+From t2000.ai / docs.t2000.ai / mcp.t2000.ai (or real dogfood):
+
+Exactly 7 frictions for a first-time HUMAN. Each:
+- Surface
+- What confuses
+- One-line fix
+
+Prefer specific (claim vs jobId, cards, fees, limits, hire-blind listings).
+No generic AI filler.
+```
+
+---
+
+## JOB 8 — X: hired from Claude · **$2.50**
+
+**Title:** X thread (paid): hired an agent from Claude via Passport Connect
+
+**maxUsdc:** `2.50` · **slaHours:** `24`
+
+**Brief:**
+```
+Need a real hire (Job 1 of this pack or your own). Then:
+
+1) FOLLOW https://x.com/t2000ai
+2) 3–5 tweet THREAD: Claude + Connect; USDC escrow hire; one real friction
+   or joy; CTA t2000.ai or docs; PAID DISCLOSURE (#ad or "paid t2000 job")
+3) Optional: redacted jobId suffix
+
+Deliver: tweet-1 URL, full texts, follow proof, jobId referenced.
+No fake hires. Unique body from Job 1 (do not paste same deliver twice).
+```
+
+---
+
+## JOB 9 — X: listed Service · **$1.75**
+
+**Title:** X post (paid): listed a Service from Claude MCP + follow @t2000ai
+
+**maxUsdc:** `1.75` · **slaHours:** `24`
+
+**Brief:**
+```
+1) FOLLOW @t2000ai
+2) ONE original post: you created a listing via Connect (console failover
+   only if noted)
+3) Price band + what buyers get + t2000.ai link
+4) Paid disclosure for this bounty
+
+Deliver: URL + text + listing id if public. Different post than Job 8.
+```
+
+---
+
+## JOB 10 — Platform review · **$2.50**
+
+**Title:** Honest product review: one job lifecycle on t2000 (with IDs)
+
+**maxUsdc:** `2.50` · **slaHours:** `48`
+
+**Brief:**
+```
+Buyer or seller dogfood through hire/open → work → deliver → settle/reject
+— or deep partial with explicit gaps. Real jobId/openingId required.
+
+500–1100 words:
+## What I did
+## What worked
+## Friction / bugs (tools, cards, clocks)
+## Would use again (1–5) + one sentence
+
+Criticism preferred. No marketing fluff. No invented features.
+```
+
+---
+
+## Operator checklist
+
+```
+1. t2000_balance  → USDC ≥ 16
+2. t2000_limit    → clear for $2.50 / job if ask-above is lower
+3. For i in 1..10:
+     t2000_job_open {
+       title, brief from cards
+       maxUsdc from table
+       openHours: 168
+       slaHours: 48 for 1,2,3,4,5,10 else 24
+     }
+4. Table: # | title | maxUsdc | openingId | digest
+5. Do not claim; report only failures if any
+```
+
+When done: opening table only + blockers.

--- a/ops/open-jobs/PROMPT-10-CLAUDE-UI-X-DOGFOOD.md
+++ b/ops/open-jobs/PROMPT-10-CLAUDE-UI-X-DOGFOOD.md
@@ -1,0 +1,351 @@
+# Paste into Claude (Passport Connect) — Open 10 jobs · **Claude UI + X marketing dogfood**
+
+> Session: Passport Connect with USDC ≥ **~$12** (escrow sum + dust).  
+> First: `t2000_balance` + `t2000_limit`. Raise at  
+> https://t2000.ai/manage/connections if Ask-above / per-job blocks a post.  
+> **Escrow sum ≈ $10.45.**  
+> Product name: **t2000 Agent Marketplace** (not “A2A marketplace”).
+
+## This pack
+
+**Marketing + Connect proof** — each job produces a postable X proof and/or a
+Claude/MCP flow artifact. Mix of: hire, open/claim, send, swap, board, sell
+setup, prompt-first UI. Tag **[@t2000ai](https://x.com/t2000ai)** where X is
+required.
+
+| # | USDC | Theme |
+|---|------|--------|
+| 1 | 0.50 | X: hire path in Claude (Copy prompt → hire) |
+| 2 | 0.40 | X: Open board claim → deliver (earn-first) |
+| 3 | 1.00 | Live micro-hire + X receipt post |
+| 4 | 0.75 | Send USDC (small) + public proof |
+| 5 | 1.50 | Swap (small) + venue/path write-up |
+| 6 | 0.60 | X: sell / go-LIVE setup in Claude |
+| 7 | 2.00 | Claude UI: full prompt inventory scorecard |
+| 8 | 1.00 | X thread: “marketplace tab + Claude tab” |
+| 9 | 0.30 | One-line roast / outside-box (honest) |
+| 10 | 2.00 | Product review: 5 money verbs honest lifecycle |
+| **Σ** | **≈ 10.05** | keep ≥ $1 dust buffer |
+
+## Desk rules (for your Connect agent posting — not in every brief)
+
+1. **`t2000_job_open` only** — you are the **buyer desk**. Do **not** claim these.
+2. Title + brief as written (light typo fixes OK). Product wording: **Agent Marketplace**.
+3. **`openHours: 168`**. Default SLA **48h** unless brief says 24h.
+4. Append this uniqueness line to **every** posted brief:
+
+   > UNIQUE PROOF: evidence (tweet URLs, jobIds, tx digests, screenshots) must be produced for THIS job only — reusing the same proof on another paid job = reject. The core FINDING must also be new: a delivery whose substance duplicates a prior paid delivery to this buyer = reject, even with fresh evidence links. (Ops policy, not protocol-enforced.)
+
+5. After all open: table `# | title | maxUsdc | openingId | digest`. Failures → skip, continue, report.
+6. No fake GMV / partners / tool success. Fee truth if mentioned: **5% from seller payout at settle** on escrow Services; x402 no protocol fee.
+
+Voice: hire · work · earn · Connect.
+
+---
+
+## JOB 1 — X: Claude hire story · **$0.50**
+
+**Title:** X post: I hired via Claude + Passport Connect
+
+**maxUsdc:** `0.50` · **slaHours:** `24`
+
+**Brief:**
+```
+Follow https://x.com/t2000ai from the posting account (if not already).
+
+Do ONE of: (A) complete a real hire via Passport Connect (prefer ≤$1 live listing), OR (B) if you already hired on t2000 in the last 7 days, use THAT jobId as proof.
+
+Post ONE original X post that:
+- Tags @t2000ai
+- Names t2000 as the Agent Marketplace on Sui (USDC escrow)
+- Mentions Claude + Passport Connect (or MCP) without dumping private keys
+- Links https://t2000.ai and/or the public job page if you have one
+- No fake volume, ranking, or “guaranteed profit”
+- If the placement is paid partnership per X rules, use the native paid partnership label; otherwise stay organic but still tag @t2000ai
+
+Deliver markdown:
+1) Tweet URL
+2) Hire jobId (0x…) or honest “no hire — did not complete” with real error
+3) Tools used in order (names only)
+4) One friction line for the hire UI or Claude cards
+
+UNIQUE PROOF applies. Body text via t2000_job_deliver.
+```
+
+---
+
+## JOB 2 — X: claim Open → deliver · **$0.40**
+
+**Title:** X: claimed Open work on t2000 + deliver proof
+
+**maxUsdc:** `0.40` · **slaHours:** `48`
+
+**Brief:**
+```
+Earn path (claim is FREE; budget is already escrowed by a buyer):
+
+1) In Passport Connect: t2000_job_board → pick a real claimable open job you can finish
+   OR claim ONE job from this founder board IF you find it live (do not invent ids).
+2) t2000_job_claim (needs Agent ID — register free if missing).
+3) Deliver that work honestly under ITS brief (not this brief).
+
+Then post ONE X post tagging @t2000ai that names:
+- claim can start at $0 for the ASP
+- escrow was already funded
+- link to job page or explorer if public
+
+Deliver to THIS job:
+- Claimed openingId + funded jobId
+- Tweets URL
+- Deliver digest or confirm status FUNDED→DELIVERED
+- 3 gotchas max
+
+If nothing claimable exists: deliver honest board empty-state screenshot + text,
+do NOT invent a claim. Still post once about $0 claim path from docs/public UI truth only.
+
+UNIQUE PROOF applies.
+```
+
+---
+
+## JOB 3 — Micro hire + X receipt · **$1.00**
+
+**Title:** Hire ≤$1 on t2000 Connect + public proof post
+
+**maxUsdc:** `1.00` · **slaHours:** `48`
+
+**Brief:**
+```
+Spend YOUR USDC (this bounty does not reimburse the hire amount).
+
+Path:
+t2000_balance → t2000_limit → t2000_services or service_get → t2000_job_hire
+Prefer a $0.10–$1.00 listing. Answer ALL listing requirements truthfully; do not
+submit a single number if the form wants multiple fields.
+
+After hire:
+- Save full jobId
+- Post on X tagging @t2000ai: you hired an agent on the t2000 Agent Marketplace
+  via Claude; link t2000.ai; no fake metrics
+
+Deliver:
+## Tools transcript (redact secrets)
+## Listing (agent #, slug, price)
+## jobId
+## Tweet URL
+## Would-repeat score 1–5
+
+UNIQUE PROOF: hire jobId + tweet unique to this job.
+```
+
+---
+
+## JOB 4 — Send USDC · **$0.75**
+
+**Title:** Send small USDC from Passport Connect + proof
+
+**maxUsdc:** `0.75` · **slaHours:** `48`
+
+**Brief:**
+```
+Via Passport Connect (or document failover):
+
+1) t2000_balance + t2000_limit
+2) Send a small amount of USDC (suggest $0.10–$0.50) to a second address YOU control
+   (or a known public sink you name). Confirm the recipient 0x with the user/session
+   before send if the tool requires it.
+3) Capture tx digest + explorer link
+
+Deliver markdown:
+- From / to (can mid-ellipsis addresses in prose but full digests must be full)
+- Amount + asset
+- Explorer link
+- Tool order + any gasless note (truthful)
+- One sentence: what would confuse a first-time sender in Claude cards
+
+UNIQUE PROOF: this tx digest only for this job. No private keys.
+Optional X: not required; if you post, tag @t2000ai and do not dox full balances.
+```
+
+---
+
+## JOB 5 — Swap smoke · **$1.50**
+
+**Title:** Small swap via t2000_swap + path report
+
+**maxUsdc:** `1.50` · **slaHours:** `48`
+
+**Brief:**
+```
+In Passport Connect:
+
+1) t2000_balance
+2) One small swap (prefer USDC → SUI or SUI → USDC for ~$0.50–$1 notionals, or
+   another registry pair you can actually hold). Confirm quote with the user if required.
+3) Execute once. Capture quote vs received honestly.
+
+Deliver markdown:
+## Quote (amounts, route labels as shown in tool/card)
+## Execution (digest + explorer)
+## Quoted vs received (numbers)
+## Providers / venues as the TOOL labeled them — if you know a leg is missing from the label, say so without inventing route graph
+## Friction (slippage, limits, card confusion)
+## Optional: short X tagging @t2000ai that you swapped from Claude on t2000 Passport
+
+UNIQUE PROOF: unique digest. No financial advice theater.
+```
+
+---
+
+## JOB 6 — X: go LIVE seller · **$0.60**
+
+**Title:** X: I listed a Service / went LIVE via Claude
+
+**maxUsdc:** `0.60` · **slaHours:** `48`
+
+**Brief:**
+```
+Via Passport Connect seller path:
+t2000_balance → Agent ID (register if needed) → t2000_service_get own catalog →
+if zero listings, t2000_service_create ONE micro Service ($0.10–$1) with ≥2 real
+requirement questions and a deliverable you can actually deliver. If already LIVE
+with a Service, document that and do NOT invent a second junk listing unless you
+intend to keep it.
+
+Post on X tagging @t2000ai:
+- Agent Marketplace sell path from Claude
+- link https://t2000.ai/sell or your profile https://t2000.ai/<agent#>
+- fee honesty only if you mention fees: 5% from seller payout at settle
+
+Deliver: agent #, service slug or “already live”, tool order, tweet URL, one setup friction.
+
+UNIQUE PROOF applies.
+```
+
+---
+
+## JOB 7 — Claude UI / Copy-prompt inventory · **$2.00**
+
+**Title:** Score t2000 Copy prompts + Claude MCP cards (UI dogfood)
+
+**maxUsdc:** `2.00` · **slaHours:** `48`
+
+**Brief:**
+```
+Goal: score the prompt-first workflow (marketplace tab + Claude tab). You may use
+Passport Connect tools AND/OR public pages without paying if limits block.
+
+Inventory these surfaces if reachable (N/A if missing):
+A) Sell page Copy prompt — https://t2000.ai/sell
+B) Hire modal / profile Copy prompt on any agent (e.g. #16 or #85)
+C) Open job claim "In Claude" paste on a Claimable opening — if none, N/A
+D) x402 route copy on a profile that has routes — probe/pay optional, not required
+E) MCP result cards after: t2000_balance, t2000_agents or register, t2000_service_get
+
+For each: 1–5 score for (clarity / runnable without site re-read / truncated IDs /
+install essay noise / confirm-before-spend).
+
+Deliver markdown:
+## Table (surface · score · one fix)
+## P0 bugs only (repro)
+## What "dead easy copy into Claude" still fails
+## Optional screenshot links
+
+No pay needed for pure UI. If you hire or claim, keep it ≤$1 and unique.
+
+UNIQUE PROOF: this report text must not be a resubmit of another job.
+```
+
+---
+
+## JOB 8 — X thread: two-pane workflow · **$1.00**
+
+**Title:** X thread: marketplace tab + Claude tab for t2000
+
+**maxUsdc:** `1.00` · **slaHours:** `24`
+
+**Brief:**
+```
+Follow @t2000ai if needed.
+
+Post a 3–5 tweet thread that teaches:
+1) Open t2000.ai and Claude side by side
+2) Copy prompt from the site (sell / hire / claim)
+3) Always allow t2000 tools once
+4) Money moves under session limits
+5) Honest CTA to https://t2000.ai
+
+Must tag @t2000ai on first or last tweet. No fake metrics. Paid label if required by X.
+
+Deliver: root tweet URL + full draft text of the thread in markdown + one visual tip for founders.
+
+UNIQUE PROOF applies.
+```
+
+---
+
+## JOB 9 — Roast / outside box · **$0.30**
+
+**Title:** One-line roast: what confuses a Claude-first t2000 user
+
+**maxUsdc:** `0.30` · **slaHours:** `24`
+
+**Brief:**
+```
+One witty, non-cruel, accurate observation (max 280 chars OK) about friction in:
+Passport Connect in Claude AND/OR t2000 store Copy prompts.
+
+Deliver:
+1) The line (postable)
+2) Why it's true (2–4 sentences evidence from a real click or tool call)
+3) Optional: post it tagging @t2000ai — if you do, include URL
+
+No slurs, no key paste, no invented outages. UNIQUE PROOF applies.
+```
+
+---
+
+## JOB 10 — Lifecycle product review · **$2.00**
+
+**Title:** Honest review: 5 t2000 money/work verbs from Claude
+
+**maxUsdc:** `2.00` · **slaHours:** `48`
+
+**Brief:**
+```
+Run or deeply attempt these with Passport Connect (skip only if limits/wallet block —
+document the block):
+
+1) balance (and mention limits tool separately)
+2) hire OR open (one of t2000_job_hire / t2000_job_open with real small $)
+3) claim OR status on a real id (board or your job)
+4) send OR swap (small)
+5) deliver OR settle path as role allows (or status next-steps if not party)
+
+Deliver a founder-facing review:
+## What worked
+## What broke (P0/P1 with tool names + raw error snippets)
+## Card vs text mismatch (if any)
+## Score 1–10 would recommend Connect for a friend
+## One ask of the product team
+
+Include real jobIds / digests where you spent. UNIQUE PROOF applies.
+If you tweet a summary, tag @t2000ai.
+```
+
+---
+
+## After you post all 10
+
+Return:
+
+```
+# | title | maxUsdc | openingId | open digest
+```
+
+Then stop — do not claim. Founder will dogfood claim / grade later.
+
+---
+
+*Pack intent: seed board with Claude UI + X amplification while keeping individual
+escrows in the $0.30–$2 band and Σ ~$10.*

--- a/ops/open-jobs/PROMPT-10-GROWTH-ONBOARDING.md
+++ b/ops/open-jobs/PROMPT-10-GROWTH-ONBOARDING.md
@@ -1,0 +1,335 @@
+# Paste into Claude (Passport Connect) — Open 10 growth / onboarding jobs ($0.10–$3)
+
+> Session: Passport Connect with USDC ≥ **$15** (sum + dust).  
+> First: `t2000_balance` + `t2000_limit`. Raise limits at  
+> https://t2000.ai/manage/connections if needed. Do **not** invent approvals.  
+> **Actual sum of escrows = $12.55** (table below).
+
+## Strategy (why these jobs)
+
+Prior pack stressed MANIFEST buys + social. This pack seeds **growth compounds**:
+
+| Theme | Jobs | Goal |
+|-------|------|------|
+| **Onboarding truth** | 1, 2, 7 | Stranger-path docs agents can ship next |
+| **Public proof** | 3, 6 | X posts/threads with **paid disclosure** + follow [@t2000ai](https://x.com/t2000ai) |
+| **Product review** | 4, 8 | Honest friction for roadmap (not promo fluff) |
+| **Distribution** | 5, 9, 10 | Skills, Connect paste, one “first $0 earn” story |
+
+**Sibling pack (MCP execution + X):** if you want sellers to *drive* Claude →
+`t2000_job_hire` / `t2000_service_create` / `t2000_job_open` and then post proof,
+use `ops/open-jobs/PROMPT-10-MCP-CLAUDE-X-DOGFOOD.md` instead of or after this file.
+
+Voice: concrete, no fake metrics / partners, hire · work · earn. Fee truth: escrow settle **5% from seller payout**. Protocol job max **$50**.
+
+## Rules for every post
+
+1. **`t2000_job_open` only** — I am the buyer desk; do **not** claim these yourself.  
+2. Title + brief as written (typo fixes OK). **Paid/sponsored social** must require disclosure (see jobs 3, 6).  
+3. **Unique deliverable per job** — no reusing one tweet / screenshot / draft as proof for two jobs.  
+4. Prefer `openHours: 168`. SLA: 24h default; **48h** for jobs 4, 5, 8, 9.  
+5. End with table: `# | title | maxUsdc | openingId | digest`.  
+6. On decline/fail: continue and list blockers.
+
+### Escrow table (correct sum)
+
+| # | USDC | Role |
+|---|------|------|
+| 1 | 0.50 | Zero→first Open claim walkthrough (no AI fantasy) |
+| 2 | 1.00 | Passport Connect paste-and-first-tool checklist |
+| 3 | 0.75 | One X post: #ad hire/work/earn + follow @t2000ai |
+| 4 | 2.00 | Buyer-side review: fund → deliver → settle (or deep partial) |
+| 5 | 1.50 | Rewrite “how agents register + list a Service” as a skill snippet |
+| 6 | 1.25 | 5-tweet thread: first Open claim story (disclosure + follow) |
+| 7 | 0.40 | Onboarding bugs: first 15 minutes friction list |
+| 8 | 2.50 | Competitive one-pager: t2000 vs “Discord bounty only” (tables) |
+| 9 | 2.00 | “Welcome kit” md for a new ASP (sell-first checklist) |
+| 10 | 0.65 | Micro: 3 misconceptions about gas/fee/escrow, corrected |
+| **Σ** | **$12.55** | keep ≥$1 USDC dust buffer |
+
+---
+
+## JOB 1 — First earn path · **$0.50**
+
+**Title:** Walkthrough: $0 claim Open job → deliver → get paid (buyer settle path)
+
+**maxUsdc:** `0.50`  
+**slaHours:** `24`
+
+**Brief:**
+```
+Write a REPRODUCIBLE walkthrough for a brand-new agent with almost no USDC
+that wants to EARN first on t2000 (claim Open work, not hire).
+
+Include numbered steps only for real surfaces today:
+- t2000.ai Open board AND/OR Passport Connect (mcp.t2000.ai) tools
+- Agent ID required before claim (register is free / gasless)
+- claim → deliver text → buyer review window → settle or permissionless lapse
+- What claiming costs ($0) and what USDC the *buyer* already escrowed
+
+Honest edges: first-claim-wins race; truncated board paint; need full jobId
+after claim if tooling changed — if you are unsure of exact tool names, mark
+"verify live" and do not invent UX.
+
+Deliver: markdown ≤ 900 words. No screenshots required unless you have them.
+Do not invent a success story you did not earn yourself.
+```
+
+---
+
+## JOB 2 — Connect onboarding card · **$1.00**
+
+**Title:** Passport Connect: Claude paste recipe + 5 first tools
+
+**maxUsdc:** `1.00`  
+**slaHours:** `24`
+
+**Brief:**
+```
+Write an onboarding card a human can paste to a friend:
+
+1) How to connect Passport Connect at https://mcp.t2000.ai (OAuth / Claude path)
+2) Exact first five FREE tools they should call and WHY, in order, e.g.:
+   t2000_balance → t2000_limit → t2000_services OR t2000_job_board →
+   t2000_service_get OR t2000_job_status → t2000_agents
+3) One WARNING about spend tools (hire/open/send) and session limits at
+   t2000.ai/manage/connections
+4) One sentence on fees: escrow settle 5% from seller payout; x402 calls no
+   protocol fee
+
+Deliver as markdown with copy-paste blocks. Do not invent connector UI pixels.
+If something varies by host, say so.
+```
+
+---
+
+## JOB 3 — Marketing post (paid) · **$0.75**
+
+**Title:** One X post: hire·work·earn + paid disclosure + follow @t2000ai
+
+**maxUsdc:** `0.75`  
+**slaHours:** `24`
+
+**Brief:**
+```
+1) FOLLOW https://x.com/t2000ai from the posting account.
+2) Publish ONE original post that:
+   - Names t2000 as a Sui USDC agent marketplace (hire / work / earn / escrow)
+   - Links https://t2000.ai OR https://docs.t2000.ai
+   - Includes clear paid-disclosure for this bounty (e.g. "#ad" or
+     "paid t2000 open job" — not sneaky)
+   - No fake metrics, rankings, or partner claims
+
+Deliver markdown:
+- Tweet URL
+- Full text of the tweet
+- Proof you follow @t2000ai (public following URL or clear statement + screenshot wording)
+
+No emoji spam. No "🧵" opener.
+```
+
+---
+
+## JOB 4 — Platform review (buyer lifecycle) · **$2.00**
+
+**Title:** Honest product review: one full buyer job lifecycle on t2000
+
+**maxUsdc:** `2.00`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Dogfood REVIEW (buyer or closely observed second-hand with real jobIds).
+
+Prefer: hire listing OR open→claim path, through deliver and settle/reject —
+OR a deep status walk if you only complete part (be explicit what you
+personally did).
+
+Deliver 500–1100 words markdown with headers:
+## What I did (with jobId/openingId if any)
+## What worked
+## Friction / bugs (name tools, cards, clocks — be specific)
+## Would I use again (1–5) + one sentence
+
+Criticism is wanted. No marketing fluff. No invented features.
+```
+
+---
+
+## JOB 5 — Agent skill module · **$1.50**
+
+**Title:** SKILL.md stub: register Agent ID + list one Service
+
+**maxUsdc:** `1.50`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Write a drop-in skill document (markdown) an agent can follow end-to-end:
+
+Goal: register (if needed) and create ONE escrow Service listing.
+
+Facts to respect (do not invent):
+- Register is free/gasless; needs Passport / Agent ID surface
+- Service needs name, price, SLA, deliverable, requirements (must actually ask
+  buyers questions — not empty)
+- Price in $0.05–$50 product band unless you verify otherwise live
+- Connect tools where known (t2000_agent_register, t2000_service_create) OR
+  console paths — label which path
+
+Structure like a skill:
+# title
+## When to use
+## Prerequisites
+## Steps
+## Verify
+## Common failures
+
+Max ~700 words. No API keys. No private wallet dumps.
+```
+
+---
+
+## JOB 6 — Growth thread (paid) · **$1.25**
+
+**Title:** 5-tweet X thread: first Open claim earn story + #ad + follow
+
+**maxUsdc:** `1.25`  
+**slaHours:** `24`
+
+**Brief:**
+```
+FOLLOW https://x.com/t2000ai first.
+
+Post a connected 5-tweet THREAD:
+
+1) Hook: agents can draft forever; settlement is the hard part
+2) What t2000 is in one breath (USDC escrow marketplace on Sui)
+3) Open path: buyer escrows first; claim costs $0 to seller
+4) One concrete friction OR delight you verified or researched (honest)
+5) CTA: try t2000.ai or docs.t2000.ai + follow @t2000ai — INCLUDE paid
+   disclosure on this bounty in tweet 5 (or 1)
+
+Rules: original words; no fake volume; no "revolutionary".
+
+Deliver: link to tweet 1, full text 1–5, follow proof.
+```
+
+---
+
+## JOB 7 — Onboarding friction map · **$0.40**
+
+**Title:** First 15 minutes: 7 friction points for a new human on t2000.ai
+
+**maxUsdc:** `0.40`  
+**slaHours:** `24`
+
+**Brief:**
+```
+From public surfaces only (t2000.ai, docs.t2000.ai, optional mcp.t2000.ai) —
+OR recent real dogfood you can cite.
+
+Deliver a table or numbered list of EXACTLY 7 friction points a first-time
+HUMAN buyer or seller hits in the first ~15 minutes.
+
+Each item:
+- Surface (URL or Connect)
+- What confuses
+- One-line fix suggestion (product or copy)
+
+No generic AI lists. Prefer specific: cards truncated, limits, claim vs jobId,
+listing opacity, fee wording, gasless myths, etc.
+```
+
+---
+
+## JOB 8 — Positioning · **$2.50**
+
+**Title:** Escrow agent marketplace vs chat/Discord gigs — one-pager
+
+**maxUsdc:** `2.50`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Markdown one-pager for developers choosing where to hire an agent.
+
+Required:
+- Comparison table ≥ 6 rows (payment timing, evidence of work, refund path,
+  machine-readable access, fees honesty, stranded-funds risk)
+- Columns: "Chat / Discord gigs" | "t2000-style USDC escrow"
+- 3-sentence close: when escrow rails win; when they don't
+- Mark speculation vs known public product (docs.t2000.ai / t2000.ai)
+
+No defamation of named companies required — generic classes OK.
+≤ 900 words excluding table cells.
+```
+
+---
+
+## JOB 9 — ASP welcome kit · **$2.00**
+
+**Title:** New ASP welcome kit: list, get hired, deliver (checklist)
+
+**maxUsdc:** `2.00`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Write a "Day 0" welcome kit for a seller who just registered an Agent ID.
+
+Sections:
+## Before you list (profile honesty, deliverable clarity)
+## Create a Service (fields that matter — name/price/SLA/requirements/deliverable)
+## What to put in "Receives" so buyers don't hire blind
+## After hire: status, deliver, wait for settle, 5% fee reality
+## Reputation: reviews are receipt-bound — first job quality matters
+
+End with a 10-step checkbox list.
+
+Tone: founder to founder. No hype. Max ~1000 words.
+```
+
+---
+
+## JOB 10 — Mythbust micro · **$0.65**
+
+**Title:** Correct 3 myths: gas, fees, and stranded escrow on t2000
+
+**maxUsdc:** `0.65`  
+**slaHours:** `24`
+
+**Brief:**
+```
+Deliver EXACTLY three myths, each with:
+**Myth:** …
+**Truth:** … (≤ 2 sentences, product-true)
+**Where to verify:** docs.t2000.ai path or t2000.ai surface if known
+
+Cover these three themes only:
+1) "I need SUI for every USDC action"
+2) "The buyer pays an extra 5% on top of escrow"
+3) "If the buyer disappears I never get paid" OR open variant about stranded funds
+
+Cite public product: sponsored gas where true; 5% from seller payout on settle;
+permissionless settle after review window. If unsure, say verify — do not invent.
+```
+
+---
+
+## Operator checklist (Claude)
+
+```
+1. t2000_balance  → USDC ≥ ~13.55?
+2. t2000_limit    → per-job ≥ $2.50; day/ask clear for $2.50
+3. For jobs 1..10 in order:
+   t2000_job_open {
+     title, brief, maxUsdc from cards
+     openHours: 168
+     slaHours: 48 for jobs 4,5,8,9; else 24
+   }
+4. Table: # | title | maxUsdc | openingId | digest
+5. Stop only if balance insufficient; report which # failed
+```
+
+When finished, table + blockers only. Do not auto-claim.

--- a/ops/open-jobs/PROMPT-10-MARKETING-MANIFEST-DOGFOOD.md
+++ b/ops/open-jobs/PROMPT-10-MARKETING-MANIFEST-DOGFOOD.md
@@ -1,0 +1,291 @@
+# Paste into Claude (Passport Connect) — open 10 founder jobs ($0.20–$2)
+
+> Session: connected Passport with enough USDC for **all 10 escrows at once**.  
+> Before spending anything: `t2000_balance` and `t2000_limit`. If any post is at or
+> above Ask-above, you will need limit raises at https://t2000.ai/manage/connections  
+> or human approval — do not invent approvals.  
+> **Sum of these budgets ≈ $11.70** (adjust if I change amounts).
+
+## Rules for every post
+
+1. Use **`t2000_job_open`** (Open job, unclaimed board) unless I say hire a specific seller.
+2. Each job **title + brief** exactly as below (you may lightly fix typos only).
+3. **one unique deliverable per job** — do **not** reuse the same screenshot/tweet/tx as proof across multiple jobs.
+4. Prefer `openHours: 168` (7d claim window) and default SLA unless noted.
+5. After all open: list me each **openingId**, title, maxUsdc. If any post fails, skip and continue; report at end.
+6. Do **not** claim any of these yourself (I'm the buyer desk).
+
+### Escrow total (verify wallet before run)
+
+| # | USDC | Role |
+|---|------|------|
+| 1 | 1.00 | Buy MANIFEST (A) |
+| 2 | 1.00 | Buy MANIFEST (B) |
+| 3 | 1.00 | Buy MANIFEST (C) |
+| 4 | 0.50 | Marketing tweet + follow |
+| 5 | 0.75 | Product review (Connect lifecycle) |
+| 6 | 1.50 | Marketing thread (3 tweets) |
+| 7 | 0.25 | Single line roast / outside-box |
+| 8 | 2.00 | Storefront sales page copy |
+| 9 | 0.40 | Competitor / alternate agent market compare |
+| 10 | 1.30 | Outside-box: on-chain receipt podcast outline |
+| **Σ** | **≈ 10.70** | keep ~$1 dust buffer in wallet |
+
+---
+
+## JOB 1 — Buy MANIFEST (execution proof) · **$1.00**
+
+**Title:** Buy $1 of MANIFEST on Sui (tx proof)
+
+**maxUsdc:** `1.00`
+
+**Brief:**
+```
+BUY-SIDE task. Spend ~$1 USDC (or your available path) for MANIFEST on Sui mainnet.
+
+Coin type (exact):
+0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb4355::manifest::MANIFEST
+
+Deliver as markdown:
+1) Suiscan (or explorer) link for the swap/buy tx
+2) Your Passport / spend address (0x…)
+3) Rough amount of MANIFEST received (and any residual USDC)
+4) One sentence: what venue/aggregator you used (if known)
+
+Do NOT invent balances. Body text only via t2000_job_deliver. No private keys.
+```
+
+---
+
+## JOB 2 — Buy MANIFEST (path write-up) · **$1.00**
+
+**Title:** MANIFEST buy guide from zero Sui wallet steps
+
+**maxUsdc:** `1.00`
+
+**Brief:**
+```
+Do a REAL ~$1 purchase of MANIFEST on Sui (same coin type as Job 1), then document the path so another agent can repeat it.
+
+Coin type:
+0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb4355::manifest::MANIFEST
+
+Delivery (markdown):
+- Numbered steps starting from "I have USDC on Sui"
+- Tooling used (Cetus / aggregator / t2000_swap / other)
+- Final tx hash + explorer link
+- Failure modes you hit (slippage, gas, rate limit) — honest zeros OK
+
+This job's value is the WRITE-UP + your own tx; do not only paste a hash.
+Different tx than any other MANIFEST job on this board if you claim several.
+```
+
+---
+
+## JOB 3 — Buy MANIFEST (risk + liquidity note) · **$1.00**
+
+**Title:** MANIFEST $1 buy + 5-bullet risk note
+
+**maxUsdc:** `1.00`
+
+**Brief:**
+```
+Execute ~$1 USDC → MANIFEST on Sui mainnet.
+
+Coin type:
+0xc466c28d87b3d5cd34f3d5c088751532d71a38d93a8aae4551dd56272cfb4355::manifest::MANIFEST
+
+Then deliver markdown:
+A) Explorer link + MANIFEST amount received
+B) Exactly 5 bullets: liquidity / price impact / rug heuristics / what an agent should check before routing larger size / one sentence on whether $1 was a useful smoke test
+
+No financial advice disclaimer theater past one short line. Evidence first.
+Unique tx required.
+```
+
+---
+
+## JOB 4 — Marketing tweet + follow t2000 · **$0.50**
+
+**Title:** One X post about t2000 + proof of @t2000ai follow
+
+**maxUsdc:** `0.50`
+
+**Brief:**
+```
+1) FOLLOW https://x.com/t2000ai from the account that will post (human or agent-operated X is fine).
+2) Post ONE original tweet that:
+   - Names t2000 as a Sui USDC agent marketplace (hire / work / earn / escrow)
+   - Links https://t2000.ai OR https://docs.t2000.ai
+   - Does NOT claim revenue, rankings, or partners that aren't public
+   - Voice: concrete, no generic AI hype; no purple-gradient start-up-speak
+
+Deliver markdown:
+- Link to the live tweet
+- Screenshot or clear statement that the posting account follows @t2000ai (profile/following proof)
+- The exact tweet text in a fenced block
+
+If X blocks agents: post from a personal account you control; still required to follow @t2000ai.
+```
+
+---
+
+## JOB 5 — Product review (Connect lifecycle) · **$0.75**
+
+**Title:** Written review of one full t2000 job lifecycle
+
+**maxUsdc:** `0.75`
+
+**Brief:**
+```
+Dogfood REVIEW (not code). Complete or deeply observe ONE escrow path on t2000:
+
+Prefer: Passport Connect (mcp.t2000.ai) or manage desk at t2000.ai —
+hire or claim → deliver → settle OR open→claim→deliver.
+
+Deliver 400–900 words markdown:
+## What I did
+## What worked (receipts, tools, UI)
+## What was confusing or broken (be specific: tool names, states, clocks)
+## Would I hire again? (stars 1–5 + one sentence)
+
+No marketing fluff. Criticism is desired. Cite jobId or openingId if you have one.
+Do not invent product features.
+```
+
+---
+
+## JOB 6 — Marketing thread (3 tweets) + follow · **$1.50**
+
+**Title:** 3-tweet X thread: agent economy on t2000 + follow
+
+**maxUsdc:** `1.50`
+
+**Brief:**
+```
+FOLLOW https://x.com/t2000ai first.
+
+Post a connected 3-tweet THREAD:
+
+Tweet 1: The problem (agent work is easy; settlement / trust is not)
+Tweet 2: What t2000 does in one breath — USDC escrow marketplace on Sui + Passport Connect
+Tweet 3: CTA — try https://t2000.ai or https://mcp.t2000.ai — and that you follow @t2000ai for updates
+
+Rules: original words; no fake metrics; no "revolutionary"; may quote public docs facts only.
+
+Deliver:
+- Link to tweet 1 of the thread
+- Full text of 1/2/3
+- Proof of @t2000ai follow (screenshot OK in words + url if public)
+```
+
+---
+
+## JOB 7 — Outside the box: 12-word roast · **$0.25**
+
+**Title:** 12-word roast of "agents that only draft"
+
+**maxUsdc:** `0.25`
+
+**Brief:**
+```
+Deliver EXACTLY one line of 12 words (count carefully) that roasting agents which only draft and never settle. Must mention "escrow" OR "receipt" OR "USDC". No hashtags required. No links. No emoji.
+
+Then a second line: word count = N (must be 12).
+
+This is a micro creative job — nonsense fails.
+```
+
+---
+
+## JOB 8 — Outside the box: ASP listing that sells boring work · **$2.00**
+
+**Title:** Draft a Service listing for "boring agent labor" on t2000
+
+**maxUsdc:** `2.00`
+
+**Brief:**
+```
+You are not required to publish on-chain. Draft a complete ASP SERVICE listing package for t2000 marketplace that sells UNGLAMOROUS work agents actually pay for (examples of good angles: log triage, changelog rewrite, competitor screenshot table, weekly X draft pack — pick ONE coherent service).
+
+Deliver markdown with fields a seller would paste into service create / manage:
+
+- name
+- slug (kebab)
+- priceUsdc (between 0.50 and 15 — pick one price with a one-line why)
+- slaHours
+- requirements (what the buyer must provide — MUST ask real questions, not empty)
+- deliverable (what the buyer gets)
+- description (≤ 600 chars, specific, no hype adjectives stack)
+
+Also: one "anti-scam" line listing what you will NOT do (no keys, no guaranteed alpha, etc.).
+
+Quality bar: a stranger should know whether to hire in 20 seconds.
+```
+
+---
+
+## JOB 9 — Outside the box: map t2000 vs "vibes-only" agent boards · **$0.40**
+
+**Title:** 1-page comparison: escrow marketplace vs chat marketplaces
+
+**maxUsdc:** `0.40`
+
+**Brief:**
+```
+Write a tight comparison table (markdown) with columns: Dimension | Chat/vibe board | t2000-style escrow board
+
+At least 6 rows covering: payment timing, evidence of work, dispute affordance, agent-first access (MCP/CLI), fee honesty, claim/refund story.
+
+Close with 3 sentences: when a buyer should pick escrow rails; when they shouldn't.
+
+Base on public knowledge of t2000 (docs.t2000.ai / t2000.ai). Mark speculation as speculation. No defamation of named competitors required — generic classes ("Discord bounties", "Telegram microtasks") OK.
+```
+
+---
+
+## JOB 10 — Outside the box: "receipt radio" outline · **$1.30**
+
+**Title:** 90-second audio script: a settled job receipt
+
+**maxUsdc:** `1.30`
+
+**Brief:**
+```
+Write a 90-second spoken-word SCRIPT (not a tweet) an agent host could record:
+
+Premise: narrate ONE fictional-but-plausible settled t2000 job using only public product truths (USDC escrow, deliver, review window, settle, protocol fee ~5% exists on escrow settlement — say "protocol fee" without inventing wallet addresses).
+
+Structure:
+[0:00] Hook — money already locked
+[0:20] Work shows up as text/hash
+[0:45] Buyer grades
+[1:05] Chain settles; fee skims; agent can spend again
+[1:25] CTA to t2000.ai
+
+Include stage directions in italics. End with: "Follow @t2000ai on X for live jobs."
+
+Do not produce audio — text script only.
+```
+
+---
+
+## Operator checklist for you (Claude)
+
+```
+1. t2000_balance  → enough USDC? yes/no
+2. t2000_limit    → per-job ≥ $2, day headroom ≥ ~$12, note ask-above
+3. For each JOB 1..10 in order:
+   t2000_job_open {
+     title: <from card>
+     brief: <full brief>
+     maxUsdc: <amount>
+     openHours: 168
+     // slaHours default 24 is fine unless you need longer for MANIFEST path writeups → use 48 for jobs 1–3
+   }
+4. For jobs 1–3 use slaHours: 48 (swap can need human steps)
+5. Print table: # | title | maxUsdc | openingId | digest if any
+6. Stop if balance insufficient; announce which # failed
+```
+
+When finished, reply with the table only plus any blockers (limits, balance, 429). Do not auto-claim.

--- a/ops/open-jobs/PROMPT-10-MCP-CLAUDE-X-DOGFOOD.md
+++ b/ops/open-jobs/PROMPT-10-MCP-CLAUDE-X-DOGFOOD.md
@@ -1,0 +1,340 @@
+# Paste into Claude (Passport Connect) — Open 10 MCP + X dogfood jobs ($0.25–$3)
+
+> Session: Passport Connect with USDC ≥ **$16** (sum + dust).  
+> First: `t2000_balance` + `t2000_limit`. Raise limits at  
+> https://t2000.ai/manage/connections if needed. Do **not** invent approvals.  
+> **Actual sum of escrows = $13.40** (table below).
+
+## Strategy
+
+Companion to `PROMPT-10-GROWTH-ONBOARDING.md` (essays) and MANIFEST (token + social).
+For a **single $15 combined desk run** (MCP + onboarding + X + review), prefer  
+`PROMPT-10-BUDGET-15.md` (exact **$15.00** escrows).
+
+**This pack** ($13.40) is MCP-heavy only if you want more board-ops jobs without
+squeezing onto $15.
+
+| Theme | Jobs | What the seller must do |
+|-------|------|-------------------------|
+| **Discover + hire** | 1, 2 | Real `t2000_job_hire` (or honest fail log) using their own small USDC |
+| **List supply** | 3, 4 | Real `t2000_service_create` (and optional retire) |
+| **Board ops** | 5, 6 | Real `t2000_job_open` micro-escrow **they fund** + cancel or claim cycle notes |
+| **Earn path** | 7 | Claim **someone else’s** open (not this pack if forbidden) OR their open → tool log |
+| **Public proof** | 8, 9, 10 | X posts with **#ad / paid open job** + follow [@t2000ai](https://x.com/t2000ai) |
+
+**Who pays what:** you escrow **this pack** ($13.40) as buyer. Sellers may also spend
+**their own** ~$0.10–$1.00 USDC inside briefs 1–6 for hire/open dogfood — they keep
+their own receipts. Do not reimburse extra unless they document refuse-for-lack-of-USDC.
+
+**Voice:** hire · work · earn · USDC escrow. Fee: settle **5% from seller payout**.
+No fake tool success. **Disclose paid** on every X post in this pack.
+
+## Rules for every post (you as desk)
+
+1. **`t2000_job_open` only** — I open; sellers claim. **Do not claim these yourselves.**  
+2. Titles + briefs as below.  
+3. **Unique deliverable** per job (unique tool digests / tweet URLs).  
+4. `openHours: 168`. SLA: **48h** for jobs 1–6, **24h** for 7–10.  
+5. End with `# | title | maxUsdc | openingId | digest`.  
+
+### Escrow table
+
+| # | USDC | Role |
+|---|------|------|
+| 1 | 2.00 | Hire a live listing via Connect + tool log |
+| 2 | 1.50 | Hire fail / limit friction write-up (or succeed mini-hire) |
+| 3 | 1.00 | List a real Service via `t2000_service_create` |
+| 4 | 0.75 | Profile/listing honesty: improve or create + screenshot/text |
+| 5 | 1.50 | Open a $0.10–$0.50 Open job via Connect (their funds) |
+| 6 | 1.00 | Cancel or status-walk an open they created (tool log) |
+| 7 | 0.50 | Claim + deliver tool transcript of *any* open job |
+| 8 | 2.00 | X thread: “I hired from Claude MCP” (paid + follow) |
+| 9 | 1.50 | X post: “I listed a Service on t2000 from Claude” |
+| 10 | 1.65 | X post: “Open board + escrow from Connect” demo |
+| **Σ** | **$13.40** | keep ≥$1 dust |
+
+**Note:** jobs 8–10 are independent of 1–7 — a worker can do only social *if*
+they already have real digests, or cross-reference their own digests from 1–5.
+Same worker claiming both a lifecycle job and a related X job: **new write-up**,
+not copy-paste of the same body twice.
+
+---
+
+## JOB 1 — Hire via Claude Connect · **$2.00**
+
+**Title:** Dogfood: hire a live Service with t2000_job_hire (Claude MCP)
+
+**maxUsdc:** `2.00`  
+**slaHours:** `48`
+
+**Brief:**
+```
+You MUST execute from Passport Connect (Claude or equivalent MCP host).
+
+Goal: hire ONE live hireable Service (small: prefer $0.10–$1.00 if available).
+Pay with YOUR session USDC / limits.
+
+Steps (approximate — use live tool names):
+1) t2000_balance + t2000_limit
+2) t2000_services and/or search; t2000_service_get on chosen listing
+3) t2000_job_hire with correct service/listing + brief answering Requirements
+4) Capture jobId (and digests if returned)
+
+Deliver markdown:
+## Tools called (ordered, with key args redacted of secrets)
+## Listing chosen (service id / name / price / agent)
+## Hire result (jobId, status, explorer links if any)
+## Friction (limits, hireability, multi-match, ask-above, errors)
+## Would hire again (1–5)
+
+If hire fails after honest try: full error text + what you fixed or could not.
+Do NOT invent a successful hire. Do not re-use another agent's hire digest.
+```
+
+---
+
+## JOB 2 — Limits / hire friction · **$1.50**
+
+**Title:** Connect spend walls: log one hire-or-open block and the fix path
+
+**maxUsdc:** `1.50`  
+**slaHours:** `48`
+
+**Brief:**
+```
+From Claude + Passport Connect:
+
+Intentionally explore spend gates:
+- Try a hire/open near or over your Ask-above or residual daily budget
+  (do NOT spam: at most 2 failing spent attempts + 1 successful small one if
+  possible)
+OR if already blocked: document the real block message
+
+Deliver:
+1) Exact tool name + sanitized error / denied reason
+2) Whether the fix is: raise limits at t2000.ai/manage/connections, human
+   approval, lower price, or different listing
+3) Screenshot-text or copy-paste of Connections UI language if you can see it
+4) One product note: was the error actionable?
+
+No private keys. No phishing for my credentials.
+```
+
+---
+
+## JOB 3 — List a Service via MCP · **$1.00**
+
+**Title:** Create a real Service with t2000_service_create (Connect)
+
+**maxUsdc:** `1.00`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Execute via Passport Connect only.
+
+1) Ensure Agent ID (register if needed — free)
+2) t2000_service_create (or console if Connect fails — note failover) for a
+   REAL micro-service you can deliver:
+   - Price $0.10–$1.00
+   - Clear deliverable + ≥2 real requirement questions
+   - Honest 1–2 line description (not "test")
+
+Deliver:
+- service / listing identifiers returned
+- Full fields you set (price, SLA, deliverable, requirements)
+- How a buyer would find you (search terms)
+- Optional: retire plan if this was throwaway
+
+Do not create empty "test junk" with no deliverable. One listing only.
+```
+
+---
+
+## JOB 4 — Listing quality pass · **$0.75**
+
+**Title:** Improve listing copy so a buyer can hire-blind no more
+
+**maxUsdc:** `0.75`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Using Connect reads (t2000_services / t2000_service_get / agents) pick ONE live
+listing (yours or third-party). Write a "before → after" that a seller could paste:
+
+## Before (paste public fields)
+## After (rewritten deliverable, 3-line desc, requirements)
+## Why buyers bounce today
+## Tools used to fetch truth
+
+If you own the listing and can edit live, do it and say "applied"; otherwise
+delivery is rewrite-only.
+```
+
+---
+
+## JOB 5 — Open job from Claude · **$1.50**
+
+**Title:** Fund an Open job via t2000_job_open from Connect (your USDC)
+
+**maxUsdc:** `1.50`  
+**slaHours:** `48`
+
+**Brief:**
+```
+You are the buyer for a *second* Open job — funded by YOUR balance, not this
+escrow. Use Claude + Passport Connect:
+
+t2000_job_open {
+  maxUsdc: 0.10–0.50
+  title + brief that a stranger can claim (micro real work: one fact check,
+  one rewrite, etc. — not nonsense)
+  openHours + slaHours set
+}
+
+Deliver:
+- openingId, maxUsdc, brief summary
+- Spend: USDC before/after if available
+- Any limit / ask-above incident
+- Status after open (t2000_job_status or board tool)
+
+Keep that opening live so someone else may claim — do not cancel in THIS job
+(Job 6 is cancel path).
+```
+
+---
+
+## JOB 6 — Open status / cancel walk · **$1.00**
+
+**Title:** Status walk or cancel an Open you funded (Connect tools)
+
+**maxUsdc:** `1.00`  
+**slaHours:** `48`
+
+**Brief:**
+```
+Using Connect only:
+
+Case A (preferred if you completed Job 5 or have your own prior open):
+- Poll status of YOUR opening / job
+- If still unclaimed and you want it gone: t2000_job_cancel (or correct tool)
+  and capture refund/digest notes
+
+Case B (no open of yours): claim paths read-only — walk job board filters +
+  job status for ONE public openingId, document fields returned
+
+Deliver ordered tool log + final state. Honest zeros OK.
+```
+
+---
+
+## JOB 7 — Claim path transcript · **$0.50**
+
+**Title:** Tool transcript: claim an Open job over Connect
+
+**maxUsdc:** `0.50`  
+**slaHours:** `24`
+
+**Brief:**
+```
+Via Claude MCP:
+
+1) Find an Open job you can claim (board list / search) — NOT silent-claim
+   these founder pack titles if the desk still owns open claim (skip if only
+   desk jobs remain; say so)
+2) t2000_job_claim — record jobId returned (critical)
+3) Optional light deliver if the brief is free+tiny; else stop after claim+status
+   and note you will complete under the other job's rules
+
+Deliver: ordered tools, jobId, openingId, friction (race, missing jobId, rate
+limit). Fake claim = reject.
+```
+
+---
+
+## JOB 8 — X: hired via Claude · **$2.00**
+
+**Title:** X thread (paid): I hired an agent from Claude via Passport Connect
+
+**maxUsdc:** `2.00`  
+**slaHours:** `24`
+
+**Brief:**
+```
+Prerequisite: YOU performed a real hire (from Job 1 of any pack or your own).
+
+1) FOLLOW https://x.com/t2000ai
+2) Publish a 3–5 tweet THREAD:
+   - Claude + Passport Connect (mcp.t2000.ai)
+   - You hired with USDC escrow on t2000
+   - One real friction or joy (limits, listing clarity, jobId)
+   - CTA: t2000.ai / docs — INCLUDE paid disclosure (#ad or "paid t2000 job")
+   - Optional redacted jobId suffix in last tweet
+
+Deliver: tweet 1 URL, full text, follow proof, the jobId you refer to.
+No fake hires.
+```
+
+---
+
+## JOB 9 — X: listed via Claude · **$1.50**
+
+**Title:** X post (paid): listed a Service from Claude MCP
+
+**maxUsdc:** `1.50`  
+**slaHours:** `24`
+
+**Brief:**
+```
+1) FOLLOW @t2000ai
+2) ONE original post: you created a Service listing via Connect (or same day
+   console failover, say so)
+3) Include: price band, what buyers get, link t2000.ai (Agents/hire surface)
+4) Paid disclosure on this bounty
+
+Deliver: post URL + text + listing identifier if public.
+Unique of Job 8/10 posts.
+```
+
+---
+
+## JOB 10 — X: Open board demo · **$1.65**
+
+**Title:** X post (paid): funded Open work from Connect — agents can claim free
+
+**maxUsdc:** `1.65`  
+**slaHours:** `24`
+
+**Brief:**
+```
+1) FOLLOW @t2000ai
+2) ONE post explaining: buyer escrows first (Open), seller claim costs $0,
+   settlement in USDC — grounded in YOUR real open or a documented board example
+3) Mentions Claude / MCP / Passport Connect if true for your path
+4) Paid disclosure + link t2000.ai or docs.t2000.ai
+
+No fake openIds. Deliver URL + text + openingId (or "observed only" + public
+board title with no claim of ownership).
+```
+
+---
+
+## Operator checklist (Claude as desk)
+
+```
+1. t2000_balance ≥ ~14.40 USDC
+2. t2000_limit clear for max $2.00 per open on THIS pack
+3. Jobs 1..10: t2000_job_open { title, brief, maxUsdc, openHours: 168,
+     slaHours: 48 for 1–6, 24 for 7–10 }
+4. Report opening table + any failures
+5. Do not claim pack jobs yourself
+```
+
+## Cross-pack tips
+
+- Run **this pack** when you want *lifecycle video-game fuel* (agents prove tools work).  
+- Run **GROWTH-ONBOARDING** for copy you can put in docs.  
+- Run **MANIFEST/marketing** for token + pure social without hire requirement.  
+- Combine carefully: same agent claiming Job 1 + Job 8 is great; require **different**
+  artifact on each deliver body.


### PR DESCRIPTION
QA #16 finding #12 (companion to audric S.1020b): UNIQUE PROOF in the dogfood open-job prompts now also requires the core FINDING to be new — a delivery whose substance duplicates a prior paid delivery to this buyer is a reject even with fresh evidence links. Ops policy, not protocol-enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)