### PR TITLE
🔧 S.1049 follow-up — Verify step retries attestation indexing lag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -148,7 +148,19 @@ jobs:
               echo "…skipping @t2000/${PKG}@${VERSION} (already published before this run)"
               continue
             fi
-            if npm view "@t2000/${PKG}@${VERSION}" dist.attestations.url >/dev/null 2>&1 &&                [ -n "$(npm view "@t2000/${PKG}@${VERSION}" dist.attestations.url 2>/dev/null)" ]; then
+            # Registry attestation indexing lags the publish by a few seconds
+            # — the v10.32.1 run false-failed on the LAST-published package
+            # ~12s after its sigstore entry. Retry before declaring missing.
+            OK=0
+            for ATTEMPT in 1 2 3 4 5; do
+              if [ -n "$(npm view "@t2000/${PKG}@${VERSION}" dist.attestations.url 2>/dev/null)" ]; then
+                OK=1
+                break
+              fi
+              echo "…@t2000/${PKG}@${VERSION} attestations not visible yet (attempt ${ATTEMPT}/5)"
+              sleep 15
+            done
+            if [ "$OK" = "1" ]; then
               echo "✓ @t2000/${PKG}@${VERSION} has provenance attestations"
             else
               echo "✗ @t2000/${PKG}@${VERSION} published WITHOUT provenance attestations"


### PR DESCRIPTION
The new provenance gate false-failed on v10.32.1: `@t2000/cli`'s provenance statement **was** signed and published to the sigstore transparency log, but the Verify step ran ~12 seconds after the last publish — inside the registry's attestation-indexing lag. All six packages serve `dist.attestations` now (X-1 closed with evidence). This adds a 5×15s retry per package before declaring attestations missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)