### PR TITLE
🔒 S.1049 — Agent ID trust anchors + intent verify + publish hygiene

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,20 @@ jobs:
       # https://www.npmjs.com/package/@t2000/sdk?activeTab=provenance and
       # provide cryptographic linkage from the published tarball back to
       # the GitHub Actions run that produced it.
-      # HARD-FAIL on the dialect + discovery publishes — no continue-on-error.
+      #
+      # S.1049 (Aegis X-1): despite the --provenance flag, 10.32.0 shipped
+      # with NO dist.attestations — pnpm's recursive `--filter … publish`
+      # does not reliably forward the flag to the underlying npm publish
+      # (a direct `pnpm publish` does). Fixes: NPM_CONFIG_PROVENANCE env on
+      # every publish step (npm reads config regardless of flag routing);
+      # ALL six steps now hard-fail on anything but the already-published
+      # E409 (continue-on-error swallowed real errors); and a Verify step
+      # below fails the job when attestations did not attach to a version
+      # this run actually published. If verification still fails, the
+      # founder-ops fallback is npm Trusted Publishing: on npmjs.com, each
+      # @t2000/* package → Settings → Publishing access → add this repo's
+      # publish.yml as a Trusted Publisher (OIDC), then drop NPM_TOKEN.
+      # HARD-FAIL on every publish — no continue-on-error.
       # The @t2000/x402 v10.20.0 E409 (publishing onto an unpublish tombstone)
       # was swallowed by continue-on-error, so serve/sdk shipped depending on
       # a package that didn't exist. An already-published version is the ONLY
@@ -84,36 +97,68 @@ jobs:
           pnpm --filter @t2000/sui-x402 publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-sui-x402.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-sui-x402.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish @t2000/discovery
         run: |
           pnpm --filter @t2000/discovery publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-discovery.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-discovery.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish @t2000/sdk
-        run: pnpm --filter @t2000/sdk publish --no-git-checks --access public --provenance
+        run: |
+          pnpm --filter @t2000/sdk publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-sdk.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-sdk.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish @t2000/cli
-        run: pnpm --filter @t2000/cli publish --no-git-checks --access public --provenance
+        run: |
+          pnpm --filter @t2000/cli publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-cli.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-cli.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish @t2000/id
-        run: pnpm --filter @t2000/id publish --no-git-checks --access public --provenance
+        run: |
+          pnpm --filter @t2000/id publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-id.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-id.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
+          NPM_CONFIG_PROVENANCE: 'true'
 
       - name: Publish @t2000/serve
