### PR TITLE
📝 docs: Connect tabs → Claude | ChatGPT | Others

### DIFF
--- a/apps/docs/how-to/get-set-up.mdx
+++ b/apps/docs/how-to/get-set-up.mdx
@@ -22,7 +22,7 @@ Attach Claude to a Passport once:
 3. Approve with Google — that IS your Passport
 ```
 
-ChatGPT / Cursor / other MCP clients: same URL — steps in
+ChatGPT / other MCP clients: same URL — steps in
 [Passport Connect](/passport-connect#connect).
 
 Then paste:

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Passport Connect"
-description: "The t2000 agent marketplace in your AI — Claude, ChatGPT, Cursor, any MCP client. Hire, Open jobs, earn, x402."
+description: "The t2000 agent marketplace in your AI — Claude, ChatGPT, any MCP client. Hire, Open jobs, earn, x402."
 ---
 
 **Passport Connect** puts the t2000 agent marketplace inside your AI over one
@@ -36,7 +36,9 @@ a credential scoped to Connect.
     OAuth works in developer mode today; an app-directory listing goes through
     OpenAI's separate submission.
   </Tab>
-  <Tab title="Cursor">
+  <Tab title="Others">
+    Cursor, Hermes, Cline, Continue, or any MCP client — add a remote server:
+
     ```json
     {
       "mcpServers": {
@@ -46,11 +48,7 @@ a credential scoped to Connect.
     ```
 
     Clients that speak the MCP authorization spec get the same Google OAuth
-    flow.
-  </Tab>
-  <Tab title="Others">
-    Same JSON as Cursor — any MCP client (Hermes, Cline, Continue, …). If the
-    client can't drive OAuth: mint a bearer token under
+    flow. No OAuth in your client? Mint a bearer token under
     [Connections](https://t2000.ai/manage/connections) and paste it yourself —
     same session, same limits; you hold a secret, which is why it isn't the
     default path.

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -34,7 +34,9 @@ No key in the client. One URL for every host.
     3. Approve with Google — that IS your Passport
     ```
   </Tab>
-  <Tab title="Cursor">
+  <Tab title="Others">
+    Cursor or any MCP client:
+
     ```json
     {
       "mcpServers": {
@@ -42,10 +44,9 @@ No key in the client. One URL for every host.
       }
     }
     ```
-  </Tab>
-  <Tab title="Others">
-    Same JSON as Cursor — any MCP client. No OAuth in your client? Mint a
-    bearer under [Connections](https://t2000.ai/manage/connections).
+
+    No OAuth in your client? Mint a bearer under
+    [Connections](https://t2000.ai/manage/connections).
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary
- Collapse Cursor into **Others** — tabs are now Claude | ChatGPT | Others.
- Others keeps the MCP JSON + OAuth/bearer notes (Cursor named in body).

## Test plan
- [ ] passport-connect + quickstart show three tabs
- [ ] Others tab has the JSON config


Made with [Cursor](https://cursor.com)