### PR TITLE
✨ S.1041 — t2 services category filter + ranked-board client params

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -7,6 +7,20 @@ The highlights, newest first. For the exhaustive per-version log, see
 [GitHub Releases](https://github.com/mission69b/t2000/releases). The `@t2000/sdk`,
 `@t2000/cli`, `@t2000/id`, `@t2000/serve`, `@t2000/sui-x402`, and `@t2000/discovery` packages ship together on one version (six packages; the stdio `@t2000/mcp` was deleted 2026-08-03 — Passport Connect is the MCP surface).
 
+<Update label="Ranked services board + category filter" description="August 14, 2026">
+  **`GET /v1/services` market browse is now ranked, not newest-first**
+  (S.1041): Featured pins → seller lifetime settled USDC → newest — the same
+  order humans see on [t2000.ai/services](https://t2000.ai/services). If your
+  agent assumed newest-first, that is the one behavior change; the per-seller
+  view (`?agent=0x…`) stays newest-first. New: `?category=<slug>` filters to
+  a seller directory category (invalid slugs 400 with the allow-list; ANDs
+  with `?q=`), and every row now carries `category`, `featured`,
+  `reviewScore`, `reviewCount`, and `settledUsdc` (additive). Same surface
+  everywhere: `t2 services --category creative` (CLI), a `category` input on
+  Connect's `t2000_services`, and `category`/`limit`/`offset` filters on the
+  SDK's `listServices`.
+</Update>
+
 <Update label="Agent ownership deprecated" description="August 13, 2026">
   **Passport↔agent ownership left the product** (S.1032). Agents are
   autonomous Agent IDs; a paid Passport's own registration is its Verified

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -51,7 +51,7 @@ t2 swap 100 USDC SUI --quote
 | Command | What it does |
 | --- | --- |
 | `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
-| `t2 services [query]` | Discover Services in the Agent Marketplace — escrow work + ASP x402 endpoints. Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller (active listings only); free text searches market-wide. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | Discover Services in the Agent Marketplace — escrow work + ASP x402 endpoints. Market browse is ranked featured → most settled USDC → newest. Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller (active listings only); free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 t2 services "chat"
@@ -152,7 +152,7 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service create` | seller | List (or update — same slug overwrites). Required: `--name` · `--price <usdc>` · `--sla <duration>` · `--description` · `--deliverable`. Optional: `--slug` · `--requirements` (prefer a JSON object of required buyer fields — enforced at hire) · `--review 24h` · `--split 8000` · `--category <cat>` (required once unless set on your profile). |
 | `t2 service list [agent]` | anyone | An agent's services — your own wallet's by default (retired included). |
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
-| `t2 services [query]` | buyer | Search Services across every agent — or scope to one seller with `0x…` / `#id` / `@handle`. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | buyer | Search Services across every agent (ranked featured → most settled → newest) — scope to one seller with `0x…` / `#id` / `@handle`, or to a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 # seller — one command, listed

--- a/packages/cli/src/commands/service.test.ts
+++ b/packages/cli/src/commands/service.test.ts
@@ -45,6 +45,17 @@ describe('resolveServicesQuery (S.1017)', () => {
     expect(scope.kind).toBe('search');
     expect(url).toContain('q=0xnothex');
   });
+
+  it('category (S.1041) ANDs onto any scope — bare, text, and agent', async () => {
+    const bare = await resolveServicesQuery(BASE, undefined, 'creative');
+    expect(bare.url).toBe(`${BASE}/services?category=creative`);
+    const text = await resolveServicesQuery(BASE, 'logo', 'creative');
+    expect(text.url).toBe(`${BASE}/services?q=logo&category=creative`);
+    const agent = await resolveServicesQuery(BASE, ADDR, 'creative');
+    expect(agent.url).toBe(
+      `${BASE}/services?agent=${encodeURIComponent(ADDR)}&category=creative`,
+    );
+  });
 });
 
 describe('serviceSellerLabel (S.1017)', () => {

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -382,15 +382,21 @@ export type ServicesScope =
  *  beta #93): a 0x address or agent ref (#N / @handle) is a PRINCIPAL scope
  *  and goes to `?agent=` — free-text `?q=` never matches hex, so the old
  *  path answered "No services match 0x…" for a seller with live listings.
- *  Anything else stays a text search. Pure except the one resolver hop for
+ *  Anything else stays a text search. An optional directory `category`
+ *  (S.1041) ANDs onto any scope. Pure except the one resolver hop for
  *  #N / @handle (the same endpoint the site uses). */
 export async function resolveServicesQuery(
   base: string,
   query: string | undefined,
+  category?: string,
 ): Promise<{ url: string; scope: ServicesScope }> {
+  const withCategory = (url: string): string =>
+    category
+      ? `${url}${url.includes('?') ? '&' : '?'}category=${encodeURIComponent(category)}`
+      : url;
   const q = query?.trim();
   if (!q) {
-    return { url: `${base}/services`, scope: { kind: 'all' } };
+    return { url: withCategory(`${base}/services`), scope: { kind: 'all' } };
   }
   if (q.startsWith('0x')) {
     // One address check for the whole CLI — validateAddress; invalid hex
@@ -398,7 +404,7 @@ export async function resolveServicesQuery(
     try {
       const agent = validateAddress(q);
       return {
-        url: `${base}/services?agent=${encodeURIComponent(agent)}`,
+        url: withCategory(`${base}/services?agent=${encodeURIComponent(agent)}`),
         scope: { kind: 'agent', agent },
       };
     } catch {
@@ -407,12 +413,12 @@ export async function resolveServicesQuery(
   } else if (looksLikeAgentRefValue(q)) {
     const ref = await resolveAgentRef(base, q);
     return {
-      url: `${base}/services?agent=${encodeURIComponent(ref.address)}`,
+      url: withCategory(`${base}/services?agent=${encodeURIComponent(ref.address)}`),
       scope: { kind: 'agent', agent: ref.address, numericId: ref.numericId },
     };
   }
   return {
-    url: `${base}/services?q=${encodeURIComponent(q)}`,
+    url: withCategory(`${base}/services?q=${encodeURIComponent(q)}`),
     scope: { kind: 'search', q },
   };
 }
@@ -428,12 +434,16 @@ function scopeLabel(scope: ServicesScope): string {
 
 function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
   command
-    .argument('[query]', 'What you need — free text, or a SELLER scope: 0x… address, #id, or @handle (empty = everything)')
+    .argument('[query]', 'What you need — free text, or a SELLER scope: 0x… address, #id, or @handle (empty = everything, ranked featured → most settled → newest)')
+    .option('--category <category>', `Seller directory category (${AGENT_CATEGORIES.join(' | ')}) — ANDs with the query`)
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(async (query: string | undefined, cmdOpts: { api?: string }) => {
+    .action(async (query: string | undefined, cmdOpts: { api?: string; category?: string }) => {
       try {
         const base = cmdOpts.api ?? DEFAULT_API_BASE;
-        const { url, scope } = await resolveServicesQuery(base, query);
+        // Fail fast on an off-enum category (same local mirror the sell
+        // gate uses) — the API would 400 with the same allow-list.
+        const category = cmdOpts.category ? parseCategory(cmdOpts.category) : undefined;
+        const { url, scope } = await resolveServicesQuery(base, query, category);
         const json = await fetchJson(url);
         const all = (json.services ?? []) as ServiceListing[];
         // Buyer discovery is the ACTIVE board: `?agent=` serves the seller's
@@ -461,8 +471,10 @@ function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
             scope.kind === 'agent'
               ? `No active services for ${scopeLabel(scope)}.`
               : scope.kind === 'search'
-                ? `No services match "${scope.q}".`
-                : 'No services listed yet.',
+                ? `No services match "${scope.q}"${category ? ` in ${category}` : ''}.`
+                : category
+                  ? `No services in ${category} yet.`
+                  : 'No services listed yet.',
           );
           printBlank();
           return;
@@ -494,7 +506,7 @@ export function registerServices(program: Command) {
   registerDiscovery(
     program
       .command('services')
-      .description('Find agent Services to buy — the t2000 A2A marketplace'),
+      .description('Find agent Services to buy — the t2000 A2A marketplace (ranked featured → most settled → newest; --category for directory buckets)'),
   );
 }
 

--- a/packages/sdk/src/commerce.test.ts
+++ b/packages/sdk/src/commerce.test.ts
@@ -103,6 +103,16 @@ describe('listServices — browse/list filter plumbing', () => {
     expect(url).toContain(`agent=${encodeURIComponent(agent)}`);
     expect(url).toContain('q=market+report');
   });
+
+  it('passes category + limit/offset (S.1041 — directory bucket + paging)', async () => {
+    const fn = mockFetch({ total: 0, services: [] });
+    await listServices(BASE, { category: 'creative', limit: 20, offset: 40 });
+    const url = (fn.mock.calls[0] as unknown[])[0] as string;
+    expect(url).toContain('category=creative');
+    expect(url).toContain('limit=20');
+    expect(url).toContain('offset=40');
+    expect(url).not.toContain('q=');
+  });
 });
 
 describe('assertBuyerRequirements — the shared hire gate (SPEC_ACP_JOB_SPEC_V1 §4.1)', () => {

--- a/packages/sdk/src/commerce.ts
+++ b/packages/sdk/src/commerce.ts
@@ -46,17 +46,41 @@ export interface ServiceListing {
   requirements: unknown;
   deliverable: string;
   retired: boolean;
+  // Rank/trust facts (S.1041) — what the market board sorted by, so a
+  // consumer can display or locally re-rank without a second source.
+  /** The seller's directory category (AGENT_CATEGORIES slug), or null. */
+  category: string | null;
+  /** Live Featured pin — paid placement, sorts first on market browse. */
+  featured: boolean;
+  /** Avg receipt-bound review stars for the seller; null = no reviews yet. */
+  reviewScore: number | null;
+  reviewCount: number;
+  /** Seller lifetime settled (released-escrow) USDC — the organic rank key. */
+  settledUsdc: number;
 }
 
-/** Browse / list agent services — free-text `query` across every agent, or
- *  one agent's full catalog (retired included) via `agent`. */
+/** Browse / list agent services. Market browse (no `agent`) is RANKED
+ *  Featured → seller settled USDC → newest — not newest-first; `agent`
+ *  returns that seller's full catalog (retired included, newest-first).
+ *  `query` is free text; `category` is the seller's directory bucket
+ *  (AGENT_CATEGORIES slug — the API 400s off-enum values with the
+ *  allow-list); they AND. */
 export async function listServices(
   base: string,
-  filter: { agent?: string; query?: string } = {},
+  filter: {
+    agent?: string;
+    query?: string;
+    category?: string;
+    limit?: number;
+    offset?: number;
+  } = {},
 ): Promise<{ total: number; services: ServiceListing[] }> {
   const params = new URLSearchParams();
   if (filter.agent) params.set('agent', filter.agent);
   if (filter.query) params.set('q', filter.query);
+  if (filter.category) params.set('category', filter.category);
+  if (filter.limit !== undefined) params.set('limit', String(filter.limit));
+  if (filter.offset !== undefined) params.set('offset', String(filter.offset));
   const qs = params.size > 0 ? `?${params.toString()}` : '';
   const json = await commerceFetchJson(`${base}/services${qs}`);
   const services = (json.services ?? []) as ServiceListing[];


### PR DESCRIPTION
Client half of the ranked services board (audric mission69b/audric#340):

- **SDK** — `listServices` gains `category` / `limit` / `offset`; `ServiceListing` carries the new rank/trust fields (`category`, `featured`, `reviewScore`, `reviewCount`, `settledUsdc`).
- **CLI** — `t2 services --category <slug>` (fast-fail on the local AGENT_CATEGORIES mirror; ANDs onto any scope); help copy says market browse is ranked Featured → most settled → newest.
- **Docs** — CLI reference rows updated; changelog entry calls out the default-sort consumer delta (market browse is no longer newest-first).

Tests: SDK param plumbing + CLI `resolveServicesQuery` category pins. Typecheck/lint/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)