-        run: pnpm --filter @t2000/serve publish --no-git-checks --access public --provenance
+        run: |
+          pnpm --filter @t2000/serve publish --no-git-checks --access public --provenance 2>&1 | tee /tmp/pub-serve.log ||             grep -q "You cannot publish over the previously published versions" /tmp/pub-serve.log
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      # S.1049 (Aegis X-1): provenance intent without registry attestations
+      # is false comfort — verify what npm actually serves. Fails the job
+      # for any package this run NEWLY published (its log lacks the E409
+      # marker) whose version has no dist.attestations. Idempotent re-runs
+      # of an old, pre-provenance version skip cleanly.
+      - name: Verify provenance attached
+        run: |
+          VERSION=$(node -p "require('./packages/sdk/package.json').version")
+          FAIL=0
+          for PKG in sui-x402 discovery sdk cli id serve; do
+            if grep -q "You cannot publish over the previously published versions" "/tmp/pub-${PKG}.log"; then
+              echo "…skipping @t2000/${PKG}@${VERSION} (already published before this run)"
+              continue
+            fi
+            if npm view "@t2000/${PKG}@${VERSION}" dist.attestations.url >/dev/null 2>&1 &&                [ -n "$(npm view "@t2000/${PKG}@${VERSION}" dist.attestations.url 2>/dev/null)" ]; then
+              echo "✓ @t2000/${PKG}@${VERSION} has provenance attestations"
+            else
+              echo "✗ @t2000/${PKG}@${VERSION} published WITHOUT provenance attestations"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" = "1" ]; then
+            echo "Provenance did not attach — see the S.1049 comment above (NPM_CONFIG_PROVENANCE / Trusted Publishing)."
+            exit 1
+          fi
 
   release:
     name: GitHub Release

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     ],
     "overrides": {
       "@mysten/sui": "^2.17.0",
-      "@mysten/bcs": "^2.0.1"
+      "@mysten/bcs": "^2.0.1",
+      "valibot": "^1.4.2"
     }
   },
   "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,8 +56,11 @@
     "vitest": "^3"
   },
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "dependencies": {
-    "@t2000/id": "workspace:^",
+    "@t2000/id": "workspace:*",
     "qrcode": "^1.5.4"
   }
 }

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -22,6 +22,7 @@ import {
 import { registerWallet } from '../../lib/agent-register.js';
 import {
   assertSigningHostAllowed,
+  assertTxMatchesIntent,
   isAllowUntrustedApi,
 } from '../../lib/tx-guard.js';
 import { withAgent } from '../../lib/with-agent.js';
@@ -262,11 +263,12 @@ Subcommands:
 
           // Two-phase sponsored flow, inline (not runSponsoredTx) so a failed
           // probe surfaces its per-check findings, not just one message.
-          // Inline does NOT mean unguarded: the host pin still applies, and
-          // it has to run before the address is sent (S.930). Intent checking
-          // stops at the host for this verb — it calls the registry package,
-          // which is outside the escrow allowlist, so claiming to verify its
-          // shape here would be theatre.
+          // Inline does NOT mean unguarded: the host pin runs before the
+          // address is sent (S.930), and since S.1049 the prepared bytes are
+          // intent-verified too — endpoint list/remove is a registry
+          // `update`, and the guard's allowlist pins the MAINNET agent_id
+          // package literal (the old comment calling that "theatre" predates
+          // the registry joining ACTION_TARGETS).
           assertSigningHostAllowed(base, isAllowUntrustedApi());
           const prepRes = await fetch(`${base}/agent/endpoint/prepare`, {
             method: 'POST',
@@ -324,6 +326,13 @@ Subcommands:
           if (!(prep.nonce && prep.txBytes)) {
             throw new Error('Failed to prepare the listing.');
           }
+          // S.1049: the server proposed; check it proposed a registry
+          // `update` (endpoint prepare builds buildUpdateTx) before signing.
+          assertTxMatchesIntent(
+            prep.txBytes,
+            { action: 'update' },
+            { allowUntrusted: isAllowUntrustedApi() },
+          );
           const bytes = new Uint8Array(Buffer.from(prep.txBytes, 'base64'));
           const { signature } = await agent.keypair.signTransaction(bytes);
           const sub = await fetchJson(`${base}/agent/endpoint/submit`, {

--- a/packages/cli/src/lib/agent-register.ts
+++ b/packages/cli/src/lib/agent-register.ts
@@ -39,8 +39,9 @@ async function postJson(
 
 /**
  * Generic sponsored-tx round-trip: prepare (server builds the tx) → sign the
- * returned bytes → submit (server sponsor-co-signs + executes). Shared by the
- * ownership-link commands (`link`/`confirm`). Returns the tx digest.
+ * returned bytes → submit (server sponsor-co-signs + executes). (The
+ * ownership-link callers left with S.1032; job verbs ride this today.)
+ * Returns the tx digest.
  */
 export async function runSponsoredTx(opts: {
   keypair: SigningKeypair;

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -1,9 +1,10 @@
 import { Transaction } from '@mysten/sui/transactions';
+import { MAINNET_AGENT_ID_PACKAGE_ID } from '@t2000/id';
 import {
   MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
   MAINNET_A2A_ESCROW_PACKAGE_ID,
 } from '@t2000/sdk';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runSponsoredTx } from './agent-register.js';
 import {
   assertSigningHostAllowed,
@@ -472,5 +473,92 @@ describe('the funnel never signs what it refused', () => {
       }),
     ).resolves.toEqual({ digest: '0xdead' });
     expect(signTransaction).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── S.1049 — Agent ID verbs join the Move-target allowlist ─────────────────
+// `register` used to be a HOST_PINNED_ONLY carve-out that returned before
+// any package/module/function check — the wallet signed host-prepared
+// registry bytes blind. Now register/update/set-active verify against the
+// MAINNET agent_id literal, and the carve-out set is gone entirely.
+
+describe('B — Agent ID registry verbs (S.1049)', () => {
+  const REGISTRY = async (fn: string) =>
+    buildTxB64(`${MAINNET_AGENT_ID_PACKAGE_ID}::registry::${fn}`);
+
+  it('register allows the mainnet registry::register', async () => {
+    expect(() =>
+      assertTxMatchesIntent(awaited.register, { action: 'register' }),
+    ).not.toThrow();
+  });
+
+  it('update allows registry::update; set-active allows registry::set_active', async () => {
+    expect(() =>
+      assertTxMatchesIntent(awaited.update, { action: 'update' }),
+    ).not.toThrow();
+    expect(() =>
+      assertTxMatchesIntent(awaited.setActive, { action: 'set-active' }),
+    ).not.toThrow();
+  });
+
+  it('register refuses the wrong function, module, and package', async () => {
+    expect(() =>
+      assertTxMatchesIntent(awaited.setActive, { action: 'register' }),
+    ).toThrow(IntentMismatchError);
+    const escrowCreate = await buildTxB64(
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`,
+    );
+    expect(() =>
+      assertTxMatchesIntent(escrowCreate, { action: 'register' }),
+    ).toThrow(IntentMismatchError);
+    const evil = await buildTxB64(`${EVIL_PACKAGE}::registry::register`);
+    expect(() =>
+      assertTxMatchesIntent(evil, { action: 'register' }),
+    ).toThrow(IntentMismatchError);
+  });
+
+  it('a poisoned AGENT_ID_PACKAGE_ID env cannot widen the allowlist', async () => {
+    // The guard pins the MAINNET literal at import time; the env-aware
+    // builder constant is deliberately not consulted. Re-evaluate both
+    // modules under a poisoned env and prove the fresh guard still refuses
+    // the poisoned package and still accepts mainnet.
+    vi.resetModules();
+    process.env.AGENT_ID_PACKAGE_ID = EVIL_PACKAGE;
+    try {
+      const freshGuard = await import('./tx-guard.js');
+      const evil = await buildTxB64(`${EVIL_PACKAGE}::registry::register`);
+      expect(() =>
+        freshGuard.assertTxMatchesIntent(evil, { action: 'register' }),
+      ).toThrow(freshGuard.IntentMismatchError);
+      expect(() =>
+        freshGuard.assertTxMatchesIntent(awaited.register, {
+          action: 'register',
+        }),
+      ).not.toThrow();
+    } finally {
+      delete process.env.AGENT_ID_PACKAGE_ID;
+      vi.resetModules();
+    }
+  });
+
+  it('link / confirm are unknown verbs now — refused, not silently host-pinned', async () => {
+    for (const action of ['link', 'confirm']) {
+      expect(() =>
+        assertTxMatchesIntent(awaited.register, { action }),
+      ).toThrow(/not a verb this wallet knows how to verify/);
+    }
+  });
+
+  // Built once — Transaction.build() is async and `it` bodies above want
+  // sync assertion shapes for the poisoned-env re-import.
+  const awaited: { register: string; update: string; setActive: string } = {
+    register: '',
+    update: '',
+    setActive: '',
+  };
+  beforeAll(async () => {
+    awaited.register = await REGISTRY('register');
+    awaited.update = await REGISTRY('update');
+    awaited.setActive = await REGISTRY('set_active');
   });
 });

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -1,6 +1,7 @@
 import { bcs } from '@mysten/sui/bcs';
 import { Transaction } from '@mysten/sui/transactions';
 import { normalizeSuiAddress } from '@mysten/sui/utils';
+import { MAINNET_AGENT_ID_PACKAGE_ID } from '@t2000/id';
 import { setSponsoredTxGuard } from '@t2000/sdk';
 import {
   MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID,
@@ -128,6 +129,27 @@ const ACTION_TARGETS: Record<
     module: 'opening',
     functions: ['refund_unclaimed'],
   },
+  // Agent ID registry verbs (S.1049) — these used to skip Move-target
+  // verification entirely via a HOST_PINNED_ONLY carve-out, which meant
+  // `register` signed host-prepared bytes blind. Same rule as escrow now:
+  // the allowlist pins the MAINNET literal from @t2000/id — deliberately
+  // NOT the env-overridable AGENT_ID_PACKAGE_ID, which an attacker's
+  // environment could point at their own package.
+  register: {
+    pkgs: [MAINNET_AGENT_ID_PACKAGE_ID],
+    module: 'registry',
+    functions: ['register'],
+  },
+  update: {
+    pkgs: [MAINNET_AGENT_ID_PACKAGE_ID],
+    module: 'registry',
+    functions: ['update'],
+  },
+  'set-active': {
+    pkgs: [MAINNET_AGENT_ID_PACKAGE_ID],
+    module: 'registry',
+    functions: ['set_active'],
+  },
 };
 
 /** The Sui framework package, in the padded form decoded PTBs report. */
@@ -162,11 +184,6 @@ const FRAMEWORK_PRELUDE: Record<string, ReadonlySet<string>> = {
   coin: new Set(['redeem_funds', 'into_balance', 'zero', 'destroy_zero']),
   balance: new Set(['redeem_funds', 'zero']),
 };
-
-/** Verbs that are NOT marketplace escrow calls and are verified by host pin
- *  alone — the registry package is not in the escrow allowlist, and its args
- *  aren't extractable here. Narrow and named rather than a silent fallthrough. */
-const HOST_PINNED_ONLY = new Set(['register', 'link', 'confirm']);
 
 export type TxIntent = {
   /** The verb the user typed, as sent to the prepare endpoint. */
@@ -244,9 +261,6 @@ export function assertTxMatchesIntent(
   // meaningless (a local chain publishes its own), so the host flag is the
   // only lock left. That is the operator's explicit choice.
   if (opts.allowUntrusted) {
-    return;
-  }
-  if (HOST_PINNED_ONLY.has(intent.action)) {
     return;
   }
 

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['esm'],
   dts: false,
   clean: true,
-  sourcemap: true,
+  sourcemap: false,
   // Bundle ALL deps so the CLI is a self-contained binary. Fixes Node 25+ ESM
   // strictness when npm flattens transitive deps in global installs.
   noExternal: [/.*/],

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@t2000/discovery",
   "version": "10.32.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Probe and validate x402 seller endpoints on Sui — 402 accepts[] / WWW-Authenticate probing plus OpenAPI paid-endpoint extraction. The discovery half of the @t2000 serve stack.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/discovery/tsup.config.ts
+++ b/packages/discovery/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     clean: true,
-    sourcemap: true,
+    sourcemap: false,
     splitting: false,
     treeshake: true,
   },

--- a/packages/id/README.md
+++ b/packages/id/README.md
@@ -31,7 +31,17 @@ const tx = buildRegisterTx({
 | `buildUpdateTx(reg?)` | `update` (full-replace) | the agent |
 | `buildSetActiveTx(agent, active)` | `set_active` | the agent |
 
-Package + Registry object ids are baked in (mainnet) and overridable via `AGENT_ID_PACKAGE_ID` / `AGENT_ID_REGISTRY_ID` env vars for testnet/dev.
+Two tiers of ids (S.1049):
+
+- **`MAINNET_AGENT_ID_PACKAGE_ID` / `MAINNET_AGENT_ID_REGISTRY_ID`** — literal
+  mainnet trust anchors, never influenced by the environment. Anything that
+  *verifies* a transaction before signing (allowlists, intent guards) must
+  use these.
+- **`AGENT_ID_PACKAGE_ID` / `AGENT_ID_REGISTRY_ID`** — builder ids, overridable
+  via the same-named env vars for testnet/dev. These are conveniences for
+  *constructing* transactions, **not** a security boundary: a guard that read
+  them would let whoever controls the environment supply both the transaction
+  and the yardstick it is checked against.
 
 ## License
 

--- a/packages/id/package.json
+++ b/packages/id/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@t2000/id",
   "version": "10.32.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Agent ID — on-chain agent identity registry client for the t2000 stack (Sui). Build register/update/ownership/active transactions against the agent_id::registry Move package.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/id/src/index.test.ts
+++ b/packages/id/src/index.test.ts
@@ -38,3 +38,35 @@ describe('@t2000/id builders', () => {
     expect(Object.keys(mod).filter((k) => /[Oo]wner/.test(k))).toEqual([]);
   });
 });
+
+// S.1049 — MAINNET trust anchors: literals, never env-influenced. The
+// builder ids may follow AGENT_ID_PACKAGE_ID env for testnet/dev; the
+// MAINNET_* pair must not move, because signature-time verification (the
+// CLI intent guard) checks prepared bytes against THEM.
+describe('MAINNET trust anchors (S.1049)', () => {
+  it('are the pinned mainnet literals', async () => {
+    const mod = await import('./index.js');
+    expect(mod.MAINNET_AGENT_ID_PACKAGE_ID).toBe(
+      '0xe94a8b8f14104b75ee4c7e359289da78698fbfffdd0e5e3e9cb7d250887df7a7',
+    );
+    expect(mod.MAINNET_AGENT_ID_REGISTRY_ID).toBe(
+      '0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119',
+    );
+  });
+
+  it('a poisoned env moves the BUILDER id, never the MAINNET literal', async () => {
+    const { vi } = await import('vitest');
+    vi.resetModules();
+    process.env.AGENT_ID_PACKAGE_ID = `0x${'e'.repeat(64)}`;
+    try {
+      const fresh = await import('./index.js');
+      expect(fresh.AGENT_ID_PACKAGE_ID).toBe(`0x${'e'.repeat(64)}`);
+      expect(fresh.MAINNET_AGENT_ID_PACKAGE_ID).toBe(
+        '0xe94a8b8f14104b75ee4c7e359289da78698fbfffdd0e5e3e9cb7d250887df7a7',
+      );
+    } finally {
+      delete process.env.AGENT_ID_PACKAGE_ID;
+      vi.resetModules();
+    }
+  });
+});

--- a/packages/id/src/index.ts
+++ b/packages/id/src/index.ts
@@ -18,21 +18,36 @@ import { deriveDynamicFieldID } from '@mysten/sui/utils';
  * Deployed on Sui mainnet 2026-06-29. Override via env for testnet/dev.
  */
 
-/** The published `agent_id` package id — pin the LATEST upgrade id ONLY
- *  (the S.1019 rule; event/type anchors stay on the original package
- *  `0x7669be20…be9a45e9`, which remains callable for its own functions).
- *  LATEST = the S.1032 v2 upgrade (2026-08-13, ownership deprecated;
- *  Registry migrated to version 2 — upgrade digest 7ZUiRi48…, migrate
- *  digest 97sNqgt9…). The previous id `0x78d36506…d15451` now aborts
+/** MAINNET trust anchor (S.1049 — the S.930 escrow pattern): the published
+ *  `agent_id` package id as a LITERAL, never `process.env`. Signature-time
+ *  verification (the CLI intent guard's allowlist) imports THIS — reading
+ *  the env-aware constant below would let an attacker who controls the
+ *  environment supply both the transaction and the yardstick.
+ *
+ *  Pin the LATEST upgrade id ONLY (the S.1019 rule; event/type anchors stay
+ *  on the original package `0x7669be20…be9a45e9`, which remains callable for
+ *  its own functions). LATEST = the S.1032 v2 upgrade (2026-08-13, ownership
+ *  deprecated; Registry migrated to version 2 — upgrade digest 7ZUiRi48…,
+ *  migrate digest 97sNqgt9…). The previous id `0x78d36506…d15451` now aborts
  *  EWrongVersion on every mutator. */
-export const AGENT_ID_PACKAGE_ID =
-  process.env.AGENT_ID_PACKAGE_ID ??
+export const MAINNET_AGENT_ID_PACKAGE_ID =
   '0xe94a8b8f14104b75ee4c7e359289da78698fbfffdd0e5e3e9cb7d250887df7a7';
 
-/** The shared `Registry` object id. */
-export const AGENT_ID_REGISTRY_ID =
-  process.env.AGENT_ID_REGISTRY_ID ??
+/** MAINNET trust anchor: the shared `Registry` object id (same rule —
+ *  literal, never env). */
+export const MAINNET_AGENT_ID_REGISTRY_ID =
   '0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119';
+
+/** BUILDER id — env-overridable for testnet/dev. NOT a trust anchor:
+ *  transaction BUILDERS may read it so a dev chain works, but guards and
+ *  allowlists must use MAINNET_AGENT_ID_PACKAGE_ID (S.1049). */
+export const AGENT_ID_PACKAGE_ID =
+  process.env.AGENT_ID_PACKAGE_ID ?? MAINNET_AGENT_ID_PACKAGE_ID;
+
+/** BUILDER id — env-overridable for testnet/dev; same not-a-trust-anchor
+ *  rule as AGENT_ID_PACKAGE_ID. */
+export const AGENT_ID_REGISTRY_ID =
+  process.env.AGENT_ID_REGISTRY_ID ?? MAINNET_AGENT_ID_REGISTRY_ID;
 
 const CLOCK_ID = '0x6';
 const MODULE = 'registry';

--- a/packages/id/tsup.config.ts
+++ b/packages/id/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     clean: true,
-    sourcemap: true,
+    sourcemap: false,
     splitting: false,
     treeshake: true,
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@t2000/sdk",
   "version": "10.32.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "TypeScript SDK for Agent Wallets on Sui — gasless USDC + USDsui transfers, Cetus swap routing, NAVI lending (programmatic), MPP paid API access, zkLogin compatible.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     clean: true,
-    sourcemap: true,
+    sourcemap: false,
     splitting: false,
     treeshake: true,
   },

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@t2000/serve",
   "version": "10.32.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "Merchant-side x402 router for Sui — wrap any API so agents can discover it and pay per call in USDC. One builder: .paid().body().handler(). Sign-then-settle, no seller key, no seller gas.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/serve/tsup.config.ts
+++ b/packages/serve/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     clean: true,
-    sourcemap: true,
+    sourcemap: false,
     splitting: false,
     treeshake: true,
   },

--- a/packages/x402/package.json
+++ b/packages/x402/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@t2000/sui-x402",
   "version": "10.32.0",
+  "engines": {
+    "node": ">=20"
+  },
   "description": "The x402 payment dialect for Sui — scheme `exact`, sign-then-settle gasless USDC. Requirements builders, header parse/verify/settle, and the digest replay store shared by @t2000/serve and @t2000/sdk.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/x402/tsup.config.ts
+++ b/packages/x402/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig([
     format: ['esm', 'cjs'],
     dts: true,
     clean: true,
-    sourcemap: true,
+    sourcemap: false,
     splitting: false,
     treeshake: true,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@mysten/sui': ^2.17.0
   '@mysten/bcs': ^2.0.1
+  valibot: ^1.4.2
 
 importers:
 
@@ -43,7 +44,7 @@ importers:
   packages/cli:
     dependencies:
       '@t2000/id':
-        specifier: workspace:^
+        specifier: workspace:*
         version: link:../id
       qrcode:
         specifier: ^1.5.4
@@ -5266,8 +5267,8 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  valibot@1.3.1:
-    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -6711,7 +6712,7 @@ snapshots:
       gql.tada: 1.9.1(graphql@16.13.2)(typescript@5.9.3)
       graphql: 16.13.2
       poseidon-lite: 0.2.1
-      valibot: 1.3.1(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
     transitivePeerDependencies:
       - '@gql.tada/svelte-support'
       - '@gql.tada/vue-support'
@@ -11982,7 +11983,7 @@ snapshots:
 
   uuid@11.1.1: {}
 
-  valibot@1.3.1(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
Aegis unpaid pre-hire supply-chain scan of lockstep 10.32.0 — founder triage 2026-08-15: fix the Highs + pin + provenance; riders where cheap. After merge + the next lockstep **patch** publish, a re-scan should no longer report C-1, I-1, C-2, or X-1.

## I-1 (High) — `@t2000/id` MAINNET trust anchors
`MAINNET_AGENT_ID_PACKAGE_ID` / `MAINNET_AGENT_ID_REGISTRY_ID` exported as **literals** (the S.930 escrow pattern; same values that previously sat behind `process.env` fallbacks). The env-aware `AGENT_ID_PACKAGE_ID`/`AGENT_ID_REGISTRY_ID` survive as builder conveniences for testnet/dev, documented as *not* trust anchors; README rewritten accordingly. Builders unchanged.

## C-1 (High) — intent-verify Agent ID verbs; `HOST_PINNED_ONLY` deleted
`register` used to return **before any `pkg::module::fn` check** and sign host-prepared bytes blind. Now `register`/`update`/`set-active` are `ACTION_TARGETS` entries pinned to the **MAINNET literal** (never the env-poisonable constant); `link`/`confirm` (gone since S.1032) refuse as unknown verbs. `t2 agent sell` (endpoint list/remove) now runs `assertTxMatchesIntent(…, { action: 'update' })` before signing — it was host-pin-only, with a stale comment calling registry verification "theatre". Host pin + `--allow-untrusted-api` contracts unchanged.

**Tests:** registry allow/refuse matrix; a poisoned `AGENT_ID_PACKAGE_ID` env **cannot widen the allowlist** (fresh-import under poisoned env still refuses 0xevil and still accepts mainnet); link/confirm refusal; MAINNET-literal pins + builder-vs-anchor env split in `@t2000/id`.

## C-2 — exact `@t2000/id` pin
CLI `workspace:^` → `workspace:*` (publishes the exact lockstep version like sdk/serve; `^10.32.0` was a range a malicious id patch could satisfy).

## X-1 — provenance must actually land
`@t2000/cli@10.32.0` (and siblings) have **no `dist.attestations`** despite `--provenance`. Local diagnosis: a *direct* `pnpm publish` forwards the flag to npm; the workflow's **recursive `pnpm --filter … publish` does not reliably forward it**. Fixes in `publish.yml`:
1. `NPM_CONFIG_PROVENANCE: 'true'` on all six publish steps (npm reads config regardless of flag routing).
2. `continue-on-error` **dropped** on sdk/cli/id/serve — the already-published E409 is the only tolerated failure (same tee‖grep as x402/discovery).
3. New **Verify provenance attached** step: fails the job when a version *newly published this run* has no `dist.attestations` (idempotent re-runs of old versions skip).

**X-1 status: not yet closed — needs the next publish as evidence.**
- [ ] **Founder ops:** trigger `release.yml` bump=**patch** when ready; the Verify step is the proof. If it fails, the documented fallback is npm **Trusted Publishing** (each @t2000/* package → Settings → Publishing access → add this repo's `publish.yml` as Trusted Publisher, then drop `NPM_TOKEN`) — spelled out in the job comment.

## Riders
- **C-3:** `sourcemap: false` in all six tsup configs (CLI tarball was 63% maps).
- **C-4:** `engines.node >=20` on all six published `package.json`s.
- **S-1/S-2:** `pnpm.overrides` `valibot ^1.4.2` — tree previously resolved 1.3.1 under `@mysten/sui`; verified via `pnpm why` (1.4.2 everywhere), sdk suite green. Do **not** run `npm audit fix --force` (it downgrades sui).

## Out of scope (per triage)
C-5 spend caps · S-3 elliptic via @phala/dcap-qvl (accepted) · claim griefing · Connect/MCP sponsored-signing parity (tracker note: owed — Connect register/endpoint intent-verify).

**Verify:** id 7/7 · cli 289/289 (46 in tx-guard) · sdk 570/570 · typecheck+lint 9/9 tasks · CLI build bundles the new import. **No publish from this PR** — founder triggers the patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)