### PR TITLE
✨ feat(docs,skills): machine front door — skills feed.json + ship gate (S.1024)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -14,9 +14,17 @@ apply to this slice. Don't silently skip.
 - [ ] CLI command + tests (`packages/cli/src/commands/`)
 - [ ] MCP tool + tests (Connect — `audric/apps/mcp/lib/tools.ts`)
 - [ ] Agent Skill (`t2000-skills/skills/`) — only on lifecycle/policy/money-rule changes; never for Connect card/`next` polish (tools/list is the inventory SSOT)
-- [ ] Mintlify docs (`apps/docs/*.mdx`) — auto-deploys to developers.t2000.ai
+- [ ] Mintlify docs (`apps/docs/*.mdx`) — auto-deploys to docs.t2000.ai
 - [ ] Root `README.md`
 - [ ] Package `README.md`s
+- [ ] **Machine front door** — if this slice changed a *machine contract*
+      (public `api.t2000.ai/v1/*` paths/shapes agents rely on · CLI
+      marketplace/wallet verbs agents are told to run · Connect auth model or
+      connector URL · discovery URLs · who can sign · earn-first/fee/
+      open-reject locks), update `audric/apps/console/app/llms.txt/route.ts`
+      and confirm every URL it cites returns non-5xx. UI polish/copy nits
+      don't fire the gate — write N/A. Depth:
+      `.claude/skills/t2000-machine-front-door/SKILL.md`
 - [ ] Version bump + build all packages (`/release`)
 
 Tests live **inline next to source** (`Foo.ts` + `Foo.test.ts`) — never add a new
@@ -24,7 +32,7 @@ Tests live **inline next to source** (`Foo.ts` + `Foo.test.ts`) — never add a 
 
 ## Docs cadence — two tiers, not "dump as you go"
 
-- **Per-slice (now):** keep developers.t2000.ai *factually correct* only — version,
+- **Per-slice (now):** keep docs.t2000.ai *factually correct* only — version,
   command surface, behavior (limits-on, no-charge-on-failure). Cheap; prevents the
   staleness class.
 - **Per-phase (later):** a dedicated structured-docs task turning the phase's specs
@@ -49,7 +57,7 @@ Cross-check before writing, and prefer linking the live endpoint over duplicatin
 ## Positioning capture
 
 - [ ] Append the slice's feature + proof point to `SITE_REPOSITIONING_BRIEF.md` §6
-- [ ] Land the developers.t2000.ai factual delta if the dev-facing contract changed
+- [ ] Land the docs.t2000.ai factual delta if the dev-facing contract changed
 
 ## Then
 

--- a/.claude/skills/t2000-machine-front-door/SKILL.md
+++ b/.claude/skills/t2000-machine-front-door/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: t2000-machine-front-door
+description: >-
+  The machine front door — t2000.ai/llms.txt (the apex machine playbook) and
+  the agent-skills well-known manifest. Use when editing llms.txt or any
+  .well-known/discovery surface, writing agent-facing discovery copy, or
+  shipping a slice that changes a machine contract (public api.t2000.ai/v1
+  paths, CLI marketplace/wallet verbs, Connect auth model or connector URL,
+  discovery URLs, who can sign, earn-first/fee/open-reject locks).
+license: Proprietary
+metadata:
+  author: t2000
+  version: "1.0"
+  requires: none
+---
+
+# Machine front door
+
+`https://t2000.ai/llms.txt` is how autonomous agents learn the marketplace.
+It is a **hand-authored short playbook**, not generated docs.
+
+## One SSOT
+
+- The apex playbook lives at `audric/apps/console/app/llms.txt/route.ts` →
+  serves `t2000.ai/llms.txt`. **Never create a second machine-playbook SSOT**
+  — when the machine contract changes, edit that file.
+- `docs.t2000.ai/llms.txt` is Mintlify's **doc index** — a different job.
+  Link it from More; do not merge the two.
+- The skills shelf enumerator is `t2000-skills/feed.json` (raw GitHub can't
+  list a directory). `t2000-skills/validate.ts` fails CI when feed.json and
+  `skills/*/SKILL.md` drift in either direction — edit both together.
+
+## The gate (when to update llms.txt)
+
+Update ONLY when any of these change:
+
+- public `api.t2000.ai/v1/*` path / response contract agents rely on
+- CLI marketplace / wallet verbs agents are told to run
+- Connect auth model (Passport vs local key) or connector URL
+- discovery URLs (skills manifest, AGENTS.md, well-known)
+- who can sign (CLI keypair · SDK · prepare/submit · Connect Passport)
+- earn-first / fee / open-reject product locks agents must not misread
+
+**Skip** for pure UI polish, copy nits, manage chrome, Connect card layout.
+
+## Facts that must stay true in the playbook
+
+- **Connect ≠ BYO local key.** Hosted MCP (`mcp.t2000.ai/mcp`) always signs
+  as the Passport (Google/zkLogin) wallet — it does NOT accept an arbitrary
+  local private key. Local Ed25519 keys belong to the CLI, `@t2000/sdk`
+  (`T2000.init` / `fromPrivateKey`), and the sponsored
+  prepare → sign → submit HTTP path.
+- Cite only **live** endpoints. Agent refs (`#163` / numeric / `@handle`)
+  resolve via MCP `t2000_agents` or the CLI — there is no public GET for
+  them (`/v1/agents/{numericId}` is 404; only the full `0x…` works).
+- No Connect dollar defaults in llms.txt — they drift; the SSOT is
+  `audric/packages/accounts/src/connect-defaults.ts`.
+
+## Verify
+
+```bash
+curl -sS https://t2000.ai/llms.txt | head -n 5
+curl -sS -o /tmp/m.json -w '%{http_code}\n' \
+  https://t2000.ai/.well-known/agent-skills/index.json   # expect 200, ≥1 skill
+npx tsx t2000-skills/validate.ts                          # feed ↔ dirs in sync
+# every URL the playbook cites must return non-5xx
+```

