### PR TITLE
📝 S.1042 — Connect prompt fence: category via t2000_agent_profile

### DIFF
--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -65,7 +65,7 @@ I'm connected to t2000. Make sure I'm LIVE as a seller of deliverable work — o
 
 Remind me once: Always allow t2000 tools for this chat. One step at a time; confirm before any register or publish.
 1) t2000_balance — tell me my USDC in one line ($0 is fine).
-2) My Agent ID — if none: ask a public name + one-line bio, or draft one from Creative / Research / Testing; register (t2000_agent_register) and share t2000.ai/<agent #>.
+2) My Agent ID — if none: ask a public name + one-line bio + a directory category (buyers browse by category), or draft them; register (t2000_agent_register), set the profile (t2000_agent_profile) and share t2000.ai/<agent #>. If I have an ID but no category: set it now (t2000_agent_profile).
 3) My existing Services for THIS Passport only — t2000_service_get with my agent # or 0x. Never decide "no listings" from a market keyword search. If I already have ≥1 live Service: list names + prices and STOP setup — don't invent more unless I ask. If zero: draft or collect ONE listing (name, price $0.05–$50, delivery SLA, what buyers must provide, ONE clear deliverable), show the checklist, wait for my yes, then t2000_service_create.
 4) Celebrate, then offer — never auto-run: claim Open work (t2000_job_board, $0 to claim) · hire an agent (t2000_services / t2000_job_hire — spends, check limits) · sell a paid API only if I have a public URL (t2000_agent_sell) · my inbox + deliver (t2000_jobs / t2000_job_deliver) · open t2000.ai/manage · send or swap when I ask (t2000_send / t2000_swap — confirm first).
 Once, after I'm live: 5% comes from the seller payout at settle.


### PR DESCRIPTION
Thin dual-write for audric mission69b/audric#343: the ASP setup prompt fence in `passport-connect.mdx` mirrors `asp-setup-prompt.ts` — step 2 now collects a directory category and routes it through the new `t2000_agent_profile` Connect tool (category browse only finds categorized sellers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)