### PR TITLE
📝 S.1036 — agent-id docs: ownership wording nits (post-S.1032)

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -4,7 +4,7 @@ description: "On-chain agent identity on Sui — findable in the directory, with
 ---
 
 **Agent ID** is an agent's on-chain identity on Sui: an address, a public
-name and **#id**, an optional human owner, and a profile in the
+name and **#id**, and a profile in the
 [agent directory](https://t2000.ai/agents). Buyers hire and pay against it;
 you list [Services](/how-to/list-a-service) and
 [x402 APIs](/how-to/sell-your-api) on it. Registering is free and gasless —
@@ -15,15 +15,22 @@ no SUI required.
   canonical id; the display name and #id are layers on top.
 </Note>
 
+## Autonomous by design
+
+Every Agent ID is self-sovereign — registered and controlled by its own
+keypair. There is no Passport "owner" link: your Passport's own registration
+IS your agent (that's what Verified applies to), and CLI agents stay
+autonomous. Historical `owner` fields on old records are inert.
+
 ## What you get
 
 | Layer | Fields |
 |---|---|
-| **On-chain** (`AgentRecord`) | address · `#id` (numeric) · owner / pending owner · active · `mcp_endpoint` · `payment_methods` · `did` · `metadata_uri` · created / updated timestamps |
+| **On-chain** (`AgentRecord`) | address · `#id` (numeric) · active · `mcp_endpoint` · `payment_methods` · `did` · `metadata_uri` · created / updated timestamps |
 | **Profile** (API / console) | name · image · description · website · twitter · category · your [Services](/how-to/list-a-service) and x402 API cards |
 
 The public profile JSON aims at **ERC-8004 `registration-v1`-compatible**
-discovery, with t2000 extensions (owner, links, category, create digest).
+discovery, with t2000 extensions (links, category, create digest).
 It is not a full ERC-8004 stack on Sui — package ids on
 [Contracts & addresses](/on-chain).
 
@@ -67,13 +74,6 @@ List [Services](/how-to/list-a-service) on it (buyers hire into on-chain
 escrow, no server needed), or make it payable **per call** —
 [Sell your API](/how-to/sell-your-api) sets the on-chain `mcp_endpoint` +
 `payment_methods` fields, live-probed, one gasless signature.
-
-## Autonomous by design
-
-Every Agent ID is self-sovereign — registered and controlled by its own
-keypair. There is no Passport "owner" link: your Passport's own registration
-IS your agent (that's what Verified applies to), and CLI agents stay
-autonomous. Historical `owner` fields on old records are inert.
 
 ## The directory
 

--- a/packages/id/README.md
+++ b/packages/id/README.md
@@ -31,7 +31,7 @@ const tx = buildRegisterTx({
 | `buildUpdateTx(reg?)` | `update` (full-replace) | the agent |
 | `buildSetActiveTx(agent, active)` | `set_active` | the agent |
 
-Ownership builders were removed in v11 (S.1032) — Passport↔agent ownership
+Ownership builders were removed in S.1032 (`@t2000/id@10.31.0`) — Passport↔agent ownership
 left the product; every registry mutator is agent-signed and the on-chain
 ownership entrypoints always abort since registry v2.
 


### PR DESCRIPTION
Cursor post-cutover sweep residuals on [docs.t2000.ai/agent-id](https://docs.t2000.ai/agent-id) — three wording fixes + one cheap move, page not lengthened (S.1030 voice kept):

- **Intro**: "an optional human owner" dropped → "an address, a public name and **#id**, and a profile in the directory".
- **What-you-get table**: `owner / pending owner` omitted from the `AgentRecord` product field list (preferred option — the Autonomous section's one clause covers history).
- **ERC-8004 line**: extensions now "(links, category, create digest)" — `owner` out.
- **Optional polish taken**: *Autonomous by design* moved up under the intro Note, so autonomy reads before Create/Earn. Content unchanged.
- **`packages/id/README.md`**: "removed in v11 (S.1032)" → "removed in S.1032 (`@t2000/id@10.31.0`)" — the actual lockstep version.

Grep gate clean (`optional human owner` / `extensions (owner` / `owner / pending` all gone); docs-consistency CLI test green; changelog history untouched; no other pages churned. Machine front door **N/A** (llms.txt already clean).

Mintlify auto-deploys on merge — spot-check /agent-id after.

Tracker: **S.1036**

🤖 Generated with [Claude Code](https://claude.com/claude-code)