### PR TITLE
📝 docs: drop demo redirect; fill Prompt directory gaps

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -165,11 +165,5 @@
     "body": {
       "family": "Space Grotesk"
     }
-  },
-  "redirects": [
-    {
-      "source": "/how-to/demo-with-claude",
-      "destination": "/prompts"
-    }
-  ]
+  }
 }

--- a/apps/docs/prompts.mdx
+++ b/apps/docs/prompts.mdx
@@ -42,6 +42,23 @@ Don't hire yet — pick one service and draft the hire brief; wait for my confir
 
 See also: [How to hire](/how-to/hire).
 
+## Post an Open job
+
+Budget escrows when you post. Confirm before posting.
+
+```text
+Post an Open job on the t2000 marketplace board — budget $1,
+keep open 24h, delivery 24h once claimed.
+Title: "Logo sketch".
+Need: a minimal one-color logo sketch for a CLI tool called t2.
+Done when: two concept write-ups in markdown, each with an HTTPS link
+to the PNG/SVG (delivery body is text-only; no binary attach).
+Proof: the markdown (links + one line on the idea behind each).
+Show me the brief, budget, and both time windows, then post once I say go.
+```
+
+See also: [Post an Open job](/how-to/open-job).
+
 ## Pay an API (x402)
 
 ```text
@@ -52,12 +69,31 @@ and exactly what it cost.
 
 See also: [How to pay an API](/how-to/pay-an-api).
 
+## List a Service
+
+No server — a Hire card on your profile. Listing is free.
+
+```text
+List a service on my t2000 Agent ID:
+- name: One-paragraph brief
+- price: 0.10 USDC
+- SLA: 24 hours
+- buyers provide: {"topic":"what to brief on"}
+- deliverable: One short markdown paragraph, sources cited
+Confirm the fields with me, then publish.
+```
+
+See also: [List a Service](/how-to/list-a-service).
+
 ## Sell an API (end-to-end)
 
 A job for a **coding agent** (Claude Code, Cursor, a local CLI), not a chat
 paste: deploy the Vercel template, probe the 402, list, and prove it with a
 real paid call. The full prompt lives on
 [Sell your API](/how-to/sell-your-api#paste-into-your-coding-agent).
+
+URL already live? Short list paste on that page under
+[List it on your Agent ID](/how-to/sell-your-api#3--list-it-on-your-agent-id).
 
 ## Earn — claim an Open job
 
@@ -84,6 +120,16 @@ Send $0.10 USDC to alice@audric — confirm the resolved address before sending.
 ```
 
 Works with a `0x…` address, a SuiNS name, or a Passport handle you choose.
+
+## Swap (quote first)
+
+```text
+Quote a swap of 0.5 USDC to SUI — quoting is free. Show me the route,
+the expected output, and the price impact, then execute that quote once I
+say go.
+```
+
+See also: [Swap tokens](/how-to/swap).
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Remove Mintlify redirect `/how-to/demo-with-claude` → `/prompts` (old path 404s by design).
- Add missing marketplace pastes on Prompts: **Post an Open job**, **List a Service**, **Swap**; link the short “URL already live” list paste under Sell an API.

## Test plan
- [ ] `docs.json` has no `redirects` key
- [ ] `/prompts` shows Open job / List a Service / Swap sections
- [ ] `/how-to/demo-with-claude` 404s after deploy (expected)


Made with [Cursor](https://cursor.com)