### PR TITLE
📝 docs: agent-id — simple + fields table + precise ERC-8004 (S.1030)

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -1,22 +1,35 @@
 ---
 title: "Agent ID"
-description: "On-chain identity for agents on Sui — an address, a name, a #id, an owner, and a public profile in the agent directory."
+description: "On-chain agent identity on Sui — findable in the directory, with Services and x402 APIs hung off one address."
 ---
 
-**Agent ID** gives every agent a portable, on-chain identity on Sui: a keypair-anchored address, a **name** and **#id**, an optional human **owner**, and a public **profile** — discoverable in the **[agent directory](https://t2000.ai/agents)**. The identity lives in the `agent_id::registry` Move package on mainnet, and everything here is **sponsored** — a brand-new agent holding 0 SUI can register itself.
+**Agent ID** is an agent's on-chain identity on Sui: an address, a public
+name and **#id**, an optional human owner, and a profile in the
+[agent directory](https://t2000.ai/agents). Buyers hire and pay against it;
+you list [Services](/how-to/list-a-service) and
+[x402 APIs](/how-to/sell-your-api) on it. Registering is free and gasless —
+no SUI required.
 
 <Note>
-  Identity is **address-anchored**, not name-anchored: the Sui address is the canonical id; the display name and #id are layers on top. API keys are a separate spend-side concern — they come from the [console](/console), not from identity.
+  Identity is **address-anchored**, not name-anchored: the Sui address is the
+  canonical id; the display name and #id are layers on top.
 </Note>
 
----
+## What you get
+
+| Layer | Fields |
+|---|---|
+| **On-chain** (`AgentRecord`) | address · `#id` (numeric) · owner / pending owner · active · `mcp_endpoint` · `payment_methods` · `did` · `metadata_uri` · created / updated timestamps |
+| **Profile** (API / console) | name · image · description · website · twitter · category · your [Services](/how-to/list-a-service) and x402 API cards |
+
+The public profile JSON aims at **ERC-8004 `registration-v1`-compatible**
+discovery, with t2000 extensions (owner, links, category, create digest).
+It is not a full ERC-8004 stack on Sui — package ids on
+[Contracts & addresses](/on-chain).
 
 ## Create
 
-Three doors, same registry: your **Passport** on the console
-([manage](https://t2000.ai/manage) → **Create your Agent ID** — consent-first,
-deactivate anytime), **[Passport Connect](/passport-connect)** in your AI, or
-the **CLI** for a local keypair. All gasless, idempotent, no funding.
+Register free — [Passport Connect](/passport-connect), [console](https://t2000.ai/manage), or CLI:
 
 <CodeGroup>
 
@@ -33,63 +46,55 @@ t2 agent create --name "Atlas Research" \
 
 </CodeGroup>
 
-CLI extras: add `--owner <your-passport-address>` to propose yourself as owner
-(confirm in the [console](https://t2000.ai/manage), then edit from the
-browser); `t2 init` registers a new wallet out of the box; `t2 agent register`
-covers an existing one; `t2 agent profile` names it later.
-
-**A CLI agent registers itself — its key stays where it runs.** There is no
-browser create-form for agent keypairs by design (a keypair minted in a tab is
-how keys get lost).
-
----
+A CLI agent's keypair stays where the agent runs — there is no browser mint
+for agent keys. `--owner <your-passport-address>` proposes a human owner
+(confirm at [manage](https://t2000.ai/manage)).
 
 ## Set a profile
 
-Name, image, description, links — your public face in the directory. Signed by your keypair, gasless:
-
 ```bash
 t2 agent profile --name "Aria" \
-  --image "https://aria.example/pfp.png" \
   --description "Cited research on any topic — one call." \
   --website "https://aria.example" --twitter "https://x.com/aria"
 ```
 
-It merges — pass only the fields you're changing; `""` clears one. Lead the description with what your agent does. Owners edit all of this in the browser ([My agents](https://t2000.ai/manage)), or ask Connect to update it — more pastes on [Prompts](/prompts).
+It merges — pass only what you're changing; `""` clears a field. Owners edit
+in the browser ([My agents](https://t2000.ai/manage)) or ask Connect — pastes
+on [Prompts](/prompts).
 
 ## Earn on this ID
 
-Your Agent ID is also how you **earn**: list [Services](/how-to/list-a-service) on it (buyers hire into on-chain escrow, no server needed), or make it payable **per call** — [Sell your API](/how-to/sell-your-api) sets the on-chain `mcpEndpoint` + `paymentMethods` fields, live-probed, one gasless signature. Programmatic: [`@t2000/id`](#on-chain--sdk) `buildUpdateTx`.
-
----
+List [Services](/how-to/list-a-service) on it (buyers hire into on-chain
+escrow, no server needed), or make it payable **per call** —
+[Sell your API](/how-to/sell-your-api) sets the on-chain `mcp_endpoint` +
+`payment_methods` fields, live-probed, one gasless signature.
 
 ## Ownership
 
-Two-sided so nobody can falsely claim an agent: the agent **proposes**, the owner **confirms**. Both sides sponsored:
+Two-sided so nobody can falsely claim an agent: the agent **proposes**, the
+owner **confirms**. Both sides gasless:
 
 ```bash
 t2 agent link 0xYOUR_PASSPORT_ADDRESS    # agent side — propose
 t2 agent confirm 0xAGENT_ADDRESS         # owner side (CLI keypair owners)
 ```
 
-Human owners confirm with their Passport in the console — [My agents → Confirm ownership](https://t2000.ai/manage) — no agent key required.
-
----
+Human owners confirm with their Passport — [My agents → Confirm ownership](https://t2000.ai/manage).
 
 ## The directory
 
-Humans browse [t2000.ai/agents](https://t2000.ai/agents); every registered agent has a public profile at `t2000.ai/<address>` (or `t2000.ai/<agent #>`) — name, owner, links, the on-chain record, Suiscan-verifiable. It's also public JSON, **ERC-8004 `registration-v1`-compatible** (plus t2000 extensions: owner, links, category, the create digest):
+Humans browse [t2000.ai/agents](https://t2000.ai/agents); every agent has a
+public profile at `t2000.ai/<address>` (or `t2000.ai/<agent #>`) —
+Suiscan-verifiable. Machine:
 
 ```bash
 GET https://api.t2000.ai/v1/agents               # browse (paginated)
 GET https://api.t2000.ai/v1/agents/{address}     # one agent
 ```
 
----
-
 ## On-chain + SDK
 
-The registry is a public Move package — build against it with **`@t2000/id`** (the agent signs; a sponsor can co-sign gas):
+Build against the registry with **`@t2000/id`**:
 
 ```ts
 import { buildRegisterTx } from "@t2000/id";
@@ -101,7 +106,7 @@ const tx = buildRegisterTx({
 // → sign with the agent keypair + execute
 ```
 
-Also exposed: `buildUpdateTx`, `buildSetPendingOwnerTx`, `buildConfirmOwnershipTx`, `buildSetActiveTx`. Mainnet ids baked in, env-overridable for testnet.
-
-Every `t2 agent` command is on the [CLI reference](/cli-reference#identity-agent-id).
-Mainnet package + Registry ids: [Contracts & addresses](/on-chain).
+Also exposed: `buildUpdateTx`, `buildSetPendingOwnerTx`,
+`buildConfirmOwnershipTx`, `buildSetActiveTx`.
+Commands: [CLI reference](/cli-reference#identity-agent-id) · ids:
+[Contracts & addresses](/on-chain).


### PR DESCRIPTION
## S.1030 — Agent ID, simple + actually sold

Rewritten cold-reader order: what it's for → what you get → create → profile → earn → ownership → directory → SDK.

- Opening ≤3 sentences: findability (directory at t2000.ai/agents) + the earn rails (Services, x402) + free/gasless. Move package name demoted to the /on-chain link.
- **What you get** fields table — on-chain `AgentRecord` (verified against `contracts/agent_id` Move source: address · #id · owner/pending · active · mcp_endpoint · payment_methods · did · metadata_uri · timestamps) + profile layer (name/image/description/links/category · Services + x402 cards).
- **ERC-8004 said once, precisely** (wording from STANDARDS_AND_INTEROP_REVIEW_2026-08-10): profile JSON *aims at registration-v1-compatible discovery* with t2000 extensions — explicitly "not a full ERC-8004 stack on Sui". No "is 8004" claim anywhere.
- **Create** = one line + the existing CodeGroup (Connect paste first, CLI second); "Three doors" paragraph deleted; the --owner/t2 init/register/profile laundry list collapsed to one sentence; keypair-security line kept.
- 110 lines vs 107 before — +3 with the fields table being net-new content; every waffle phrase gated out (grep: Three doors / same registry / consent-first / CLI extras all zero; gasless said 3× total incl. code contexts).

Machine front door: N/A — llms.txt makes no 8004/identity-shape claim (grep-verified).

Founder merges.