--- a/.cursor/rules/machine-front-door.mdc
+++ b/.cursor/rules/machine-front-door.mdc
@@ -1,0 +1,22 @@
+---
+description: Machine front door — t2000.ai/llms.txt is the ONE hand-authored machine playbook and the skills well-known manifest is fed by t2000-skills/feed.json; update on machine-contract changes only (API paths, CLI verbs, Connect auth, discovery URLs, signing paths, product locks). Full rule in .claude/skills/t2000-machine-front-door/.
+alwaysApply: false
+---
+
+# Machine Front Door → `.claude/skills/t2000-machine-front-door/SKILL.md`
+
+**The invariant:** `t2000.ai/llms.txt` (served from
+`audric/apps/console/app/llms.txt/route.ts`) is the single machine playbook —
+never create a second SSOT. Update it only when a machine contract changes
+(public `api.t2000.ai/v1/*` shapes, CLI marketplace/wallet verbs, Connect auth
+model or connector URL, discovery URLs, who can sign, earn-first/fee/open-reject
+locks) — never for UI polish. Connect always signs as Passport, never a local
+key. The skills manifest enumerates from `t2000-skills/feed.json`, gated by
+`validate.ts` in CI.
+
+**Read the full rule before editing llms.txt, well-known routes, or
+agent-discovery copy:** `.claude/skills/t2000-machine-front-door/SKILL.md` —
+gate list, facts that must stay true, verify curls.
+
+*(Pointer only — do not re-inline the content here; same pattern as
+env-validation-gate.mdc so Cursor and Claude Code cannot drift.)*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
       - run: pnpm --filter @t2000/sdk lint
       - run: pnpm --filter @t2000/cli lint
       - run: pnpm --filter @t2000/serve lint
+      # Skills shelf gate (S.1024): frontmatter + the feed.json ↔ skills/
+      # two-way sync — the apex well-known manifest reads feed.json, so
+      # drift here breaks t2000.ai/.well-known/agent-skills/index.json.
+      - run: npx tsx t2000-skills/validate.ts
 
   test:
     name: Unit Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ speculatively):
 | `t2000-financial-amounts` | Floor-never-round, per-token precision, the canonical token registry |
 | `t2000-sui-platform` | Address Balances (SIP-58) concurrency + gasless-transfer eligibility gotchas |
 | `t2000-design-system` | Copy-in tokens, per-app shadcn, house near-black theme |
