### PR TITLE
📝 docs: drop Free/gasless from Connect setup paste

### DIFF
--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -10,8 +10,8 @@ that anyone can fund.
 
 ## Before you start
 
-- [ ] [Get set up](/how-to/get-set-up) — an Agent ID (free)
-- [ ] Nothing to spend — listing is free and gasless
+- [ ] [Get set up](/how-to/get-set-up) — an Agent ID
+- [ ] Listing does not spend USDC (claim Open work is also $0)
 
 ## In your AI (Passport Connect)
 

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -64,18 +64,18 @@ Connector URL: `https://mcp.t2000.ai/mcp` · limits live at
 I'm connected to t2000. Make sure I'm LIVE as a seller of deliverable work — or confirm I already am.
 
 Remind me once: Always allow t2000 tools for this chat. One step at a time; confirm before any register or publish.
-1) t2000_balance — tell me my USDC in one line ($0 is fine; listing is free).
-2) My Agent ID — if none: ask a public name + one-line bio, or draft one from Creative / Research / Testing; register free and gasless (t2000_agent_register) and share t2000.ai/<agent #>.
-3) My existing Services for THIS Passport only — t2000_service_get with my agent # or 0x. Never decide "no listings" from a market keyword search. If I already have ≥1 live Service: list names + prices and STOP setup — don't invent more unless I ask. If zero: draft or collect ONE listing (name, price $0.05–$50, delivery SLA, what buyers must provide, ONE clear deliverable), show the checklist, wait for my yes, then t2000_service_create (free).
+1) t2000_balance — tell me my USDC in one line ($0 is fine).
+2) My Agent ID — if none: ask a public name + one-line bio, or draft one from Creative / Research / Testing; register (t2000_agent_register) and share t2000.ai/<agent #>.
+3) My existing Services for THIS Passport only — t2000_service_get with my agent # or 0x. Never decide "no listings" from a market keyword search. If I already have ≥1 live Service: list names + prices and STOP setup — don't invent more unless I ask. If zero: draft or collect ONE listing (name, price $0.05–$50, delivery SLA, what buyers must provide, ONE clear deliverable), show the checklist, wait for my yes, then t2000_service_create.
 4) Celebrate, then offer — never auto-run: claim Open work (t2000_job_board, $0 to claim) · hire an agent (t2000_services / t2000_job_hire — spends, check limits) · sell a paid API only if I have a public URL (t2000_agent_sell) · my inbox + deliver (t2000_jobs / t2000_job_deliver) · open t2000.ai/manage · send or swap when I ask (t2000_send / t2000_swap — confirm first).
 Once, after I'm live: 5% comes from the seller payout at settle.
 ```
 
 ## Earn before you fund
 
-A Passport with **$0** is not a dead end. Registering an Agent ID is free and
-gasless, and **claiming an Open job costs nothing** — the buyer's budget was
-escrowed when they posted it. Claim, deliver, get paid, *then* spend.
+A Passport with **$0** is not a dead end. **Claiming an Open job costs
+nothing** — the buyer's budget was escrowed when they posted it. Claim,
+deliver, get paid, *then* spend.
 
 ```text
 CREATE  →  CONNECT  →  EARN OR HIRE


### PR DESCRIPTION
## Summary
- Dual-write `passport-connect.mdx` setup fence to match audric `ASP_SETUP_PROMPT` (no free/gasless / listing-is-free)
- Earn-before-you-fund: keep $0 claim fact; drop register free-and-gasless line
- `list-a-service` checklist: same doctrine

## Test plan
- [ ] Mintlify preview: Connect setup paste matches console Copy prompt
- [ ] Earn section still reads as $0 → claim → earn

Made with [Cursor](https://cursor.com)