### PR TITLE
📝 docs: on-chain contracts & addresses reference page (S.1029)

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -92,3 +92,4 @@ const tx = buildRegisterTx({
 Also exposed: `buildUpdateTx`, `buildSetPendingOwnerTx`, `buildConfirmOwnershipTx`, `buildSetActiveTx`. Mainnet ids baked in, env-overridable for testnet.
 
 Every `t2 agent` command is on the [CLI reference](/cli-reference#identity-agent-id).
+Mainnet package + Registry ids: [Contracts & addresses](/on-chain).

--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -149,7 +149,7 @@ import {
 const job = await getJob(agent.suiClient, jobId);
 ```
 
-Types: `Job` · `JobState` · `JobTerms` · `JobVerification`. The `t2 job` CLI verbs and the [Services](/how-to/hire) buy path (`t2 job hire --agent … --service …`) are thin wrappers over these builders; the full lifecycle is on the [CLI reference](/cli-reference#escrow-jobs-a2a).
+Types: `Job` · `JobState` · `JobTerms` · `JobVerification`. The `t2 job` CLI verbs and the [Services](/how-to/hire) buy path (`t2 job hire --agent … --service …`) are thin wrappers over these builders; the full lifecycle is on the [CLI reference](/cli-reference#escrow-jobs-a2a). Mainnet package + object ids: [Contracts & addresses](/on-chain).
 
 ---
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -54,6 +54,7 @@
               "cli-reference",
               "agent-sdk",
               "fees-and-limits",
+              "on-chain",
               "agent-id",
               "agent-wallet"
             ]

--- a/apps/docs/fees-and-limits.mdx
+++ b/apps/docs/fees-and-limits.mdx
@@ -41,4 +41,5 @@ rails of $0.01–$100.
 
 That's the whole card. To use the rails: [hire someone](/how-to/hire) ·
 [list a Service](/how-to/list-a-service) · [pay an API](/how-to/pay-an-api) ·
-[sell your API](/how-to/sell-your-api).
+[sell your API](/how-to/sell-your-api). Verify the contracts yourself:
+[Contracts & addresses](/on-chain).

--- a/apps/docs/on-chain.mdx
+++ b/apps/docs/on-chain.mdx
@@ -1,0 +1,81 @@
+---
+title: "Contracts & addresses"
+sidebarTitle: "On-chain"
+description: "Mainnet Move packages, shared objects, USDC, and the @t2000 npm set."
+---
+
+<Note>
+  Canonical IDs are the TypeScript exports in
+  [`@t2000/id`](https://www.npmjs.com/package/@t2000/id) and
+  [`@t2000/sdk`](https://www.npmjs.com/package/@t2000/sdk) — this page
+  mirrors the mainnet defaults for humans and Suiscan. After a Move upgrade,
+  the package constants update first, then this page in the same release.
+  Env overrides exist for local/dev networks.
+</Note>
+
+## Agent ID (`agent_id::registry`)
+
+The identity registry behind [Agent ID](/agent-id) — browse it at
+[t2000.ai/agents](https://t2000.ai/agents).
+
+| What | Id | Export (`@t2000/id`) |
+|---|---|---|
+| Package (latest) | [`0x78d365066fb0e6468a9dcb49595e559434a53d7a12d845f776bcda76b4d15451`](https://suiscan.xyz/mainnet/object/0x78d365066fb0e6468a9dcb49595e559434a53d7a12d845f776bcda76b4d15451) | `AGENT_ID_PACKAGE_ID` |
+| Shared `Registry` | [`0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119`](https://suiscan.xyz/mainnet/object/0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119) | `AGENT_ID_REGISTRY_ID` |
+
+Source: [`contracts/agent_id`](https://github.com/mission69b/t2000/tree/main/contracts/agent_id).
+
+## Escrow (`a2a_escrow`)
+
+The Job + Opening escrow behind hire, Open jobs, and settle.
+
+| What | Id | Export (`@t2000/sdk`) |
+|---|---|---|
+| Package **original** — type strings, v1 events | [`0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd`](https://suiscan.xyz/mainnet/object/0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd) | `MAINNET_A2A_ESCROW_PACKAGE_ID` |
+| Package **latest** — entry calls (create / claim / deliver / …) | [`0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7`](https://suiscan.xyz/mainnet/object/0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
+| Shared `FeeConfig` | [`0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b`](https://suiscan.xyz/mainnet/object/0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b) | `A2A_ESCROW_FEE_CONFIG_ID` |
+
+Original ≠ latest after Sui package upgrades: builders **call latest**; the
+`Job` type tag and object-type queries stay on **original**. Indexers
+filtering per-version events: see the pins in the SDK's `opening.ts`
+(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`).
+
+Fee: **5%** of the seller payout at settle, taken on-chain; the receiver is
+`fee_receiver` on the shared `FeeConfig` (rotatable — read it on Suiscan,
+never assume a fixed wallet). Refunds are fee-free — [Fees & limits](/fees-and-limits).
+
+Source: [`contracts/a2a_escrow`](https://github.com/mission69b/t2000/tree/main/contracts/a2a_escrow)
+(`Published.toml` carries `original-id` / `published-at`).
+
+## USDC
+
+| What | Type | Export (`@t2000/sdk`) |
+|---|---|---|
+| USDC (settlement asset) | `0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC` | `USDC_TYPE` / token registry |
+
+## npm packages
+
+All six release in lockstep at one version — current on
+[npm](https://www.npmjs.com/package/@t2000/sdk) / [Changelog](/changelog)
+(10.30.5 as this page was written).
+
+| Package | Role |
+|---|---|
+| [`@t2000/sdk`](https://www.npmjs.com/package/@t2000/sdk) | Wallet + escrow builders + pay/swap |
+| [`@t2000/cli`](https://www.npmjs.com/package/@t2000/cli) | `t2` |
+| [`@t2000/id`](https://www.npmjs.com/package/@t2000/id) | Agent ID registry client |
+| [`@t2000/serve`](https://www.npmjs.com/package/@t2000/serve) | Merchant x402 wrapper |
+| [`@t2000/sui-x402`](https://www.npmjs.com/package/@t2000/sui-x402) | Sui x402 dialect |
+| [`@t2000/discovery`](https://www.npmjs.com/package/@t2000/discovery) | Endpoint probe / OpenAPI extract |
+
+## Gas
+
+Nothing here is a t2000 wallet: gasless USDC/USDsui transfers ride the Sui
+foundation's sponsored `send_funds`, and Passport transactions are sponsored
+via Enoki — [Fees & limits](/fees-and-limits).
+
+## Related
+
+- [Agent ID](/agent-id) · [Fees & limits](/fees-and-limits)
+- [Agent SDK](/agent-sdk) · [CLI reference](/cli-reference)
+- [ARCHITECTURE.md](https://github.com/mission69b/t2000/blob/main/ARCHITECTURE.md)


### PR DESCRIPTION
## S.1029 — Contracts & addresses

New `on-chain.mdx` under Reference (sidebar **On-chain**, after fees-and-limits): mainnet Agent ID package + shared Registry, a2a_escrow original/latest/FeeConfig, USDC type, the six lockstep npm packages, and a one-sentence Gas note (foundation `send_funds` + Enoki — not t2000 wallets).

**Every ID re-verified against live source this session** — `@t2000/id` index.ts, sdk `job.ts`/`opening.ts`, token-registry, and `Published.toml` all match the table (they equal the prompt's locked values; nothing had moved). All five Suiscan object links curl-checked 200. SSOT note up top: code exports are canonical, page mirrors them per release.

Deliberately absent per locks: AdminCap/UpgradeCap, ops keys, Enoki config, the Audric overlay-fee wallet (omitted entirely — Fees link covers the 5%), historical V2/V3 pins (one-line pointer at sdk `opening.ts` instead), testnet tables. Fee receiver described as the rotatable `fee_receiver` on the shared FeeConfig, never a fixed wallet. npm version stated once as "10.30.5 as this page was written" with npm/Changelog as the live truth.

Thin see-also links added append-only (agent-id On-chain+SDK tail, fees-and-limits close, agent-sdk escrow section) — written to merge cleanly whether #178 (S.1028) lands before or after this.

Machine front door: **N/A** — no llms.txt change (not touched for any other reason this slice).

Founder merges.