+| `t2000-machine-front-door` | t2000.ai/llms.txt one-SSOT playbook, skills feed.json manifest, the ship-gate list, Connect≠local-key |
 
 **Vendored Sui skills** (10 of 20 from `MystenLabs/skills`, installed 2026-07-24 —
 `accessing-data` · `sui-sdks` · `ptbs` · `sui-object-model` · `sui-move` ·
@@ -431,6 +432,7 @@ When shipping a feature, update these files:
 - [ ] Package READMEs (`packages/*/README.md`)
 - [ ] Version bump + build all packages
 - [ ] **Feature/benefit capture** — append the slice's feature + proof point to `SITE_REPOSITIONING_BRIEF.md` §6 (positioning SSOT), and land the `docs.t2000.ai` factual delta when the dev-facing contract changed (CLI/SDK/MCP surface, version, or behavior)
+- [ ] **Machine front door** — if the slice changed a *machine contract* (public `api.t2000.ai/v1/*` paths/shapes agents rely on · CLI marketplace/wallet verbs agents are told to run · Connect auth model or connector URL · discovery URLs (skills manifest, AGENTS.md, well-known) · who can sign (CLI keypair · SDK · prepare/submit · Connect Passport) · earn-first/fee/open-reject locks), update the ONE apex playbook `audric/apps/console/app/llms.txt/route.ts` and confirm every URL it cites returns non-5xx. Pure UI polish / copy nits / manage chrome do NOT fire the gate — write N/A. Never create a second machine-playbook SSOT. Depth: `.claude/skills/t2000-machine-front-door/SKILL.md`
 
 **Docs cadence (two tiers, not "dump as you go"):**
 - **Per-slice** — keep `docs.t2000.ai` *factually correct* only (version, command surface, behavior like limits-on / no-charge-on-failure). Cheap; prevents the staleness class.

--- a/apps/docs/fees-and-limits.mdx
+++ b/apps/docs/fees-and-limits.mdx
@@ -31,8 +31,9 @@ rails of $0.01–$100.
   show / set / reset`; `--force` overrides one call. Setting limits is
   CLI-only — agents can read the leash, never lengthen it.
 - **Passport Connect:** three numbers per session — **per job**, **daily**,
-  and **ask above** (pauses for approval). **New-session defaults:** $20 per
-  job · $1000 per day · ask above $5. Revoke stops new spends immediately;
+  and **ask above** (refuses with a link to the limits editor — no one-shot
+  approve). **New-session defaults:** $50 per job · $1000 per day · ask above
+  $100; existing sessions keep their minted limits. Revoke stops new spends immediately;
   sessions expire within 7 days.
   [Details →](/passport-connect)
 - **Console:** the same Connect limits are managed in the browser at

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -103,12 +103,14 @@ to deliver, deliveries awaiting settle) with due labels and full jobIds.
 ## Limits, approvals, revoke
 
 Three numbers, set when you connect (product defaults for **new** sessions:
-**$20 per job · $1000 per day · ask above $5**) and changeable under **Connections**:
+**$50 per job · $1000 per day · ask above $100** — existing sessions keep the
+limits they were minted with) and changeable under **Connections**:
 
 - **Per job** — a single spend above this is refused outright.
 - **Daily** — rolling 24h ceiling across the session.
-- **Ask above** — spends at or above this **pause** and email you. Nothing moves
-  until you approve in the console; ignore it and the request lapses.
+- **Ask above** — spends at or above this are **refused** with a link to the
+  limits editor; raise the threshold under Connections and retry. There is no
+  one-shot approve.
 
 <Note>
   Limits are **read-only** from the agent's side (`t2000_limit`). An agent can

--- a/t2000-skills/feed.json
+++ b/t2000-skills/feed.json
@@ -1,0 +1,24 @@
+{
+  "$comment": "The skills shelf enumerator (S.1024). Raw GitHub cannot list a directory, so the apex well-known route (t2000.ai/.well-known/agent-skills/index.json, served by audric apps/console lib/skills.ts listSkillSlugs) reads THIS file to know which skills/<slug>/SKILL.md exist. validate.ts fails CI when this list and the skills/ directory drift in either direction — edit both together.",
+  "projects": [
+    {
+      "name": "t2000-skills",
+      "skills": [
+        { "slug": "deepbook" },
+        { "slug": "sui-grpc" },
+        { "slug": "sui-move-security" },
+        { "slug": "suins" },
+        { "slug": "t2000-check-balance" },
+        { "slug": "t2000-connect" },
+        { "slug": "t2000-job" },
+        { "slug": "t2000-pay" },
+        { "slug": "t2000-receive" },
+        { "slug": "t2000-send" },
+        { "slug": "t2000-services" },
+        { "slug": "t2000-setup" },
+        { "slug": "t2000-swap" },
+        { "slug": "walrus" }
+      ]
+    }
+  ]
+}

--- a/t2000-skills/validate.ts
+++ b/t2000-skills/validate.ts
@@ -185,28 +185,35 @@ function main() {
     }
   }
 
-  // v4 Agent Wallet skill set (post-S.336 pivot — the v3 DeFi skills
-  // save/withdraw/borrow/repay were removed). Keep in sync when adding
-  // or removing a skill directory.
-  const expectedSkills = [
-    'deepbook',
-    'sui-grpc',
-    'suins',
-    't2000-check-balance',
-    't2000-connect',
-    't2000-pay',
-    't2000-receive',
-    't2000-send',
-    't2000-services',
-    't2000-setup',
-    't2000-swap',
-    'walrus',
-  ];
-
-  const missing = expectedSkills.filter(s => !skillDirs.includes(s));
-  if (missing.length > 0) {
-    for (const m of missing) {
-      console.error(`  ✗ ${m} → [missing] Expected skill directory not found`);
+  // feed.json ↔ skills/ two-way sync (S.1024). feed.json is the shelf
+  // ENUMERATOR: the apex well-known manifest (t2000.ai/.well-known/
+  // agent-skills/index.json) reads it over raw GitHub because raw GitHub
+  // cannot list a directory. Drift in either direction silently breaks the
+  // machine front door, so both directions fail here. This replaced the
+  // old hand-maintained expectedSkills list — feed.json IS the list now.
+  const feedPath = resolve(scriptDir, 'feed.json');
+  if (!existsSync(feedPath)) {
+    console.error('  ✗ feed.json → [missing] Shelf enumerator not found (the apex skills manifest 500s without it)');
+    totalErrors++;
+  } else {
+    let feedSlugs: string[] = [];
+    try {
+      const feed = JSON.parse(readFileSync(feedPath, 'utf-8')) as {
+        projects?: { skills?: { slug?: string }[] }[];
+      };
+      feedSlugs = (feed.projects ?? []).flatMap(p =>
+        (p.skills ?? []).map(s => s.slug).filter((s): s is string => Boolean(s))
+      );
+    } catch {
+      console.error('  ✗ feed.json → [parse] Not valid JSON');
+      totalErrors++;
+    }
+    for (const dir of skillDirs.filter(d => !feedSlugs.includes(d))) {
+      console.error(`  ✗ ${dir} → [feed] skills/${dir}/SKILL.md exists but feed.json does not list it`);
+      totalErrors++;
+    }
+    for (const slug of feedSlugs.filter(s => !skillDirs.includes(s))) {
+      console.error(`  ✗ ${slug} → [feed] feed.json lists it but skills/${slug}/SKILL.md does not exist`);
       totalErrors++;
     }
   }


### PR DESCRIPTION
## S.1024 — machine front door (t2000 half)

**A (P0):** `t2000-skills/feed.json` — the shelf enumerator the apex well-known route reads (fixes the 500 `manifest_unavailable` at t2000.ai/.well-known/agent-skills/index.json). All 14 slugs. `validate.ts` now enforces feed↔dirs sync BOTH directions (replaces the stale hand-list that was missing sui-move-security + t2000-job) and runs in CI (`ci.yml`). Break-tested: removing a slug or citing a ghost slug each fail the run.

**C:** Ship-gate rule — CLAUDE.md Ship Checklist + `/ship` get the Machine-front-door checkbox (gate list per slice lock 3; N/A when it doesn't fire); new `.claude/skills/t2000-machine-front-door/SKILL.md` (one-SSOT, gate list, Connect≠local-key, verify curls); `.cursor/rules/machine-front-door.mdc` as a pointer (env-gate pattern, alwaysApply:false). Also fixed stale `developers.t2000.ai` → `docs.t2000.ai` in ship.md.

**D:** Mintlify Connect defaults → $50/$1000/$100 (S.1022; existing sessions keep minted limits) in passport-connect + fees-and-limits — and corrected the drifted ask-above copy (it REFUSES with a limits-editor link since S.976; the pause-and-approve it described no longer exists).

Companion audric PR carries the llms.txt body. Founder merges both; apex manifest goes green once this hits main (console reads feed.json over raw GitHub).

Verify: `npx tsx t2000-skills/validate.ts` → 14 skills, 0 errors.