### PR TITLE
🐛 S.1038b — CLI: refuse service create above MAX_JOB_USDC

### DIFF
--- a/packages/cli/src/commands/service.test.ts
+++ b/packages/cli/src/commands/service.test.ts
@@ -60,3 +60,70 @@ describe('serviceSellerLabel (S.1017)', () => {
     expect(label).not.toContain('#');
   });
 });
+
+// [S.1038b] `t2 service create` price bounds — the symmetric max joined the
+// existing min preflight; both refuse BEFORE wallet load (dist harness,
+// same pattern as agent/create.test.ts). Bounds come from @t2000/sdk
+// MIN/MAX_JOB_USDC — never a second hardcoded number.
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll } from 'vitest';
+import { MAX_JOB_USDC, MIN_JOB_USDC } from '@t2000/sdk';
+
+const CLI = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+const describeOrSkip = existsSync(CLI) ? describe : describe.skip;
+
+function runCli(
+  args: string[],
+  home: string,
+): { stdout: string; stderr: string; code: number } {
+  const result = spawnSync('node', [CLI, ...args], {
+    env: { ...process.env, HOME: home },
+    encoding: 'utf-8',
+  });
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    code: result.status ?? -1,
+  };
+}
+
+describeOrSkip('t2 service create — price bounds (S.1038b)', () => {
+  let home: string;
+  beforeAll(() => {
+    home = mkdtempSync(join(tmpdir(), 'cli-svc-'));
+  });
+  afterAll(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const base = [
+    'service',
+    'create',
+    '--name',
+    'Smoke',
+    '--sla',
+    '24h',
+    '--description',
+    'd',
+    '--deliverable',
+    'x',
+    '--requirements',
+    'Topic and angle; target word count; tone; platform.',
+  ];
+
+  it(`rejects --price above MAX_JOB_USDC (${MAX_JOB_USDC}) before any side effect`, () => {
+    const r = runCli([...base, '--price', String(MAX_JOB_USDC + 1)], home);
+    expect(r.code).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('at most');
+  });
+
+  it(`rejects --price below MIN_JOB_USDC (${MIN_JOB_USDC}) before any side effect`, () => {
+    const r = runCli([...base, '--price', String(MIN_JOB_USDC / 5)], home);
+    expect(r.code).not.toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('at least');
+  });
+});

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -23,7 +23,7 @@ import {
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
 import pc from 'picocolors';
-import { MIN_JOB_USDC, truncateAddress, validateAddress } from '@t2000/sdk';
+import { MAX_JOB_USDC, MIN_JOB_USDC, truncateAddress, validateAddress } from '@t2000/sdk';
 import {
   AGENT_CATEGORIES,
   ensureSellerCategory,
@@ -181,7 +181,10 @@ Examples:
     .command('create')
     .description('List a service under your Agent ID (re-run to update it)')
     .requiredOption('--name <name>', 'Service name (max 80 chars)')
-    .requiredOption('--price <usdc>', 'Fixed price in USDC (0.05–50)')
+    .requiredOption(
+      '--price <usdc>',
+      `Fixed price in USDC (${MIN_JOB_USDC}\u2013${MAX_JOB_USDC})`,
+    )
     .requiredOption('--sla <duration>', 'Delivery SLA — e.g. 30m, 24h, 7d')
     .requiredOption('--description <text>', 'What this service is (max 2000 chars)')
     .requiredOption('--deliverable <text>', 'What the buyer receives (max 1000 chars)')
@@ -223,6 +226,13 @@ Examples:
           if (priceUsdc < MIN_JOB_USDC) {
             throw new Error(
               `--price must be at least ${MIN_JOB_USDC} USDC — escrow jobs start there (contract-enforced minimum).`,
+            );
+          }
+          // S.1038b: the symmetric cap — a listing above the escrow job
+          // ceiling could never be hired either. Refuse at list time.
+          if (priceUsdc > MAX_JOB_USDC) {
+            throw new Error(
+              `--price must be at most ${MAX_JOB_USDC} USDC (v1 escrow listing cap).`,
             );
           }
           const slaMinutes = Math.round(parseDuration(opts.sla) / 60_000);


### PR DESCRIPTION
CLI half of S.1038b (console+MCP half: audric #332, same tracker).

- `t2 service create` now refuses `--price` above `MAX_JOB_USDC` **before wallet load** — symmetric with the existing `MIN_JOB_USDC` preflight (S.981). Error: `--price must be at most 50 USDC (v1 escrow listing cap).`
- `--price` help text interpolates `MIN/MAX_JOB_USDC` from `@t2000/sdk` instead of the hardcoded `0.05–50` literal — no second bound anywhere.
- Tests: two dist-harness cases (same `runCli` pattern as `agent/create.test.ts`) — `--price MAX+1` and `--price MIN/5` both exit non-zero pre-wallet with the bound named. **283/283** CLI tests · turbo typecheck clean.

No SDK surface changes (constants already exported). Lockstep publish can ride the next regular release — no urgency, the server gate has always enforced the cap.

Tracker: **S.1038b**

🤖 Generated with [Claude Code](https://claude.com/claude-code)