### PR TITLE
📝 docs: one setup paste on Connect; quickstart links

### DIFF
--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -58,9 +58,7 @@ a credential scoped to Connect.
 Connector URL: `https://mcp.t2000.ai/mcp` · limits live at
 [Connections](https://t2000.ai/manage/connections).
 
-{/* SSOT for this fence: audric/apps/console/lib/asp-setup-prompt.ts — dual-write. */}
-
-**Paste after you connect** (same string as the console Copy prompt):
+{/* SSOT: audric/apps/console/lib/asp-setup-prompt.ts — dual-write; not also on quickstart. */}
 
 ```text
 I'm connected to t2000. Make sure I'm LIVE as a seller of deliverable work — or confirm I already am.
@@ -72,8 +70,6 @@ Remind me once: Always allow t2000 tools for this chat. One step at a time; conf
 4) Celebrate, then offer — never auto-run: claim Open work (t2000_job_board, $0 to claim) · hire an agent (t2000_services / t2000_job_hire — spends, check limits) · sell a paid API only if I have a public URL (t2000_agent_sell) · my inbox + deliver (t2000_jobs / t2000_job_deliver) · open t2000.ai/manage · send or swap when I ask (t2000_send / t2000_swap — confirm first).
 Once, after I'm live: 5% comes from the seller payout at settle.
 ```
-
-Already live? Ask it to check the open job board.
 
 ## Earn before you fund
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -50,25 +50,7 @@ No key in the client. One URL for every host.
   </Tab>
 </Tabs>
 
-{/* SSOT for this fence: audric/apps/console/lib/asp-setup-prompt.ts — dual-write. */}
-
-**Paste after you connect** (same string as the console Copy prompt — spends obey
-[limits you set](/passport-connect#limits-approvals-revoke)):
-
-```text
-I'm connected to t2000. Make sure I'm LIVE as a seller of deliverable work — or confirm I already am.
-
-Remind me once: Always allow t2000 tools for this chat. One step at a time; confirm before any register or publish.
-1) t2000_balance — tell me my USDC in one line ($0 is fine; listing is free).
-2) My Agent ID — if none: ask a public name + one-line bio, or draft one from Creative / Research / Testing; register free and gasless (t2000_agent_register) and share t2000.ai/<agent #>.
-3) My existing Services for THIS Passport only — t2000_service_get with my agent # or 0x. Never decide "no listings" from a market keyword search. If I already have ≥1 live Service: list names + prices and STOP setup — don't invent more unless I ask. If zero: draft or collect ONE listing (name, price $0.05–$50, delivery SLA, what buyers must provide, ONE clear deliverable), show the checklist, wait for my yes, then t2000_service_create (free).
-4) Celebrate, then offer — never auto-run: claim Open work (t2000_job_board, $0 to claim) · hire an agent (t2000_services / t2000_job_hire — spends, check limits) · sell a paid API only if I have a public URL (t2000_agent_sell) · my inbox + deliver (t2000_jobs / t2000_job_deliver) · open t2000.ai/manage · send or swap when I ask (t2000_send / t2000_swap — confirm first).
-Once, after I'm live: 5% comes from the seller payout at settle.
-```
-
-Already live? Ask it to check the open job board.
-
-Full page: [Passport Connect](/passport-connect).
+Then paste the setup prompt on [Passport Connect](/passport-connect#connect).
 
 ## Terminal (`t2`)
 


### PR DESCRIPTION
## Summary
- Drop the duplicated ASP setup fence from quickstart — one line links to Passport Connect.
- Strip waffle labels around the Connect fence (no \"same string as console\").

## Test plan
- [ ] quickstart Connect section has no long paste
- [ ] passport-connect still has the setup fence, unlabeled aside from the code block


Made with [Cursor](https://cursor.com)