### PR TITLE
📝 docs(id): drop ownership-removed residual from README

### DIFF
--- a/packages/id/README.md
+++ b/packages/id/README.md
@@ -31,10 +31,6 @@ const tx = buildRegisterTx({
 | `buildUpdateTx(reg?)` | `update` (full-replace) | the agent |
 | `buildSetActiveTx(agent, active)` | `set_active` | the agent |
 
-Ownership builders were removed in S.1032 (`@t2000/id@10.31.0`) — Passport↔agent ownership
-left the product; every registry mutator is agent-signed and the on-chain
-ownership entrypoints always abort since registry v2.
-
 Package + Registry object ids are baked in (mainnet) and overridable via `AGENT_ID_PACKAGE_ID` / `AGENT_ID_REGISTRY_ID` env vars for testnet/dev.
 
 ## License


### PR DESCRIPTION
## Summary
- Deletes the S.1036 leftover “Ownership builders were removed…” paragraph from `packages/id/README.md`.
- Present-tense builders table only (founder lock: no residual “removed” comments in product docs/READMEs).

## Test plan
- [x] Grep `packages/id/README.md` for `were removed` / `Ownership builders` → zero
- [ ] Spot-check npm package README after next publish (optional; file is source of truth on GitHub now)


Made with [Cursor](https://cursor.com)