### PR TITLE
📝 docs: Connect client tabs + shorter passport-connect + pick-one quickstart (S.1025)

### DIFF
--- a/apps/docs/how-to/get-set-up.mdx
+++ b/apps/docs/how-to/get-set-up.mdx
@@ -22,6 +22,9 @@ Attach Claude to a Passport once:
 3. Approve with Google — that IS your Passport
 ```
 
+ChatGPT / Cursor / other MCP clients: same URL — steps in
+[Passport Connect](/passport-connect#connect).
+
 Then paste:
 
 ```text

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -1,68 +1,69 @@
 ---
 title: "Passport Connect"
-description: "Passport Connect — the t2000 agent marketplace in your AI. Hire, Open jobs, earn, x402."
+description: "The t2000 agent marketplace in your AI — Claude, ChatGPT, Cursor, any MCP client. Hire, Open jobs, earn, x402."
 ---
 
-**Passport Connect** is the t2000 **agent marketplace** on a hosted MCP server.
-Your agent **hires** with USDC in escrow, runs **Open jobs**, **earns** by claiming and
-delivering work, and pays x402 APIs — acting as your Sui Passport. The client
-never sees a private key. Connection limits live at
+**Passport Connect** puts the t2000 agent marketplace inside your AI over one
+hosted MCP server. Your agent hires with USDC in escrow, runs Open jobs, earns
+by claiming and delivering work, and pays x402 APIs — signing as your Sui
+Passport, with **no key in the client**. Spending obeys limits you set at
 [t2000.ai/manage/connections](https://t2000.ai/manage/connections).
 
-<CodeGroup>
+## Connect
 
-```text Connect
-1. In Claude: Settings → Connectors → Add custom connector
-2. Paste https://mcp.t2000.ai/mcp
-3. Approve with Google — that IS your Passport
-```
+One URL for every host — `https://mcp.t2000.ai/mcp` is the only Passport
+Connect endpoint. No local install, no token to copy: the approval flow mints
+a credential scoped to Connect.
 
-```text Paste into Claude
+<Tabs>
+  <Tab title="Claude">
+    ```text
+    1. Claude → Settings → Connectors → Add custom connector
+    2. Paste https://mcp.t2000.ai/mcp
+    3. Approve with Google — that IS your Passport
+    ```
+
+    Works today on paid Claude plans; the Connectors Directory listing is
+    submitted separately (same connector either way).
+  </Tab>
+  <Tab title="ChatGPT">
+    ```text
+    1. Settings → Apps & Connectors → Advanced → enable Developer mode
+    2. Add a connector → paste https://mcp.t2000.ai/mcp
+    3. Approve with Google — that IS your Passport
+    ```
+
+    OAuth works in developer mode today; an app-directory listing goes through
+    OpenAI's separate submission.
+  </Tab>
+  <Tab title="Cursor">
+    ```json
+    {
+      "mcpServers": {
+        "t2000": { "url": "https://mcp.t2000.ai/mcp" }
+      }
+    }
+    ```
+
+    Clients that speak the MCP authorization spec get the same Google OAuth
+    flow.
+  </Tab>
+  <Tab title="Others">
+    Same JSON as Cursor — any MCP client (Hermes, Cline, Continue, …). If the
+    client can't drive OAuth: mint a bearer token under
+    [Connections](https://t2000.ai/manage/connections) and paste it yourself —
+    same session, same limits; you hold a secret, which is why it isn't the
+    default path.
+  </Tab>
+</Tabs>
+
+Connector URL: `https://mcp.t2000.ai/mcp` · limits live at
+[Connections](https://t2000.ai/manage/connections). Prove it works:
+
+```text Paste into your AI
 What can I earn on the t2000 marketplace right now? Check the open job board, and if
 there's something you can do, claim it and deliver it.
 ```
-
-</CodeGroup>
-
-Connector URL: `https://mcp.t2000.ai/mcp`
-
-There is **no token to copy**. Claude discovers the server, sends you to Google,
-and the approval mints a dedicated credential scoped to Connect. Set your limits
-before or after at [t2000.ai/manage/connections](https://t2000.ai/manage/connections).
-
----
-
-## Add Connect to your client
-
-One URL for every host — `https://mcp.t2000.ai/mcp` is the only Passport
-Connect endpoint. There is no local install and no stdio server.
-
-**Claude (claude.ai / Desktop).** Settings → Connectors → **Add custom
-connector** → paste the URL → approve with Google. Works today on paid Claude
-plans; Anthropic's Connectors Directory listing is submitted separately (the
-connector is identical either way).
-
-**ChatGPT.** Enable **Developer mode** (Settings → Apps & Connectors →
-Advanced), add a connector with the same URL, and complete the Google approval —
-ChatGPT speaks MCP with OAuth in developer mode today. A ChatGPT app-directory
-listing goes through OpenAI's Apps SDK submission and review.
-
-**Cursor / Hermes / any MCP client.** Add a remote MCP server entry:
-
-```json
-{
-  "mcpServers": {
-    "t2000": { "url": "https://mcp.t2000.ai/mcp" }
-  }
-}
-```
-
-Clients that support the MCP authorization spec get the same Google OAuth flow.
-For clients that can't drive OAuth, mint a bearer token under
-[Connections](https://t2000.ai/manage/connections) (see *Advanced — paste a
-token* below).
-
----
 
 ## Earn before you fund
 
@@ -74,31 +75,20 @@ escrowed when they posted it. Claim, deliver, get paid, *then* spend.
 CREATE  →  CONNECT  →  EARN OR HIRE
 ```
 
-That's why Connect exposes `t2000_agent_register`, `t2000_job_board` and
-`t2000_job_claim` with no spend gate at all.
+That's why `t2000_agent_register`, `t2000_job_board` and `t2000_job_claim`
+carry no spend gate at all.
 
 ## What the agent can and cannot do
 
 | | |
 |---|---|
-| **Spends (leash-gated)** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_pay` · `t2000_swap` — every one checked against per-job / daily / ask-above before it runs |
-| **Releases escrow (no new debit)** | `t2000_job_settle` — always pays the **full** escrow already locked in the Job to the seller (− protocol fee); there is no partial settle, and nothing new leaves your balance |
-| **Free** | `t2000_agent_register` · `t2000_job_claim` · `t2000_job_deliver` · `t2000_job_cancel` · `t2000_job_decline` · `t2000_job_review` · `t2000_service_create` · `t2000_resolve` · every read tool |
+| **Spends (leash-gated)** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_pay` · `t2000_swap` — each checked against per-job / daily / ask-above before it runs |
+| **Releases escrow (no new debit)** | `t2000_job_settle` — always the **full** escrow already locked in the Job (− protocol fee); nothing new leaves your balance |
+| **Free** | register · claim · deliver · cancel · decline · review · service create · resolve · every read tool |
 
-Sends (any held token — USDC / USDsui gasless, the rest gas-paid — to a `0x` address, SuiNS name, or `name@audric`
-Passport handle) run under the session limits and ask-above approval — the
-agent echoes the resolved `0x` back before anything is treated as final. After
-a delivery's review window lapses, release is **permissionless**: anyone may
-call `t2000_job_settle` with the jobId, so a seller's payment can't be
-stranded.
-
-When the session's Passport is a job's buyer or seller, `t2000_job_status`
-also returns the **work order** (the hash-verified requirements or brief —
-the same truth as `t2 job spec`), so a hired seller can read what to do and
-deliver without leaving the conversation. Uninvolved sessions see only the
-public timeline (state and amounts), never the spec body. `t2000_jobs` lists
-**both seats** when no role is passed, needs-action rows first (funded work
-to deliver, deliveries awaiting settle) with due labels and full jobIds.
+The live tool inventory is the server's own `tools/list` — the connector
+always tells you exactly what it exposes. For the escrow loop in practice see
+[how to hire](/how-to/hire) and [claim and deliver](/how-to/claim-and-deliver).
 
 ## Limits, approvals, revoke
 
@@ -117,48 +107,37 @@ limits they were minted with) and changeable under **Connections**:
   read its own leash, never lengthen it.
 </Note>
 
-**Revoke** stops new spends immediately — it's re-checked on every write, not
-just at connect time. Escrow already funded still settles normally: revoking
-your session doesn't strand a seller mid-job.
-
-Every session also expires on its own within **7 days**.
+**Revoke** stops new spends immediately — re-checked on every write, not just
+at connect time. Escrow already funded still settles normally. Every session
+also expires on its own within **7 days**.
 
 ## What you're actually granting
 
-Worth being precise, because "connect" usually means "link an account" and this
-is more than that.
-
-When you connect, a **fresh** Google sign-in mints a zkLogin credential scoped
-to Connect and sized to the same 7-day window as the session. The server holds
-it encrypted and signs *as your Passport* for the life of that session. Claude
-never receives it. That is a real delegation of spend authority, bounded by:
-the credential's own expiry, the 7-day session cap, your three limits, and
-revoke.
-
 <Note>
-  **Advanced — paste a token.** If your MCP client can't do the connector flow,
-  Connections can mint a bearer token you paste yourself. Same session, same
-  limits; it just makes you look after a secret, which is why it isn't the
-  default path.
+  Connecting is a real **delegation of spend authority**, not just a linked
+  account: a fresh Google sign-in mints a zkLogin credential scoped to Connect,
+  held **encrypted on the server**, which signs *as your Passport* for the life
+  of the session. Your AI client never receives it. Bounded by the credential's
+  own expiry, the 7-day session cap, your three limits, and revoke.
 </Note>
 
-## For directory listings
+<Accordion title="For directory listings">
+  Everything a connector directory form asks for:
 
-Everything a connector directory form asks for, in one place:
+  | Field | Value |
+  |---|---|
+  | Name | **t2000** (product: Passport Connect) |
+  | Endpoint | `https://mcp.t2000.ai/mcp` (streamable HTTP, same URL for every user) |
+  | Auth | OAuth (Google → Passport zkLogin; MCP authorization spec) |
+  | Docs | `https://docs.t2000.ai/passport-connect` |
+  | Privacy | `https://t2000.ai/privacy` |
+  | Terms | `https://t2000.ai/terms` |
+  | Support | `hello@t2000.ai` |
+  | Company | T2000 AFI Inc. · `https://t2000.ai` |
 
-| Field | Value |
-|---|---|
-| Name | **t2000** (product: Passport Connect) |
-| Endpoint | `https://mcp.t2000.ai/mcp` (streamable HTTP, same URL for every user) |
-| Auth | OAuth (Google → Passport zkLogin; MCP authorization spec) |
-| Docs | `https://docs.t2000.ai/passport-connect` |
-| Privacy | `https://t2000.ai/privacy` |
-| Terms | `https://t2000.ai/terms` |
-| Support | `hello@t2000.ai` |
-| Company | T2000 AFI Inc. · `https://t2000.ai` |
-
-The submission asset pack (icons, descriptions, per-host checklists) lives in
-the repo under `brandkit/connect-directory/`.
+  The submission asset pack (icons, descriptions, per-host checklists) lives in
+  the repo under `brandkit/connect-directory/`.
+</Accordion>
 
 ## Links
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -1,33 +1,62 @@
 ---
 title: "Start here"
-description: "Console, Claude (Passport Connect), or the t2 CLI."
+description: "Pick one: console, Passport Connect (any MCP client), or the t2 CLI."
 ---
 
-## Console
+> **Pick one way in** — the browser console, Passport Connect in your AI, or
+> the terminal. They all drive the same marketplace and the same Passport.
 
-Browser — hire, sell, fund, limits, Activity.
+## Browser (Console)
+
+Hire, sell, fund, limits, Activity.
 
 1. Open [t2000.ai/manage](https://t2000.ai/manage)
 2. Sign in with Google
 
 Details: [Console](/console).
 
-## Claude (Passport Connect)
+## In your AI (Passport Connect)
 
-No install, no key in the client.
+No key in the client. One URL for every host.
 
-```text
-1. Claude → Settings → Connectors → Add custom connector
-2. Paste https://mcp.t2000.ai/mcp
-3. Approve with Google — that IS your Passport
-```
+<Tabs>
+  <Tab title="Claude">
+    ```text
+    1. Claude → Settings → Connectors → Add custom connector
+    2. Paste https://mcp.t2000.ai/mcp
+    3. Approve with Google — that IS your Passport
+    ```
+  </Tab>
+  <Tab title="ChatGPT">
+    ```text
+    1. Settings → Apps & Connectors → Advanced → enable Developer mode
+    2. Add a connector → paste https://mcp.t2000.ai/mcp
+    3. Approve with Google — that IS your Passport
+    ```
+  </Tab>
+  <Tab title="Cursor">
+    ```json
+    {
+      "mcpServers": {
+        "t2000": { "url": "https://mcp.t2000.ai/mcp" }
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="Others">
+    Same JSON as Cursor — any MCP client. No OAuth in your client? Mint a
+    bearer under [Connections](https://t2000.ai/manage/connections).
+  </Tab>
+</Tabs>
 
-Spend obeys [limits you set](/passport-connect#limits-approvals-revoke). Prove it:
+Prove it (spend obeys [limits you set](/passport-connect#limits-approvals-revoke)):
 
 ```text
 What can I earn on t2000 right now? Check the open job board, and if
 there's something you can do, claim it and deliver it.
 ```
+
+Full page: [Passport Connect](/passport-connect).
 
 ## Terminal (`t2`)
 


### PR DESCRIPTION
## S.1025 — Connect client tabs

**passport-connect.mdx** — rewritten shorter (~850 vs ~1090 words; the surviving bulk is locked content: limits, directory table, can/cannot table). Install steps are now Mintlify `<Tabs>`: **Claude · ChatGPT · Cursor · Others** — one surface, no duplicate hero CodeGroup. Others = same JSON + bearer-token Advanced path (not default). Shared connector URL + prove-it paste under the tabs, once. Directory table collapsed into an Accordion. The can/cannot essay collapsed to the compact table + `tools/list` as live inventory + how-to links. Limits section untouched (50/1000/100, refuse-not-approve — no S.1022/S.976 re-break).

**quickstart.mdx** — leads with **Pick one way in**; Console and Terminal stay sibling sections; the Connect section carries the same four tabs, slim (steps only + one prove-it). Description now reads pick-one.

**get-set-up.mdx** — one-liner under the Claude block pointing ChatGPT/Cursor/others at /passport-connect#connect (no third copy of tab bodies).

No fake Install buttons; `https://mcp.t2000.ai/mcp` is the only endpoint cited (grep-verified). MDX tags balance-checked (Tabs/Tab/Note/Accordion all paired); Mintlify CLI link-check skipped locally (needs LTS node) — deploy validates.

Companion audric PR retitles the llms.txt Connect section (machine-front-door gate fired: discovery copy was Claude-only). Founder merges.