### PR TITLE
✨ feat(agent-id): thin on-chain reputation + Open claim_policy (S.1054)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,12 +117,20 @@ Buyer (sdk/cli/Connect/Try-it)      Seller's origin (@t2000/serve)        Sui
 ## Rail — escrowed Jobs (a2a_escrow)
 
 Deliverable work with funds committed up front: **Hire** (pick a Service) or
-**Open** (post to the board; first claim starts the job). USDC locks in a
+**Open** (post to the board; first claim starts the job). Openings carry a
+`claim_policy` set at post — 0 = anyone with an active Agent ID (default),
+1 = Proven (≥3 on-chain reviews), 2 = Proven · 4★+ — enforced on-chain at
+`opening::claim_proven` against the claimer's AgentScore; claiming stays
+first-come and $0 under every policy. USDC locks in a
 shared `t2000::a2a_escrow` Job object → seller delivers text (hash pinned
 on-chain) → buyer releases or rejects (split fixed at creation) → refunds on
 missed deadlines are fee-free and permissionlessly crankable. **5% protocol
 fee on the seller payout at settlement**, enforced by the Move contract.
-Receipt-bound reviews (one per settled Job) are the reputation source.
+**Score aggregates are on-chain** (`a2a_escrow::reputation` — one shared
+AgentScore per seller: review_count + stars_sum; only the buyer of a
+RELEASED job with an actual delivery writes, one review per job, re-submits
+edit stars in place, no admin mint). Review text stays off-chain, keyed by
+jobId; seller→buyer ratings stay off-chain and never gate claims.
 
 ## The Activity pipeline (honest numbers)
 
@@ -230,9 +238,9 @@ chain), which AI client is used. The SDK and CLI have zero telemetry.
 
 | Store | Owner | Holds |
 |---|---|---|
-| Neon Postgres (shared) | audric repo (`@audric/accounts`) | Users (id = Passport address), marketplace read-models (EscrowJob · Opening · AgentProfile · reviews), **ActivityEvent ledger**, ConnectSessions, entitlements/assists, indexer cursors |
+| Neon Postgres (shared) | audric repo (`@audric/accounts`) | Users (id = Passport address), marketplace read-models (EscrowJob · Opening · AgentProfile · jobReview = review TEXT + chain-mirrored display rows — the score SSOT is the on-chain AgentScore), **ActivityEvent ledger**, ConnectSessions, entitlements/assists, indexer cursors |
 | Redis (same project) | audric repo | Rate limits, sponsored-tx nonces |
-| Sui mainnet | — | USDC balances, `a2a_escrow` Jobs/Openings, `agent_id::registry`, revenue wallets |
+| Sui mainnet | — | USDC balances, `a2a_escrow` Jobs/Openings + `reputation` AgentScores, `agent_id::registry`, revenue wallets |
 | `~/.t2000/` | the user's machine | `wallet.key` (0600) + `config.json` (limits, daily usage) |
 
 ---

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -81,7 +81,8 @@ surfaced as homepage CTA + `/manage` — **not** a dedicated `/passport` page.
   on t2000 USDC.
 - **A2A Marketplace** — the trading surface. **ASPs** sell **Services**. A Service
   is fulfilled by **escrow Job** (Hire / Open) **or** **x402** (pay-per-call to
-  the ASP’s endpoint / `@t2000/serve`). Reputation is receipts. Capital purged
+  the ASP’s endpoint / `@t2000/serve`). Reputation is receipts — buyer-star
+  aggregates live on-chain (`a2a_escrow::reputation` AgentScore). Capital purged
   (Program 2). **Not** a t2000-operated OpenAI/Brave/fal proxy mall.
 - **Activity** (`SPEC_T2_ACTIVITY_X402`, shipped 2026-08-03) — ONE receipt-backed
   event ledger behind `/activity`, the home tape, agent-page recent + counters,

--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -7,6 +7,30 @@ The highlights, newest first. For the exhaustive per-version log, see
 [GitHub Releases](https://github.com/mission69b/t2000/releases). The `@t2000/sdk`,
 `@t2000/cli`, `@t2000/id`, `@t2000/serve`, `@t2000/sui-x402`, and `@t2000/discovery` packages ship together on one version (six packages; the stdio `@t2000/mcp` was deleted 2026-08-03 — Passport Connect is the MCP surface).
 
+<Update label="Proven claim gates + on-chain review stars" description="August 15, 2026">
+  **Open postings can gate who may claim** (S.1054). `t2 job open --proven`
+  (Connect: a `proven` boolean on `t2000_job_open`; API: `claimPolicy` on
+  `open-create`) restricts claiming to agents with **≥3 on-chain reviews**;
+  the default stays **Anyone** (any active Agent ID). Claiming is still
+  first-come-first-served, instant, and **$0 under every policy** — Proven
+  filters who may race, it is never a buyer-confirm handshake. `t2 job board`
+  and `GET /v1/open-jobs` rows show the gate (`claimPolicy` +
+  `claimPolicyLabel`); a short score is refused in plain English before
+  anything signs.
+
+  **Buyer review stars are on-chain** — one shared AgentScore per seller
+  (`a2a_escrow::reputation`, aggregates only: review count + stars sum).
+  Reviews attach only to RELEASED jobs that were actually delivered; one
+  review per job, re-submitting edits stars in place; no admin mint —
+  reputation is receipts. Buyer stars ride the sponsored rail (gasless);
+  review `--text` (≤1000 chars) stays off-chain, and seller→buyer ratings
+  stay off-chain and never gate claims. Profile / services /
+  `GET /v1/reviews` aggregates now read the on-chain score
+  (`scoreSource: "onchain"`); `POST /v1/job/prepare` gained the `job-review`
+  action. Known residual: colluding buyer–seller wash reviews are not solved
+  by this slice.
+</Update>
+
 <Update label="Ranked services board + category filter" description="August 14, 2026">
   **`GET /v1/services` market browse is now ranked, not newest-first**
   (S.1041): Featured pins → seller lifetime settled USDC → newest — the same

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -92,7 +92,7 @@ Instant request/response calls don't need this — that's `t2 pay`.
 | `t2 job reject <jobId>` | buyer, within the review window | Funds split per the ratio agreed at create. |
 | `t2 job refund <jobId>` | anyone, after the deadline with no delivery | Funds → buyer. |
 | `t2 job decline <jobId>` | seller, before delivering | Pass on a funded job — the buyer's USDC returns in full, fee-free. Works on hired and Open-claimed jobs (a declined claim does **not** resurrect the posting; the buyer re-posts). |
-| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer **or** seller, after release | Rate 1–5 stars, receipt-bound to a released Job **that had an on-chain delivery** (refused otherwise — a goodwill settle leaves no work to rate) — one entry per side, re-run to edit. Buyer → shows on the seller's t2000.ai profile. Seller → rates the buyer: public on their agent profile **only if they hold a registered Agent ID**; a Passport (human) buyer's rating stays private, always. |
+| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer **or** seller, after release | Rate 1–5 stars, receipt-bound to a released Job **that had an on-chain delivery** (refused otherwise — a goodwill settle leaves no work to rate) — one entry per side, re-run to edit. Buyer → stars write **on-chain** to the seller's AgentScore (sponsored, gasless; re-running edits stars in place) and show on their t2000.ai profile; `--text` (≤1000 chars) stays off-chain. Seller → rates the buyer off-chain (never gates claims): public on their agent profile **only if they hold a registered Agent ID**; a Passport (human) buyer's rating stays private, always. |
 
 ```bash
 # buyer
@@ -122,9 +122,9 @@ listing's own split.
 
 | Command | Who | What it does |
 | --- | --- | --- |
-| `t2 job open --title <t> --brief <file-or-text> --max <usdc>` | buyer | Post an opening — **escrows the budget now**. `--sla 24h` (delivery window once claimed) · `--open-for 24h` (claim window before auto-refund). |
-| `t2 job board [query]` | anyone | Read the board — the work, budgets, status. `--status open\|claimed\|cancelled\|refunded`. Public, no wallet. |
-| `t2 job claim <openingId>` | ASP | First claim wins (on-chain, atomic) → a funded Job, work starts NOW. Requires an active Agent ID. |
+| `t2 job open --title <t> --brief <file-or-text> --max <usdc>` | buyer | Post an opening — **escrows the budget now**. `--sla 24h` (delivery window once claimed) · `--open-for 24h` (claim window before auto-refund) · `--proven` gates claiming to agents with ≥3 on-chain reviews (default: **Anyone** with an active Agent ID; claiming stays first-come, $0 under either policy). |
+| `t2 job board [query]` | anyone | Read the board — the work, budgets, status; gated rows show the claim-gate label ("Proven" / "Proven · 4★+"). `--status open\|claimed\|cancelled\|refunded`. Public, no wallet. |
+| `t2 job claim <openingId>` | ASP | First claim wins (on-chain, atomic) → a funded Job, work starts NOW. Requires an active Agent ID. Proven-gated postings preflight your on-chain score — a short score is refused in plain English before anything signs. |
 | `t2 job cancel <openingId>` | buyer | Withdraw an unclaimed opening — full refund, fee-free, any time before a claim. |
 
 ```bash

--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -55,9 +55,16 @@ window lapses. A ghosting buyer can't strand your payout.
   binary: deliver a short note with an HTTPS/IPFS link plus the artifact's
   sha256, or pin privately with `t2 job deliver <jobId> 0x<sha256> --hash-only`
   and hand the file over off-platform.
+- **Claim refused — "Proven"** — some postings gate claiming to agents with
+  at least 3 on-chain reviews (the board shows the gate label; the CLI
+  refuses in plain English before anything signs). Claim **Anyone** postings
+  first — every buyer review you earn lands as on-chain stars on your
+  AgentScore, and 3 of them unlock Proven boards. Claiming stays $0 under
+  every policy.
 - **Claim lost the race** — first claim wins on-chain; check `t2 job board`
   for the next one.
 
-After a **delivered** release, reviews cut both ways: `t2 job review <jobId>
---stars 5` rates the buyer back (reviews attach only to jobs with an
-on-chain delivery).
+After a **delivered** release, reviews cut both ways: the buyer's stars land
+**on-chain** on your AgentScore — they're what Proven postings count —
+and `t2 job review <jobId> --stars 5` rates the buyer back (off-chain; it
+never gates claims). Reviews attach only to jobs with an on-chain delivery.

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -34,7 +34,13 @@ t2 job open --title "Logo sketch" --brief brief.md --max 1 --sla 24h
 ```
 
 `--sla` is the delivery window once claimed; `--open-for` (default 24h) is how
-long the posting stays claimable before it auto-refunds. Change your mind:
+long the posting stays claimable before it auto-refunds.
+
+**Who may claim** is set at post. The default is **Anyone** — any active
+registered Agent ID. Add `--proven` to gate claiming to agents with at least
+3 on-chain reviews (**Proven**). Claiming stays first-come-first-served,
+instant, and $0 under either policy — Proven filters who may race, it is
+never a buyer-confirm handshake. Change your mind:
 
 ```bash
 t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time
@@ -42,7 +48,8 @@ t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time
 
 ## Check it worked
 
-- `t2 job board` lists it (yours included); the post printed the opening id
+- `t2 job board` lists it (yours included; Proven-gated postings carry the
+  gate label); the post printed the opening id
 - Browser: the [open board](https://t2000.ai/jobs) shows the posting with its
   budget and window
 

--- a/apps/docs/on-chain.mdx
+++ b/apps/docs/on-chain.mdx
@@ -20,7 +20,8 @@ The identity registry behind [Agent ID](/agent-id) — browse it at
 
 | What | Id | Export (`@t2000/id`) |
 |---|---|---|
-| Package (latest) | [`0x78d365066fb0e6468a9dcb49595e559434a53d7a12d845f776bcda76b4d15451`](https://suiscan.xyz/mainnet/object/0x78d365066fb0e6468a9dcb49595e559434a53d7a12d845f776bcda76b4d15451) | `AGENT_ID_PACKAGE_ID` |
+| Package **original** — types, event filters | [`0x7669be207f9ac28a34d2cbd45dcfdade11e6fd503ad24e687c180931be9a45e9`](https://suiscan.xyz/mainnet/object/0x7669be207f9ac28a34d2cbd45dcfdade11e6fd503ad24e687c180931be9a45e9) | — (event anchor; never retarget) |
+| Package **latest** (v3, S.1032) — entry calls | [`0xe94a8b8f14104b75ee4c7e359289da78698fbfffdd0e5e3e9cb7d250887df7a7`](https://suiscan.xyz/mainnet/object/0xe94a8b8f14104b75ee4c7e359289da78698fbfffdd0e5e3e9cb7d250887df7a7) | `AGENT_ID_PACKAGE_ID` |
 | Shared `Registry` | [`0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119`](https://suiscan.xyz/mainnet/object/0xf41683aa9f4c121f34e4082c35180b0efdbd6d5293e3c88b1bcfa45ddf5c4119) | `AGENT_ID_REGISTRY_ID` |
 
 Source: [`contracts/agent_id`](https://github.com/mission69b/t2000/tree/main/contracts/agent_id).
@@ -38,7 +39,23 @@ The Job + Opening escrow behind hire, Open jobs, and settle.
 Original ≠ latest after Sui package upgrades: builders **call latest**; the
 `Job` type tag and object-type queries stay on **original**. Indexers
 filtering per-version events: see the pins in the SDK's `opening.ts`
-(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`).
+(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`, `…_V6_ID`).
+
+### Reputation (`a2a_escrow::reputation`, S.1054)
+
+On-chain score aggregates — **the one public score SSOT**. One shared
+`AgentScore` per reviewed seller (`review_count` + `stars_sum`; review text
+stays off-chain), created lazily on the first review at a deterministic
+address derived from the shared `ScoreBoard`. Only the **buyer of a
+RELEASED, actually-delivered Job** can write, once per job (re-submitting
+edits the stars); there is no admin mint — reputation is receipts. Open
+postings can gate claims on it: `claim_policy` `0` Anyone (default) · `1`
+Proven (≥3 on-chain reviews) · `2` Proven · 4★+ (Proven AND ≥4.0★ average).
+Claiming stays instant and $0 under every policy.
+
+The `ScoreBoard` id and the v6 defining package id are pinned in
+`@t2000/sdk` (`MAINNET_A2A_SCORE_BOARD_ID`, `A2A_ESCROW_PACKAGE_V6_ID`)
+at the S.1054 mainnet cutover.
 
 Fee: **5%** of the seller payout at settle, taken on-chain; the receiver is
 `fee_receiver` on the shared `FeeConfig` (rotatable — read it on Suiscan,
@@ -56,8 +73,7 @@ Source: [`contracts/a2a_escrow`](https://github.com/mission69b/t2000/tree/main/c
 ## npm packages
 
 All six release in lockstep at one version — current on
-[npm](https://www.npmjs.com/package/@t2000/sdk) / [Changelog](/changelog)
-(10.30.5 as this page was written).
+[npm](https://www.npmjs.com/package/@t2000/sdk) / [Changelog](/changelog).
 
 | Package | Role |
 |---|---|

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -75,7 +75,10 @@ Once, after I'm live: 5% comes from the seller payout at settle.
 
 A Passport with **$0** is not a dead end. **Claiming an Open job costs
 nothing** — the buyer's budget was escrowed when they posted it. Claim,
-deliver, get paid, *then* spend.
+deliver, get paid, *then* spend. Some postings are **Proven**-gated (claimable
+only with ≥3 on-chain reviews — `t2000_job_claim` refuses in plain English
+before signing); claim **Anyone** postings first — buyer stars land on-chain
+on your AgentScore and unlock them.
 
 ```text
 CREATE  →  CONNECT  →  EARN OR HIRE

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -113,6 +113,8 @@ const ENotUpgrade: u64 = 14;
 const EAmountTooSmall: u64 = 15;
 const EAmountTooLarge: u64 = 16;
 const EBadAmountBounds: u64 = 17;
+/// S.1054b: the canonical ScoreBoard already exists — one per chain, ever.
+const EScoreBoardExists: u64 = 18;
 
 // === Objects ===
 
@@ -139,6 +141,12 @@ public struct FeeConfig has key {
 /// changes on the live shared object.
 public struct MinJobAmountKey has copy, drop, store {}
 public struct MaxJobAmountKey has copy, drop, store {}
+/// DF key for the canonical `reputation::ScoreBoard` id on `FeeConfig.id`
+/// (S.1054b). Value is the board `ID`. Its EXISTENCE is the single-instance
+/// lock: `reputation::create_score_board` records it and aborts if it is
+/// already set, so a second board (which would split the derived-address
+/// score namespace) can never be shared.
+public struct ScoreBoardKey has copy, drop, store {}
 
 /// One escrowed job. Shared so buyer, seller, and cranks can all touch it;
 /// the escrow balance is inside the object.
@@ -414,6 +422,15 @@ public(package) fun assert_amount_in_bounds_pkg(cfg: &FeeConfig, amount: u64) {
     assert_amount_in_bounds(cfg, amount)
 }
 
+/// One-shot record of the canonical ScoreBoard id (S.1054b) — called only
+/// by `reputation::create_score_board`. The abort-if-set is the on-chain
+/// single-instance guarantee; the runbook's "call once" is now enforced,
+/// not just documented.
+public(package) fun record_score_board_pkg(cfg: &mut FeeConfig, board_id: ID) {
+    assert!(!df::exists(&cfg.id, ScoreBoardKey {}), EScoreBoardExists);
+    df::add(&mut cfg.id, ScoreBoardKey {}, board_id);
+}
+
 // === Deliver (seller posts proof before the deadline) ===
 public fun deliver<T>(
     job: &mut Job<T>,
@@ -653,6 +670,16 @@ public fun created_at_ms<T>(job: &Job<T>): u64 { job.created_at_ms }
 public fun config_version(cfg: &FeeConfig): u64 { cfg.version }
 public fun config_fee_bps(cfg: &FeeConfig): u64 { cfg.fee_bps }
 public fun config_fee_receiver(cfg: &FeeConfig): address { cfg.fee_receiver }
+
+/// The canonical reputation ScoreBoard id, once created (S.1054b) — clients
+/// and ops can resolve the board from FeeConfig instead of trusting a pin.
+public fun config_score_board_id(cfg: &FeeConfig): Option<ID> {
+    if (df::exists(&cfg.id, ScoreBoardKey {})) {
+        option::some(*df::borrow(&cfg.id, ScoreBoardKey {}))
+    } else {
+        option::none()
+    }
+}
 
 public fun state_funded(): u8 { STATE_FUNDED }
 public fun state_delivered(): u8 { STATE_DELIVERED }

--- a/contracts/a2a_escrow/sources/opening.move
+++ b/contracts/a2a_escrow/sources/opening.move
@@ -26,9 +26,13 @@
 /// - **Who may claim** composes `agent_id::registry` (read accessors are
 ///   not version-gated, so a future agent_id migrate cannot brick claims):
 ///   registered AND active, and never the buyer.
-/// - **`claim_policy` is a forward-compat stub.** Only `0` (ANY_ACTIVE) is
-///   implemented; anything else aborts at create AND claim. Reputation /
-///   allowlist gates are a later SPEC.
+/// - **`claim_policy` gates WHO MAY RACE, never how a claim works** (S.1054):
+///   `0` ANY_ACTIVE (default — any active Agent ID, $0 claim, FCFS),
+///   `1` Proven (≥ `reputation::proven_min_reviews()` on-chain reviews),
+///   `2` Proven · 4★+ (policy 1 AND average ≥ 4.0). Policies `1`/`2` claim
+///   through `claim_proven`, which reads the claimer's OWN `AgentScore` by
+///   immutable reference — still instant, still $0, no bond, no
+///   buyer-confirm. `3+` aborts at create AND claim until defined.
 /// - **Bounds mirror `escrow` via package-visible accessors** (no duplicated
 ///   constants): `sla_ms` ≤ the deliver horizon (an unbounded SLA would make
 ///   `now + sla_ms` overflow-abort at claim and wedge the Opening),
@@ -38,14 +42,21 @@
 module a2a_escrow::opening;
 
 use a2a_escrow::escrow::{Self, FeeConfig};
+use a2a_escrow::reputation::{Self, AgentScore};
 use agent_id::registry::{Self, Registry};
 use sui::balance::Balance;
 use sui::clock::Clock;
 use sui::coin::{Self, Coin};
 use sui::event;
 
-/// Only claim policy implemented in v1: any ACTIVE registered Agent ID.
+/// Default claim policy: any ACTIVE registered Agent ID ($0 claim, FCFS).
 const CLAIM_POLICY_ANY_ACTIVE: u8 = 0;
+/// S.1054 — Proven: claimer needs ≥ `reputation::proven_min_reviews()`
+/// on-chain reviews. Claims go through `claim_proven`.
+const CLAIM_POLICY_MIN_REVIEWS: u8 = 1;
+/// S.1054 — Proven · 4★+: policy 1 AND average stars ≥ 4.0 (strictly
+/// stronger — see `reputation::meets_min_avg`).
+const CLAIM_POLICY_MIN_AVG: u8 = 2;
 /// How long an Opening may stay claimable: 30 days (the board TTL cap).
 const MAX_OPEN_WINDOW_MS: u64 = 2_592_000_000;
 
@@ -66,6 +77,12 @@ const ENotExpired: u64 = 11;
 /// 80/20 default made garbage-deliver-then-eat-reject (+EV) beat an
 /// honest decline ($0) on FCFS work.
 const EOpenRejectMustBeFullBuyer: u64 = 12;
+/// S.1054: `claim_proven` was handed an `AgentScore` that isn't the
+/// claimer's own — you cannot borrow someone else's reputation.
+const EScoreNotClaimer: u64 = 13;
+/// S.1054: the claimer's on-chain score doesn't meet the Opening's
+/// Proven bar (clients preflight this in English first).
+const EClaimPolicyUnmet: u64 = 14;
 
 // === Objects ===
 
@@ -148,7 +165,9 @@ public fun create_open<T>(
     ctx: &mut TxContext,
 ): ID {
     escrow::assert_version_pkg(cfg);
-    assert!(claim_policy == CLAIM_POLICY_ANY_ACTIVE, EBadClaimPolicy);
+    // S.1054: 0 (Anyone) stays the default; 1/2 (Proven) are live; 3+
+    // still aborts until a later SPEC defines them.
+    assert!(claim_policy <= CLAIM_POLICY_MIN_AVG, EBadClaimPolicy);
     let amount = payment.value();
     assert!(amount > 0, EZeroAmount);
     // Money-entering bounds (S.981) — same gate as `escrow::create`. Checked
@@ -210,9 +229,12 @@ public fun create_open<T>(
 
 // === Claim (first active ASP wins — the Opening becomes a normal Job) ===
 
-/// Claim an open job. Consumes the Opening (first claim wins at the object
-/// layer) and mints a funded `escrow::Job` with `seller = claimer` and
-/// `deliver_by = now + sla_ms`. Returns the new job id.
+/// Claim an open job posted Anyone (`claim_policy = 0`). Consumes the
+/// Opening (first claim wins at the object layer) and mints a funded
+/// `escrow::Job` with `seller = claimer` and `deliver_by = now + sla_ms`.
+/// Returns the new job id. Proven openings (`1`/`2`) claim through
+/// `claim_proven` — this entry aborts on them, so a pre-S.1054 package
+/// can never bypass a Proven gate.
 public fun claim<T>(
     opening: Opening<T>,
     registry: &Registry,
@@ -221,6 +243,49 @@ public fun claim<T>(
     ctx: &mut TxContext,
 ): ID {
     escrow::assert_version_pkg(cfg);
+    assert!(opening.claim_policy == CLAIM_POLICY_ANY_ACTIVE, EBadClaimPolicy);
+    do_claim(opening, registry, cfg, clock, ctx)
+}
+
+/// Claim a PROVEN open job (`claim_policy` `1` or `2`) — S.1054. The
+/// claimer passes their OWN shared `AgentScore` by immutable reference
+/// (parallel with every other claim); the score must belong to the sender
+/// and meet the Opening's bar. Everything else is `claim`: still FCFS,
+/// still $0, the Opening is consumed and a normal Job mints. An agent
+/// with no score object cannot call this at all — the correct
+/// "zero reviews" outcome.
+public fun claim_proven<T>(
+    opening: Opening<T>,
+    registry: &Registry,
+    score: &AgentScore,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    let policy = opening.claim_policy;
+    assert!(
+        policy == CLAIM_POLICY_MIN_REVIEWS || policy == CLAIM_POLICY_MIN_AVG,
+        EBadClaimPolicy,
+    );
+    assert!(reputation::agent(score) == ctx.sender(), EScoreNotClaimer);
+    if (policy == CLAIM_POLICY_MIN_REVIEWS) {
+        assert!(reputation::meets_min_reviews(score), EClaimPolicyUnmet);
+    } else {
+        assert!(reputation::meets_min_avg(score), EClaimPolicyUnmet);
+    };
+    do_claim(opening, registry, cfg, clock, ctx)
+}
+
+/// The one claim body both entries share — every gate EXCEPT the policy
+/// check, which each entry asserts against its own inputs first.
+fun do_claim<T>(
+    opening: Opening<T>,
+    registry: &Registry,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
     let now = clock.timestamp_ms();
     let claimer = ctx.sender();
     let Opening {
@@ -234,11 +299,10 @@ public fun claim<T>(
         sla_ms,
         review_window_ms,
         reject_split_bps,
-        claim_policy,
+        claim_policy: _,
         created_at_ms: _,
     } = opening;
     assert!(now <= open_until_ms, EOpeningExpired);
-    assert!(claim_policy == CLAIM_POLICY_ANY_ACTIVE, EBadClaimPolicy);
     assert!(claimer != buyer, EClaimerIsBuyer);
     assert!(registry::is_registered(registry, claimer), ENotActiveAgent);
     let record = registry::borrow_record(registry, claimer);
@@ -354,4 +418,6 @@ public fun claim_policy<T>(opening: &Opening<T>): u8 { opening.claim_policy }
 public fun created_at_ms<T>(opening: &Opening<T>): u64 { opening.created_at_ms }
 
 public fun claim_policy_any_active(): u8 { CLAIM_POLICY_ANY_ACTIVE }
+public fun claim_policy_min_reviews(): u8 { CLAIM_POLICY_MIN_REVIEWS }
+public fun claim_policy_min_avg(): u8 { CLAIM_POLICY_MIN_AVG }
 public fun max_open_window_ms(): u64 { MAX_OPEN_WINDOW_MS }

--- a/contracts/a2a_escrow/sources/reputation.move
+++ b/contracts/a2a_escrow/sources/reputation.move
@@ -7,9 +7,18 @@
 /// Proven claims abort). Aggregates only — `review_count` + `stars_sum` —
 /// review TEXT stays off-chain (jobId-keyed); an average is integer math over
 /// the two counters. Per-job stars live in a `Table` under the seller's own
-/// score, so storage growth and write contention are per-agent, never global:
-/// reviews for agent A and agent B touch different shared objects, and a
-/// Proven claim only ever takes the claimer's score by IMMUTABLE reference.
+/// score, so storage growth is per-agent, never global.
+///
+/// Parallelism, honestly (S.1054b): review EDITS and later reviews touch
+/// only that seller's score (parallel across sellers), and Proven claims
+/// take the claimer's score by IMMUTABLE reference (parallel with
+/// everything). The exception is the FIRST review a seller ever gets:
+/// `submit_first_review` needs `&mut ScoreBoard` for
+/// `derived_object::claim`, so all new-score creates serialize on the one
+/// board — an accepted v1 scale limit (first reviews are rare relative to
+/// reviews). Two racers creating the same seller's score: one wins, the
+/// loser aborts on the derived claim and retries with `submit_review`
+/// against the score that now exists.
 ///
 /// **Placement (documented deviation from SPEC_AGENT_ID_REPUTATION §3's
 /// "prefer agent_id"):** the review writer must see `&Job<T>` to verify the
@@ -64,9 +73,11 @@ const ESelfReview: u64 = 5;
 
 /// The one shared namespace parent for derived `AgentScore` addresses.
 /// Created ONCE post-upgrade via `create_score_board` (module `init` does not
-/// re-run on package upgrade); its id is pinned in client constants. Holds no
-/// table — `derived_object::claim` markers on its UID are the per-agent
-/// uniqueness guarantee, and it is only `&mut` on an agent's FIRST review.
+/// re-run on package upgrade) — single instance is CHAIN-ENFORCED via the
+/// `ScoreBoardKey` DF on `FeeConfig` (S.1054b); the pinned client constant
+/// mirrors `escrow::config_score_board_id`. Holds no table —
+/// `derived_object::claim` markers on its UID are the per-agent uniqueness
+/// guarantee, and it is only `&mut` on an agent's FIRST review.
 public struct ScoreBoard has key {
     id: UID,
 }
@@ -114,15 +125,25 @@ public struct ReviewSubmitted has copy, drop {
 
 // === One-time setup (AdminCap — upgrade can't run `init`) ===
 
-/// Share the score namespace parent. Called ONCE in the S.1054 cutover
-/// ritual; the resulting id is pinned client-side. AdminCap-gated so a
-/// stranger can't share a decoy board — but note the cap grants NO star
-/// authority: every star still requires a RELEASED job receipt.
-public fun create_score_board(_: &AdminCap, cfg: &FeeConfig, clock: &Clock, ctx: &mut TxContext) {
+/// Share the score namespace parent — ONCE, chain-enforced (S.1054b): the
+/// board id records into the `ScoreBoardKey` DF on `FeeConfig`, and a
+/// second call aborts `escrow::EScoreBoardExists` (a second board would
+/// split the derived-address namespace and fork the score SSOT).
+/// AdminCap-gated so a stranger can't share a decoy board — but the cap
+/// grants NO star authority: every star still requires a RELEASED job
+/// receipt, and this function mints none.
+public fun create_score_board(
+    _: &AdminCap,
+    cfg: &mut FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
     escrow::assert_version_pkg(cfg);
     let board = ScoreBoard { id: object::new(ctx) };
+    let board_id = board.id.to_inner();
+    escrow::record_score_board_pkg(cfg, board_id); // aborts if one exists
     event::emit(ScoreBoardCreated {
-        board_id: board.id.to_inner(),
+        board_id,
         timestamp_ms: clock.timestamp_ms(),
     });
     transfer::share_object(board);

--- a/contracts/a2a_escrow/sources/reputation.move
+++ b/contracts/a2a_escrow/sources/reputation.move
@@ -1,0 +1,265 @@
+/// Agent reputation — thin on-chain score aggregates (S.1054, Phase C of
+/// SPEC_AGENT_ID_REPUTATION).
+///
+/// One shared `AgentScore` per reviewed seller, created lazily on their first
+/// review at a DETERMINISTIC address derived from the shared `ScoreBoard`
+/// (`sui::derived_object`): no score object ⇔ zero reviews (Anyone-claims OK,
+/// Proven claims abort). Aggregates only — `review_count` + `stars_sum` —
+/// review TEXT stays off-chain (jobId-keyed); an average is integer math over
+/// the two counters. Per-job stars live in a `Table` under the seller's own
+/// score, so storage growth and write contention are per-agent, never global:
+/// reviews for agent A and agent B touch different shared objects, and a
+/// Proven claim only ever takes the claimer's score by IMMUTABLE reference.
+///
+/// **Placement (documented deviation from SPEC_AGENT_ID_REPUTATION §3's
+/// "prefer agent_id"):** the review writer must see `&Job<T>` to verify the
+/// receipt, and `a2a_escrow` already depends on `agent_id` — storing the
+/// score under `agent_id` would need either an illegal dependency cycle or a
+/// hardcoded witness-package handshake (three ordered mainnet upgrades, since
+/// the witness type's defining id doesn't exist until escrow republishes).
+/// Parking storage AND writer here keeps the apply path unforgeable for free
+/// (module-internal, `apply_review` is private) and the cutover to ONE
+/// additive escrow upgrade. The SPEC/prompt explicitly allow this shape.
+///
+/// Write authority (all Move-enforced — reputation is receipts):
+/// - sender == `Job.buyer` and `Job.state == RELEASED`
+/// - the job was actually DELIVERED (`delivered_at_ms > 0`): a goodwill
+///   release of an undelivered job is not a reviewable receipt (the on-chain
+///   form of the API's no-goodwill-review rule)
+/// - one contribution per `job_id`; resubmitting = star edit in place
+///   (`stars_sum` adjusts, `review_count` doesn't)
+/// - NO AdminCap / mint path: the protocol cannot gift stars.
+module a2a_escrow::reputation;
+
+use a2a_escrow::escrow::{Self, AdminCap, FeeConfig, Job};
+use sui::clock::Clock;
+use sui::derived_object;
+use sui::event;
+use sui::table::{Self, Table};
+
+// === Proven thresholds (S.1054 v1 — protocol constants, one SSOT) ===
+/// `claim_policy = 1` (and the floor of `2`): minimum on-chain reviews.
+const PROVEN_MIN_REVIEWS: u64 = 3;
+/// `claim_policy = 2`: minimum average stars, scaled ×10 (40 = 4.0★).
+const PROVEN_MIN_AVG_STARS_X10: u64 = 40;
+/// The ×10 scale used for the integer-math average compare.
+const AVG_SCALE: u64 = 10;
+/// Star bounds — a 0-star write would corrupt the average math.
+const MIN_STARS: u8 = 1;
+const MAX_STARS: u8 = 5;
+
+// === Errors ===
+const ENotBuyer: u64 = 0;
+const ENotReleased: u64 = 1;
+/// RELEASED but never DELIVERED = goodwill settle — not reviewable.
+const ENotDelivered: u64 = 2;
+const EBadStars: u64 = 3;
+/// The passed `AgentScore` doesn't belong to this job's seller.
+const EWrongScore: u64 = 4;
+/// Structurally impossible (escrow::create asserts buyer != seller) —
+/// asserted anyway so this module's invariant never depends on a sibling's.
+const ESelfReview: u64 = 5;
+
+// === Objects ===
+
+/// The one shared namespace parent for derived `AgentScore` addresses.
+/// Created ONCE post-upgrade via `create_score_board` (module `init` does not
+/// re-run on package upgrade); its id is pinned in client constants. Holds no
+/// table — `derived_object::claim` markers on its UID are the per-agent
+/// uniqueness guarantee, and it is only `&mut` on an agent's FIRST review.
+public struct ScoreBoard has key {
+    id: UID,
+}
+
+/// One seller's on-chain reputation. Shared, at
+/// `derived_object::derive_address(board, agent)` — clients can compute the
+/// id locally with no lookup. Aggregates only; per-job stars in `job_stars`
+/// enforce one contribution per job and make edits update-in-place.
+public struct AgentScore has key {
+    id: UID,
+    /// The reviewed seller (Agent ID address). Claim gates verify this
+    /// matches the claimer — you cannot borrow someone else's score.
+    agent: address,
+    review_count: u64,
+    stars_sum: u64,
+    job_stars: Table<ID, u8>,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+}
+
+// === Events (the indexer's score read-model is built from these) ===
+public struct ScoreBoardCreated has copy, drop {
+    board_id: ID,
+    timestamp_ms: u64,
+}
+public struct ScoreCreated has copy, drop {
+    score_id: ID,
+    agent: address,
+    timestamp_ms: u64,
+}
+/// Emitted on every review write, first OR edit — carries the post-write
+/// aggregates so the read-model never has to fetch the object.
+public struct ReviewSubmitted has copy, drop {
+    score_id: ID,
+    agent: address,
+    job_id: ID,
+    buyer: address,
+    stars: u8,
+    /// 0 = first review for this job; non-zero = an edit replacing that value.
+    previous_stars: u8,
+    review_count: u64,
+    stars_sum: u64,
+    timestamp_ms: u64,
+}
+
+// === One-time setup (AdminCap — upgrade can't run `init`) ===
+
+/// Share the score namespace parent. Called ONCE in the S.1054 cutover
+/// ritual; the resulting id is pinned client-side. AdminCap-gated so a
+/// stranger can't share a decoy board — but note the cap grants NO star
+/// authority: every star still requires a RELEASED job receipt.
+public fun create_score_board(_: &AdminCap, cfg: &FeeConfig, clock: &Clock, ctx: &mut TxContext) {
+    escrow::assert_version_pkg(cfg);
+    let board = ScoreBoard { id: object::new(ctx) };
+    event::emit(ScoreBoardCreated {
+        board_id: board.id.to_inner(),
+        timestamp_ms: clock.timestamp_ms(),
+    });
+    transfer::share_object(board);
+}
+
+// === Review writes (buyer, RELEASED receipt only) ===
+
+/// First review a seller ever receives: lazily creates + shares their
+/// `AgentScore` at its derived address. Aborts if the score already exists
+/// (`derived_object::claim` is the uniqueness gate) — callers race-fall-back
+/// to `submit_review`.
+public fun submit_first_review<T>(
+    board: &mut ScoreBoard,
+    job: &Job<T>,
+    stars: u8,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    let seller = validate_review(job, stars, ctx);
+    let now = clock.timestamp_ms();
+    let mut score = AgentScore {
+        id: derived_object::claim(&mut board.id, seller),
+        agent: seller,
+        review_count: 0,
+        stars_sum: 0,
+        job_stars: table::new(ctx),
+        created_at_ms: now,
+        updated_at_ms: now,
+    };
+    event::emit(ScoreCreated {
+        score_id: score.id.to_inner(),
+        agent: seller,
+        timestamp_ms: now,
+    });
+    apply_review(&mut score, object::id(job), ctx.sender(), stars, now);
+    transfer::share_object(score);
+}
+
+/// Every later review — and star EDITS (same buyer re-rating the same job):
+/// touches only this seller's score, so unrelated reviews run in parallel.
+public fun submit_review<T>(
+    score: &mut AgentScore,
+    job: &Job<T>,
+    stars: u8,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    let seller = validate_review(job, stars, ctx);
+    assert!(score.agent == seller, EWrongScore);
+    apply_review(score, object::id(job), ctx.sender(), stars, clock.timestamp_ms());
+}
+
+/// The receipt gate — every review path funnels through here.
+fun validate_review<T>(job: &Job<T>, stars: u8, ctx: &TxContext): address {
+    assert!(stars >= MIN_STARS && stars <= MAX_STARS, EBadStars);
+    let buyer = escrow::buyer(job);
+    let seller = escrow::seller(job);
+    assert!(ctx.sender() == buyer, ENotBuyer);
+    assert!(buyer != seller, ESelfReview);
+    assert!(escrow::state(job) == escrow::state_released(), ENotReleased);
+    assert!(escrow::delivered_at_ms(job) > 0, ENotDelivered);
+    seller
+}
+
+/// The ONLY aggregate mutator — private, so a star can never enter a score
+/// except through a validated RELEASED receipt above.
+fun apply_review(score: &mut AgentScore, job_id: ID, buyer: address, stars: u8, now: u64) {
+    let previous_stars = if (score.job_stars.contains(job_id)) {
+        let prev = score.job_stars.remove(job_id);
+        score.stars_sum = score.stars_sum - (prev as u64);
+        prev
+    } else {
+        score.review_count = score.review_count + 1;
+        0
+    };
+    score.job_stars.add(job_id, stars);
+    score.stars_sum = score.stars_sum + (stars as u64);
+    score.updated_at_ms = now;
+    event::emit(ReviewSubmitted {
+        score_id: score.id.to_inner(),
+        agent: score.agent,
+        job_id,
+        buyer,
+        stars,
+        previous_stars,
+        review_count: score.review_count,
+        stars_sum: score.stars_sum,
+        timestamp_ms: now,
+    });
+}
+
+// === Proven predicates (read by `opening::claim_proven`) ===
+
+/// `claim_policy = 1` — Proven: at least `PROVEN_MIN_REVIEWS` on-chain
+/// reviews. No score object ⇒ the claim entry can't even be called — the
+/// correct "count 0" outcome.
+public fun meets_min_reviews(score: &AgentScore): bool {
+    score.review_count >= PROVEN_MIN_REVIEWS
+}
+
+/// `claim_policy = 2` — Proven · 4★+: policy 1 AND average ≥ 4.0. Strictly
+/// stronger than plain Proven (the prompt's "require both" preset): an
+/// average over fewer than `PROVEN_MIN_REVIEWS` reviews is noise, and a gate
+/// labeled 4★+ must never admit an agent plain Proven would refuse. Integer
+/// math — `sum × 10 ≥ count × 40` — no division, no rounding.
+public fun meets_min_avg(score: &AgentScore): bool {
+    meets_min_reviews(score) &&
+        score.stars_sum * AVG_SCALE >= score.review_count * PROVEN_MIN_AVG_STARS_X10
+}
+
+// === Read accessors (clients, indexer, composing modules) ===
+public fun agent(score: &AgentScore): address { score.agent }
+public fun review_count(score: &AgentScore): u64 { score.review_count }
+public fun stars_sum(score: &AgentScore): u64 { score.stars_sum }
+public fun has_job_review(score: &AgentScore, job_id: ID): bool {
+    score.job_stars.contains(job_id)
+}
+public fun job_stars(score: &AgentScore, job_id: ID): u8 {
+    *score.job_stars.borrow(job_id)
+}
+
+/// Whether an agent has a score yet (board-side check, no score fetch).
+public fun has_score(board: &ScoreBoard, agent: address): bool {
+    derived_object::exists(&board.id, agent)
+}
+
+/// The deterministic address an agent's score lives (or will live) at.
+public fun score_address(board: &ScoreBoard, agent: address): address {
+    derived_object::derive_address(board.id.to_inner(), agent)
+}
+
+public fun proven_min_reviews(): u64 { PROVEN_MIN_REVIEWS }
+public fun proven_min_avg_stars_x10(): u64 { PROVEN_MIN_AVG_STARS_X10 }
+public fun avg_scale(): u64 { AVG_SCALE }
+public fun min_stars(): u8 { MIN_STARS }
+public fun max_stars(): u8 { MAX_STARS }

--- a/contracts/a2a_escrow/tests/opening_tests.move
+++ b/contracts/a2a_escrow/tests/opening_tests.move
@@ -309,9 +309,10 @@ fun refund_unclaimed_before_expiry_fails() {
 
 #[test]
 #[expected_failure(abort_code = opening::EBadClaimPolicy)]
-fun create_open_nonzero_policy_aborts() {
+fun create_open_undefined_policy_aborts() {
     let (mut sc, clk) = setup();
-    post_open_with(&mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, 1);
+    // S.1054: 1/2 (Proven) are live — 3+ stays undefined and must abort.
+    post_open_with(&mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, 3);
     abort 0
 }
 

--- a/contracts/a2a_escrow/tests/reputation_tests.move
+++ b/contracts/a2a_escrow/tests/reputation_tests.move
@@ -1,0 +1,583 @@
+#[test_only]
+module a2a_escrow::reputation_tests;
+
+use a2a_escrow::escrow::{Self, AdminCap, FeeConfig, Job};
+use a2a_escrow::opening::{Self, Opening};
+use a2a_escrow::reputation::{Self, AgentScore, ScoreBoard};
+use agent_id::registry::{Self, Registry};
+use sui::clock::{Self, Clock};
+use sui::coin;
+use sui::sui::SUI;
+use sui::test_scenario as ts;
+
+const ADMIN: address = @0xAD; // deployer = AdminCap holder
+const BUYER: address = @0xA;
+const ASP: address = @0xB; // registered + active seller
+const STRANGER: address = @0xC; // neither party to any job
+const OTHER_ASP: address = @0xE; // a second registered seller
+
+const AMOUNT: u64 = 1_000_000; // 1 USDC-equivalent (6dp)
+const OPEN_UNTIL: u64 = 500_000; // ms
+const SLA_MS: u64 = 400_000; // ms
+const REVIEW_WINDOW: u64 = 100_000; // ms
+const SPLIT_BPS: u64 = 10_000; // v3: open reject = 100% buyer
+const POLICY_ANY: u8 = 0;
+const POLICY_PROVEN: u8 = 1;
+const POLICY_PROVEN_4STAR: u8 = 2;
+
+fun setup(): (ts::Scenario, Clock) {
+    let mut sc = ts::begin(ADMIN);
+    escrow::init_for_testing(ts::ctx(&mut sc));
+    registry::init_for_testing(ts::ctx(&mut sc));
+    let mut clk = clock::create_for_testing(ts::ctx(&mut sc));
+    // Real time is never 0 — a 0 clock would make delivered_at_ms == 0 and
+    // trip the goodwill (never-delivered) review gate on honest deliveries.
+    clk.set_for_testing(1_000);
+    // The ScoreBoard is created ONCE by the AdminCap holder (upgrade can't
+    // run init) — mirror that ritual here.
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        reputation::create_score_board(&cap, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    register_agent(&mut sc, &clk, ASP);
+    register_agent(&mut sc, &clk, OTHER_ASP);
+    (sc, clk)
+}
+
+fun register_agent(sc: &mut ts::Scenario, clk: &Clock, who: address) {
+    ts::next_tx(sc, who);
+    let mut reg = ts::take_shared<Registry>(sc);
+    registry::register(
+        &mut reg,
+        option::none(),
+        vector[],
+        option::none(),
+        option::none(),
+        clk,
+        ts::ctx(sc),
+    );
+    ts::return_shared(reg);
+}
+
+/// Run one full Hire job BUYER→seller to RELEASED (deliver + buyer accept).
+/// Returns the job id — the receipt a review needs.
+fun released_job(sc: &mut ts::Scenario, clk: &Clock, seller: address): ID {
+    ts::next_tx(sc, BUYER);
+    let job_id = {
+        let cfg = ts::take_shared<FeeConfig>(sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(sc));
+        let id = escrow::create<SUI>(
+            seller,
+            payment,
+            b"spec-hash",
+            clk.timestamp_ms() + SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            &cfg,
+            clk,
+            ts::ctx(sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    ts::next_tx(sc, seller);
+    {
+        let cfg = ts::take_shared<FeeConfig>(sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
+        escrow::deliver(&mut job, b"delivery-hash", &cfg, clk, ts::ctx(sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
+        escrow::release(&mut job, &cfg, clk, ts::ctx(sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    job_id
+}
+
+/// Buyer reviews a released job — routes to the lazy-create or the normal
+/// entry depending on whether the seller has a score yet (the client shape).
+fun review(sc: &mut ts::Scenario, clk: &Clock, job_id: ID, stars: u8) {
+    review_as(sc, clk, BUYER, job_id, stars)
+}
+
+fun review_as(sc: &mut ts::Scenario, clk: &Clock, who: address, job_id: ID, stars: u8) {
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
+    let mut board = ts::take_shared<ScoreBoard>(sc);
+    if (reputation::has_score(&board, escrow::seller(&job))) {
+        let mut score = ts::take_shared<AgentScore>(sc);
+        reputation::submit_review(&mut score, &job, stars, &cfg, clk, ts::ctx(sc));
+        ts::return_shared(score);
+    } else {
+        reputation::submit_first_review(&mut board, &job, stars, &cfg, clk, ts::ctx(sc));
+    };
+    ts::return_shared(board);
+    ts::return_shared(job);
+    ts::return_shared(cfg);
+}
+
+/// Give `seller` `n` released-job reviews of `stars` each.
+fun reviewed_n(sc: &mut ts::Scenario, clk: &Clock, seller: address, n: u64, stars: u8) {
+    let mut i = 0;
+    while (i < n) {
+        let job_id = released_job(sc, clk, seller);
+        review(sc, clk, job_id, stars);
+        i = i + 1;
+    }
+}
+
+fun take_score(sc: &ts::Scenario): AgentScore {
+    ts::take_shared<AgentScore>(sc)
+}
+
+// === Review happy paths ===
+
+#[test]
+fun first_review_creates_score_at_derived_address() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_id, 5);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let board = ts::take_shared<ScoreBoard>(&sc);
+        let score = take_score(&sc);
+        assert!(reputation::agent(&score) == ASP, 0);
+        assert!(reputation::review_count(&score) == 1, 1);
+        assert!(reputation::stars_sum(&score) == 5, 2);
+        assert!(reputation::has_job_review(&score, job_id), 3);
+        assert!(reputation::job_stars(&score, job_id) == 5, 4);
+        // The score lives at its deterministic derived address.
+        assert!(
+            object::id(&score).to_address() == reputation::score_address(&board, ASP),
+            5,
+        );
+        assert!(reputation::has_score(&board, ASP), 6);
+        assert!(!reputation::has_score(&board, OTHER_ASP), 7);
+        ts::return_shared(score);
+        ts::return_shared(board);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun two_jobs_accumulate() {
+    let (mut sc, clk) = setup();
+    let job_a = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_a, 5);
+    let job_b = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_b, 3);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let score = take_score(&sc);
+        assert!(reputation::review_count(&score) == 2, 0);
+        assert!(reputation::stars_sum(&score) == 8, 1);
+        ts::return_shared(score);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun edit_review_updates_in_place() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_id, 5);
+    // The buyer re-rates the same job: sum adjusts, count does NOT.
+    review(&mut sc, &clk, job_id, 2);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let score = take_score(&sc);
+        assert!(reputation::review_count(&score) == 1, 0);
+        assert!(reputation::stars_sum(&score) == 2, 1);
+        assert!(reputation::job_stars(&score, job_id) == 2, 2);
+        ts::return_shared(score);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Review authority gates ===
+
+#[test]
+#[expected_failure(abort_code = reputation::ENotBuyer)]
+fun stranger_review_fails() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review_as(&mut sc, &clk, STRANGER, job_id, 5);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::ENotBuyer)]
+fun seller_reviews_own_job_fails() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review_as(&mut sc, &clk, ASP, job_id, 5);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::ENotReleased)]
+fun review_funded_job_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, BUYER);
+    let job_id = {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
+        let id = escrow::create<SUI>(
+            ASP,
+            payment,
+            b"spec-hash",
+            clk.timestamp_ms() + SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            &cfg,
+            &clk,
+            ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    review(&mut sc, &clk, job_id, 5);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::ENotReleased)]
+fun review_delivered_unreleased_job_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, BUYER);
+    let job_id = {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
+        let id = escrow::create<SUI>(
+            ASP,
+            payment,
+            b"spec-hash",
+            clk.timestamp_ms() + SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            &cfg,
+            &clk,
+            ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    ts::next_tx(&mut sc, ASP);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        escrow::deliver(&mut job, b"delivery-hash", &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    review(&mut sc, &clk, job_id, 5);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::ENotDelivered)]
+fun goodwill_release_not_reviewable() {
+    let (mut sc, clk) = setup();
+    // Buyer releases a FUNDED job without any delivery (goodwill / off-band).
+    ts::next_tx(&mut sc, BUYER);
+    let job_id = {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
+        let id = escrow::create<SUI>(
+            ASP,
+            payment,
+            b"spec-hash",
+            clk.timestamp_ms() + SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            &cfg,
+            &clk,
+            ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        escrow::release(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    review(&mut sc, &clk, job_id, 5);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EBadStars)]
+fun zero_stars_fails() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_id, 0);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EBadStars)]
+fun six_stars_fails() {
+    let (mut sc, clk) = setup();
+    let job_id = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_id, 6);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EWrongScore)]
+fun review_into_wrong_agents_score_fails() {
+    let (mut sc, clk) = setup();
+    // ASP earns a score; then a released OTHER_ASP job tries to land its
+    // review into ASP's score object.
+    let asp_job = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, asp_job, 5);
+    let other_job = released_job(&mut sc, &clk, OTHER_ASP);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let job = ts::take_shared_by_id<Job<SUI>>(&sc, other_job);
+        let mut score = take_score(&sc); // ASP's score — the only one
+        reputation::submit_review(&mut score, &job, 5, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure] // derived_object::claim aborts: score already exists
+fun duplicate_first_review_fails() {
+    let (mut sc, clk) = setup();
+    let job_a = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, job_a, 5);
+    let job_b = released_job(&mut sc, &clk, ASP);
+    // Force the lazy-create path a second time for the same seller.
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let job = ts::take_shared_by_id<Job<SUI>>(&sc, job_b);
+        let mut board = ts::take_shared<ScoreBoard>(&sc);
+        reputation::submit_first_review(&mut board, &job, 4, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(board);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+// === Proven predicates ===
+
+#[test]
+fun proven_predicates_track_thresholds() {
+    let (mut sc, clk) = setup();
+    // 2 × 5★ — below the review floor: neither predicate passes.
+    reviewed_n(&mut sc, &clk, ASP, 2, 5);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let score = take_score(&sc);
+        assert!(!reputation::meets_min_reviews(&score), 0);
+        assert!(!reputation::meets_min_avg(&score), 1);
+        ts::return_shared(score);
+    };
+    // A 3rd review (3★) crosses the floor: count passes; avg 13/3 ≈ 4.33 ≥ 4.
+    reviewed_n(&mut sc, &clk, ASP, 1, 3);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let score = take_score(&sc);
+        assert!(reputation::meets_min_reviews(&score), 2);
+        assert!(reputation::meets_min_avg(&score), 3);
+        ts::return_shared(score);
+    };
+    // A 4th review (1★) drags avg to 14/4 = 3.5 < 4: count still passes.
+    reviewed_n(&mut sc, &clk, ASP, 1, 1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let score = take_score(&sc);
+        assert!(reputation::meets_min_reviews(&score), 4);
+        assert!(!reputation::meets_min_avg(&score), 5);
+        ts::return_shared(score);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Proven claim gates (opening::claim_proven) ===
+
+fun post_open_with_policy(sc: &mut ts::Scenario, clk: &Clock, policy: u8) {
+    ts::next_tx(sc, BUYER);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(sc));
+    opening::create_open<SUI>(
+        payment,
+        b"open-spec-hash",
+        clk.timestamp_ms() + OPEN_UNTIL,
+        SLA_MS,
+        REVIEW_WINDOW,
+        SPLIT_BPS,
+        policy,
+        &cfg,
+        clk,
+        ts::ctx(sc),
+    );
+    ts::return_shared(cfg);
+}
+
+fun claim_proven_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let reg = ts::take_shared<Registry>(sc);
+    let op = ts::take_shared<Opening<SUI>>(sc);
+    let score = ts::take_shared<AgentScore>(sc);
+    let job_id = opening::claim_proven(op, &reg, &score, &cfg, clk, ts::ctx(sc));
+    ts::return_shared(score);
+    ts::return_shared(reg);
+    ts::return_shared(cfg);
+    job_id
+}
+
+#[test]
+fun proven_claim_succeeds_with_three_reviews() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    let job_id = claim_proven_as(&mut sc, ASP, &clk);
+    // A normal funded Job minted — same as an Anyone claim, still $0.
+    ts::next_tx(&mut sc, ASP);
+    {
+        let job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        assert!(escrow::seller(&job) == ASP, 0);
+        assert!(escrow::state(&job) == escrow::state_funded(), 1);
+        ts::return_shared(job);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun proven_4star_claim_succeeds_when_avg_holds() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 4); // avg exactly 4.0
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN_4STAR);
+    claim_proven_as(&mut sc, ASP, &clk);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EClaimPolicyUnmet)]
+fun proven_claim_below_review_floor_fails() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 2, 5); // only 2 reviews
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    claim_proven_as(&mut sc, ASP, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EClaimPolicyUnmet)]
+fun proven_4star_claim_below_avg_fails() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 3); // count OK, avg 3.0 < 4.0
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN_4STAR);
+    claim_proven_as(&mut sc, ASP, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EScoreNotClaimer)]
+fun proven_claim_with_someone_elses_score_fails() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 5); // ASP is Proven
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    // OTHER_ASP (no reviews) tries to claim by passing ASP's score.
+    claim_proven_as(&mut sc, OTHER_ASP, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EBadClaimPolicy)]
+fun plain_claim_on_proven_opening_fails() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    ts::next_tx(&mut sc, ASP);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        opening::claim(op, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EBadClaimPolicy)]
+fun claim_proven_on_anyone_opening_fails() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    post_open_with_policy(&mut sc, &clk, POLICY_ANY);
+    claim_proven_as(&mut sc, ASP, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::ENotActiveAgent)]
+fun proven_claim_still_requires_active_agent() {
+    let (mut sc, clk) = setup();
+    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    // ASP goes inactive AFTER earning Proven — the registry gate still holds.
+    ts::next_tx(&mut sc, ASP);
+    {
+        let mut reg = ts::take_shared<Registry>(&sc);
+        registry::set_active(&mut reg, ASP, false, &clk, ts::ctx(&mut sc));
+        ts::return_shared(reg);
+    };
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    claim_proven_as(&mut sc, ASP, &clk);
+    abort 0
+}
+
+// === create_open policy bounds (S.1054) ===
+
+#[test]
+fun create_open_accepts_proven_policies() {
+    let (mut sc, clk) = setup();
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        assert!(opening::claim_policy(&op) == POLICY_PROVEN, 0);
+        ts::return_shared(op);
+    };
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN_4STAR);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EBadClaimPolicy)]
+fun create_open_policy_three_aborts() {
+    let (mut sc, clk) = setup();
+    post_open_with_policy(&mut sc, &clk, 3);
+    abort 0
+}

--- a/contracts/a2a_escrow/tests/reputation_tests.move
+++ b/contracts/a2a_escrow/tests/reputation_tests.move
@@ -12,6 +12,7 @@ use sui::test_scenario as ts;
 
 const ADMIN: address = @0xAD; // deployer = AdminCap holder
 const BUYER: address = @0xA;
+const BUYER2: address = @0xF; // the first-review race loser in the retry test
 const ASP: address = @0xB; // registered + active seller
 const STRANGER: address = @0xC; // neither party to any job
 const OTHER_ASP: address = @0xE; // a second registered seller
@@ -34,18 +35,20 @@ fun setup(): (ts::Scenario, Clock) {
     // trip the goodwill (never-delivered) review gate on honest deliveries.
     clk.set_for_testing(1_000);
     // The ScoreBoard is created ONCE by the AdminCap holder (upgrade can't
-    // run init) — mirror that ritual here.
-    ts::next_tx(&mut sc, ADMIN);
-    {
-        let cap = ts::take_from_sender<AdminCap>(&sc);
-        let cfg = ts::take_shared<FeeConfig>(&sc);
-        reputation::create_score_board(&cap, &cfg, &clk, ts::ctx(&mut sc));
-        ts::return_shared(cfg);
-        ts::return_to_sender(&sc, cap);
-    };
+    // run init) — single instance chain-enforced via the FeeConfig DF.
+    create_board(&mut sc, &clk);
     register_agent(&mut sc, &clk, ASP);
     register_agent(&mut sc, &clk, OTHER_ASP);
     (sc, clk)
+}
+
+fun create_board(sc: &mut ts::Scenario, clk: &Clock) {
+    ts::next_tx(sc, ADMIN);
+    let cap = ts::take_from_sender<AdminCap>(sc);
+    let mut cfg = ts::take_shared<FeeConfig>(sc);
+    reputation::create_score_board(&cap, &mut cfg, clk, ts::ctx(sc));
+    ts::return_shared(cfg);
+    ts::return_to_sender(sc, cap);
 }
 
 fun register_agent(sc: &mut ts::Scenario, clk: &Clock, who: address) {
@@ -66,7 +69,16 @@ fun register_agent(sc: &mut ts::Scenario, clk: &Clock, who: address) {
 /// Run one full Hire job BUYER→seller to RELEASED (deliver + buyer accept).
 /// Returns the job id — the receipt a review needs.
 fun released_job(sc: &mut ts::Scenario, clk: &Clock, seller: address): ID {
-    ts::next_tx(sc, BUYER);
+    released_job_from(sc, clk, BUYER, seller)
+}
+
+fun released_job_from(
+    sc: &mut ts::Scenario,
+    clk: &Clock,
+    buyer: address,
+    seller: address,
+): ID {
+    ts::next_tx(sc, buyer);
     let job_id = {
         let cfg = ts::take_shared<FeeConfig>(sc);
         let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(sc));
@@ -92,7 +104,7 @@ fun released_job(sc: &mut ts::Scenario, clk: &Clock, seller: address): ID {
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
-    ts::next_tx(sc, BUYER);
+    ts::next_tx(sc, buyer);
     {
         let cfg = ts::take_shared<FeeConfig>(sc);
         let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
@@ -138,6 +150,32 @@ fun reviewed_n(sc: &mut ts::Scenario, clk: &Clock, seller: address, n: u64, star
 
 fun take_score(sc: &ts::Scenario): AgentScore {
     ts::take_shared<AgentScore>(sc)
+}
+
+// === ScoreBoard single instance (S.1054b) ===
+
+#[test]
+fun score_board_id_recorded_on_fee_config() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let board = ts::take_shared<ScoreBoard>(&sc);
+        let recorded = escrow::config_score_board_id(&cfg);
+        assert!(recorded == option::some(object::id(&board)), 0);
+        ts::return_shared(board);
+        ts::return_shared(cfg);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EScoreBoardExists)]
+fun second_score_board_aborts() {
+    let (mut sc, clk) = setup(); // setup already created the one board
+    create_board(&mut sc, &clk);
+    abort 0
 }
 
 // === Review happy paths ===
@@ -360,6 +398,35 @@ fun review_into_wrong_agents_score_fails() {
         ts::return_shared(cfg);
     };
     abort 0
+}
+
+// The first-review race, both halves (S.1054b). Two buyers race
+// `submit_first_review` for the same brand-new seller: the winner shares
+// the score; the LOSER aborts on `derived_object::claim` (the test below)
+// and must retry with `submit_review` against the now-existing score (the
+// test after it) — which succeeds, because per-job uniqueness is keyed by
+// job_id, not by reviewer.
+
+#[test]
+fun first_review_race_loser_retries_with_submit_review() {
+    let (mut sc, clk) = setup();
+    // BUYER wins the race: their review creates ASP's score.
+    let won = released_job(&mut sc, &clk, ASP);
+    review(&mut sc, &clk, won, 5);
+    // BUYER2 (the race loser) holds their own RELEASED receipt; the retry
+    // path — plain submit_review against the existing score — lands.
+    let lost = released_job_from(&mut sc, &clk, BUYER2, ASP);
+    review_as(&mut sc, &clk, BUYER2, lost, 3);
+    ts::next_tx(&mut sc, BUYER2);
+    {
+        let score = take_score(&sc);
+        assert!(reputation::review_count(&score) == 2, 0);
+        assert!(reputation::stars_sum(&score) == 8, 1);
+        assert!(reputation::job_stars(&score, lost) == 3, 2);
+        ts::return_shared(score);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
 }
 
 #[test]

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -36,6 +36,7 @@ import {
   getJob,
   getSuiClient,
   jobActionsFor,
+  submitJobReview,
   truncateAddress,
   validateAddress,
   verifyJobForSeller,
@@ -139,6 +140,33 @@ export async function loadSpecText(
  *  same bytes. ~16%% of dogfood delivers had the hash pinned on-chain while
  *  the body never loaded for the buyer. On any miss NOTHING reaches a chain
  *  verb — the store can be retried; an on-chain pin cannot. */
+/** The signed-mutation POST to /job/review (challenge nonce +
+ *  personal-message signature over sha256 of the payload — same
+ *  construction as `t2 service`). After S.1054 this path carries review
+ *  TEXT and seller→buyer ratings; buyer STARS are on-chain. */
+async function postSignedReview(
+  base: string,
+  agent: Awaited<ReturnType<typeof withAgent>>,
+  address: string,
+  payload: { jobId: string; stars: number; text: string | null },
+): Promise<Record<string, unknown>> {
+  const challenge = await fetchJson(`${base}/agent/challenge`, {
+    method: 'POST',
+    body: { address },
+  });
+  const nonce = challenge.nonce as string | undefined;
+  if (!nonce) throw new Error('Failed to get a challenge nonce.');
+  const payloadHash = createHash('sha256')
+    .update(JSON.stringify(payload), 'utf8')
+    .digest('hex');
+  const message = new TextEncoder().encode(`t2000-job-review:${nonce}:${payloadHash}`);
+  const { signature } = await agent.keypair.signPersonalMessage(message);
+  return fetchJson(`${base}/job/review`, {
+    method: 'POST',
+    body: { address, nonce, signature, payload },
+  });
+}
+
 async function putAndVerifySpec(base: string, content: string): Promise<string> {
   const hash = await putJobSpec(base, content);
   let roundTrip: string;
@@ -1045,9 +1073,9 @@ no fund step; unclaimed openings refund fee-free):
   group
     .command('review')
     .argument('<jobId>', 'The Job object id (0x…) of a RELEASED job you were party to')
-    .description('Rate a released job 1–5 stars — role-aware: buyers rate the ASP (public); ASPs rate the buyer (public only if the buyer holds an Agent ID)')
+    .description('Rate a released job 1–5 stars — role-aware: buyers rate the ASP (stars land ON-CHAIN, the one public score); ASPs rate the buyer (off-chain; public only if the buyer holds an Agent ID)')
     .requiredOption('--stars <1-5>', 'Star rating, 1 (poor) to 5 (excellent)')
-    .option('--text <text>', 'Optional short review (max 400 chars)')
+    .option('--text <text>', 'Optional short review (max 1000 chars) — text stays off-chain, keyed to the job')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(async (jobId: string, opts: { stars: string; text?: string; key?: string; api?: string }) => {
@@ -1056,11 +1084,16 @@ no fund step; unclaimed openings refund fee-free):
         if (!Number.isInteger(stars) || stars < 1 || stars > 5) {
           throw new Error(`--stars must be an integer 1–5 (got "${opts.stars}").`);
         }
+        // Role decides the rail, so the job read is required here (the
+        // chain + API refuse independently — this is the English layer).
+        const reviewedJob = await getJob(getSuiClient(), jobId).catch(() => null);
+        if (!reviewedJob) {
+          throw new Error('Could not read that job on-chain — check the id and retry.');
+        }
         // S.1015: a review requires a DELIVERY — a goodwill-released job
         // has no work to rate, and a sockpuppet ★5 on it would cost only
-        // the settle fee. Defense in depth: the API refuses too.
-        const reviewedJob = await getJob(getSuiClient(), jobId).catch(() => null);
-        if (reviewedJob && !reviewedJob.deliveryHash) {
+        // the settle fee. Move + API refuse too; defense in depth.
+        if (!reviewedJob.deliveryHash) {
           throw new Error(
             'This job has no on-chain delivery — there is no work to rate. Reviews attach only ' +
               'to jobs the seller actually delivered.',
@@ -1069,45 +1102,51 @@ no fund step; unclaimed openings refund fee-free):
         const base = opts.api ?? DEFAULT_API_BASE;
         const agent = await withAgent({ keyPath: opts.key });
         const address = agent.address();
+        const text = opts.text?.trim() || null;
 
-        // Same signed-mutation construction as `t2 service`: challenge
-        // nonce + personal-message signature over sha256 of the payload.
-        const challenge = await fetchJson(`${base}/agent/challenge`, {
-          method: 'POST',
-          body: { address },
-        });
-        const nonce = challenge.nonce as string | undefined;
-        if (!nonce) throw new Error('Failed to get a challenge nonce.');
-        const payload = {
+        if (address === reviewedJob.buyer) {
+          // Buyer → seller: STARS GO ON-CHAIN (S.1054 — the one public
+          // score SSOT; `a2a_escrow::reputation`). Sponsored rail, same as
+          // every job verb. Re-running edits the stars in place.
+          const digest = await submitJobReview(base, agent.signer, { jobId, stars });
+          // Optional text rides the existing signed API path — text is
+          // not the score; it stays off-chain keyed by jobId.
+          let textSaved = false;
+          if (text) {
+            await postSignedReview(base, agent, address, { jobId: validateAddress(jobId), stars, text });
+            textSaved = true;
+          }
+          if (isJsonMode()) {
+            printJson({ jobId: validateAddress(jobId), stars, digest, textSaved });
+            return;
+          }
+          printBlank();
+          printSuccess(
+            `Review on-chain — ${'★'.repeat(stars)}${'☆'.repeat(5 - stars)} on job ${truncateAddress(validateAddress(jobId))}.`,
+          );
+          printKeyValue('Tx', digest);
+          if (textSaved) printInfo('Your review text is saved off-chain with the job.');
+          printKeyValue('Seller page', `https://t2000.ai/${reviewedJob.seller}`);
+          printInfo('Re-run with different --stars to edit — the score updates in place.');
+          printBlank();
+          return;
+        }
+
+        // Seller → buyer rating: stays on the signed API path (off-chain by
+        // design — buyer ratings never gate Open claims).
+        const response = await postSignedReview(base, agent, address, {
           jobId: validateAddress(jobId),
           stars,
-          text: opts.text?.trim() || null,
-        };
-        const payloadHash = createHash('sha256')
-          .update(JSON.stringify(payload), 'utf8')
-          .digest('hex');
-        const message = new TextEncoder().encode(
-          `t2000-job-review:${nonce}:${payloadHash}`,
-        );
-        const { signature } = await agent.keypair.signPersonalMessage(message);
-        const response = await fetchJson(`${base}/job/review`, {
-          method: 'POST',
-          body: { address, nonce, signature, payload },
+          text,
         });
-
         if (isJsonMode()) {
           printJson(response);
           return;
         }
         printBlank();
-        printSuccess(`Review saved — ${'★'.repeat(stars)}${'☆'.repeat(5 - stars)} on job ${truncateAddress(payload.jobId)}.`);
-        const review = response.review as { seller?: string } | undefined;
-        if (review?.seller) {
-          printKeyValue('Seller page', `https://t2000.ai/${review.seller}`);
-        }
-        // Seller path (you rated the buyer): surface the privacy status the
-        // rating was written under — Agent-ID buyers are public, Passport
-        // buyers stay private, always.
+        printSuccess(`Review saved — ${'★'.repeat(stars)}${'☆'.repeat(5 - stars)} on job ${truncateAddress(validateAddress(jobId))}.`);
+        // Surface the privacy status the rating was written under —
+        // Agent-ID buyers are public, Passport buyers stay private, always.
         const rating = response.rating as { visibility?: string } | undefined;
         if (rating?.visibility) {
           printInfo(

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -1108,7 +1108,22 @@ no fund step; unclaimed openings refund fee-free):
           // Buyer → seller: STARS GO ON-CHAIN (S.1054 — the one public
           // score SSOT; `a2a_escrow::reputation`). Sponsored rail, same as
           // every job verb. Re-running edits the stars in place.
-          const digest = await submitJobReview(base, agent.signer, { jobId, stars });
+          let digest: string;
+          try {
+            digest = await submitJobReview(base, agent.signer, { jobId, stars });
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            // S.1054b: lost first-review race — two buyers created a
+            // brand-new seller's score at once; the derived claim aborts
+            // "already claimed". The retry re-routes to a normal review.
+            if (/already claimed/i.test(msg)) {
+              throw new Error(
+                "Another buyer just created this seller's score in a simultaneous first review — " +
+                  're-run the same command; your review lands as a normal update.',
+              );
+            }
+            throw error;
+          }
           // Optional text rides the existing signed API path — text is
           // not the score; it stays off-chain keyed by jobId.
           let textSaved = false;

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -22,12 +22,21 @@ import {
 import type { Command } from 'commander';
 import pc from 'picocolors';
 import {
+  A2A_SCORE_BOARD_ID,
   cancelOpenJob,
   claimOpenJob,
+  claimPolicyLabel,
+  claimPolicyRequirement,
+  getAgentScore,
+  getOpening,
   getSuiClient,
   listOpenJobs,
+  meetsClaimPolicy,
   postOpenJob,
   MAX_JOB_USDC,
+  OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  OPENING_CLAIM_POLICY_PROVEN,
+  PROVEN_MIN_REVIEWS,
   type OpenJobRow,
   resolveCreatedObjectId,
 } from '@t2000/sdk';
@@ -104,6 +113,10 @@ export function registerOpenVerbs(group: Command) {
     .requiredOption('--max <usdc>', `Budget escrowed AT POST (max ${MAX_JOB_USDC})`)
     .option('--sla <duration>', 'Delivery window once claimed (e.g. 30m, 24h, 7d)', '24h')
     .option('--open-for <duration>', 'How long the posting stays claimable before it refunds', '24h')
+    .option(
+      '--proven',
+      `Only Proven agents (≥${PROVEN_MIN_REVIEWS} on-chain reviews) may claim — default is Anyone; claiming stays instant and $0 either way`,
+    )
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(
@@ -113,6 +126,7 @@ export function registerOpenVerbs(group: Command) {
         max: string;
         sla: string;
         openFor: string;
+        proven?: boolean;
         key?: string;
         api?: string;
       }) => {
@@ -134,6 +148,9 @@ export function registerOpenVerbs(group: Command) {
             maxUsdc,
             slaMinutes: Math.round(parseDuration(opts.sla) / 60_000),
             openHours: parseDuration(opts.openFor) / 3_600_000,
+            claimPolicy: opts.proven
+              ? OPENING_CLAIM_POLICY_PROVEN
+              : OPENING_CLAIM_POLICY_ANY_ACTIVE,
           });
           recordSpendIfLanded(maxUsdc, digest);
           const openingId = await resolveCreated(digest, '::opening::Opening<');
@@ -145,6 +162,11 @@ export function registerOpenVerbs(group: Command) {
           printSuccess(
             `Posted — $${maxUsdc.toFixed(2)} USDC escrowed on-chain in the opening.`,
           );
+          if (opts.proven) {
+            printInfo(
+              `Proven gate on: only agents with ≥${PROVEN_MIN_REVIEWS} on-chain reviews can claim.`,
+            );
+          }
           printBlank();
           if (openingId) printKeyValue('Opening', openingId);
           printKeyValue('Tx', digest);
@@ -191,8 +213,13 @@ export function registerOpenVerbs(group: Command) {
           return;
         }
         for (const row of rows) {
+          // Surface the claim gate BEFORE anyone burns a claim attempt on it.
+          const gate =
+            (row.claimPolicy ?? 0) !== 0
+              ? `  ${pc.magenta(claimPolicyLabel(row.claimPolicy ?? 0))}`
+              : '';
           printLine(
-            `  ${pc.bold(row.title ?? 'Untitled opening')}  ${pc.dim(`$${row.maxUsdc.toFixed(2)}`)}  ${statusColor(row.status)}` +
+            `  ${pc.bold(row.title ?? 'Untitled opening')}  ${pc.dim(`$${row.maxUsdc.toFixed(2)}`)}  ${statusColor(row.status)}${gate}` +
               (row.status === 'open' ? pc.dim(`  ${fmtLeft(row.openUntilMs)} left`) : ''),
           );
           const brief = (row.brief ?? '').replace(/\s+/g, ' ');
@@ -221,6 +248,23 @@ export function registerOpenVerbs(group: Command) {
       try {
         const base = opts.api ?? DEFAULT_API_BASE;
         const agent = await withAgent({ keyPath: opts.key });
+        // Proven preflight (S.1054): refuse in English before the sponsored
+        // rail instead of surfacing a raw Move abort. Best-effort — a
+        // missing opening or unconfigured board falls through to the
+        // server's own checks.
+        const live = await getOpening(getSuiClient(), id.trim()).catch(() => null);
+        if (live && live.claimPolicy !== 0 && A2A_SCORE_BOARD_ID) {
+          const score = await getAgentScore(getSuiClient(), agent.address()).catch(() => null);
+          if (!meetsClaimPolicy(score, live.claimPolicy)) {
+            const have = score
+              ? `${score.reviewCount} review${score.reviewCount === 1 ? '' : 's'}, ${score.averageStars}★ avg`
+              : 'no on-chain reviews yet';
+            throw new Error(
+              `${claimPolicyRequirement(live.claimPolicy)} Your wallet has ${have}. ` +
+                'Earn reviews on Anyone openings first: t2 job board',
+            );
+          }
+        }
         const digest = await claimOpenJob(base, agent.signer, id.trim());
         const jobId = await resolveCreated(digest, '::escrow::Job<');
         if (isJsonMode()) {

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -233,6 +233,21 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
       `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open`,
     ],
     ['open-claim', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`],
+    // S.1054: Proven openings claim via claim_proven; buyer review stars
+    // land on-chain via the reputation module (both entries — the first
+    // review a seller ever gets lazily creates their AgentScore).
+    [
+      'open-claim',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim_proven`,
+    ],
+    [
+      'job-review',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::submit_review`,
+    ],
+    [
+      'job-review',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::submit_first_review`,
+    ],
     [
       'open-cancel',
       `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::cancel_open`,
@@ -267,6 +282,16 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
     [
       'open-refund',
       `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::refund`,
+    ],
+    // S.1054 phantoms: a review can never ride the escrow module, and a
+    // plain claim action must not smuggle a different module's function.
+    [
+      'job-review',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::escrow::submit_review`,
+    ],
+    [
+      'job-review',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::create_score_board`,
     ],
   ];
 

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -115,9 +115,11 @@ const ACTION_TARGETS: Record<
     functions: ['create_open'],
   },
   'open-claim': {
+    // S.1054: Proven openings (claim_policy 1/2) claim via `claim_proven`
+    // (adds the claimer's own AgentScore as an immutable input).
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
     module: 'opening',
-    functions: ['claim'],
+    functions: ['claim', 'claim_proven'],
   },
   'open-cancel': {
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
@@ -128,6 +130,13 @@ const ACTION_TARGETS: Record<
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
     module: 'opening',
     functions: ['refund_unclaimed'],
+  },
+  // On-chain review stars (S.1054) — `a2a_escrow::reputation`. Two entries:
+  // the seller's first-ever review lazily creates their AgentScore.
+  'job-review': {
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'reputation',
+    functions: ['submit_review', 'submit_first_review'],
   },
   // Agent ID registry verbs (S.1049) — these used to skip Move-target
   // verification entirely via a HOST_PINNED_ONLY carve-out, which meant

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -128,6 +128,28 @@ export {
 } from './wallet/job.js';
 export type { Job, JobState, JobTerms, JobVerification } from './wallet/job.js';
 
+// Open claim policies + on-chain reputation (S.1054) — browser-safe (pure
+// constants/predicates + fetch-style reads); console forms and boards
+// import the thresholds/labels from here, never copy the numbers.
+export {
+  OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  OPENING_CLAIM_POLICY_PROVEN,
+  OPENING_CLAIM_POLICY_PROVEN_4STAR,
+  OPENING_CLAIM_POLICIES,
+} from './wallet/opening.js';
+export {
+  PROVEN_MIN_REVIEWS,
+  PROVEN_MIN_AVG_STARS_X10,
+  REVIEW_MIN_STARS,
+  REVIEW_MAX_STARS,
+  claimPolicyLabel,
+  claimPolicyRequirement,
+  deriveAgentScoreId,
+  getAgentScore,
+  meetsClaimPolicy,
+} from './wallet/reputation.js';
+export type { AgentScore } from './wallet/reputation.js';
+
 // Commerce API client (agent services + content-addressed job specs) —
 // browser-safe (WebCrypto hashing, fetch only). Console surfaces share the
 // tamper-verify.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -174,8 +174,12 @@ export {
   MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID,
   A2A_ESCROW_PACKAGE_V2_ID,
   A2A_ESCROW_PACKAGE_V3_ID,
+  A2A_ESCROW_PACKAGE_V6_ID,
   MAX_OPEN_WINDOW_MS,
   OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  OPENING_CLAIM_POLICY_PROVEN,
+  OPENING_CLAIM_POLICY_PROVEN_4STAR,
+  OPENING_CLAIM_POLICIES,
   buildCancelOpeningTx,
   buildClaimOpeningTx,
   buildCreateOpeningTx,
@@ -184,6 +188,22 @@ export {
   preflightCreateOpening,
 } from './wallet/opening.js';
 export type { Opening, OpeningTerms } from './wallet/opening.js';
+export {
+  A2A_SCORE_BOARD_ID,
+  MAINNET_A2A_SCORE_BOARD_ID,
+  PROVEN_MIN_REVIEWS,
+  PROVEN_MIN_AVG_STARS_X10,
+  REVIEW_MIN_STARS,
+  REVIEW_MAX_STARS,
+  buildSubmitFirstReviewTx,
+  buildSubmitReviewTx,
+  claimPolicyLabel,
+  claimPolicyRequirement,
+  deriveAgentScoreId,
+  getAgentScore,
+  meetsClaimPolicy,
+} from './wallet/reputation.js';
+export type { AgentScore } from './wallet/reputation.js';
 export {
   assertBuyerRequirements,
   DEFAULT_COMMERCE_API_BASE,
@@ -206,6 +226,7 @@ export {
   setSponsoredTxGuard,
   type SponsoredTxGuard,
   refundOpenJob,
+  submitJobReview,
 } from './open-jobs.js';
 export type { OpenJobFilter, OpenJobRow } from './open-jobs.js';
 // Digest → created-object resolution (S.906 SSOT — CLI + console + Connect).

--- a/packages/sdk/src/open-jobs.test.ts
+++ b/packages/sdk/src/open-jobs.test.ts
@@ -6,6 +6,7 @@ import {
   getOpenJob,
   listOpenJobs,
   postOpenJob,
+  submitJobReview,
   refundOpenJob,
 } from './open-jobs.js';
 
@@ -117,6 +118,21 @@ describe('on-chain verbs — prepare → sign → submit (sponsored rail)', () =
       nonce: 'n-1',
       address: ADDRESS,
       signature: 'tx-sig',
+    });
+  });
+
+  it('submitJobReview writes buyer stars on-chain via the job-review action (S.1054)', async () => {
+    const signer = stubSigner();
+    const calls = mockFetchQueue([
+      { json: { nonce: 'n-r', txBytes: TX_BYTES } },
+      { json: { digest: 'DIGEST-R' } },
+    ]);
+    await expect(
+      submitJobReview(BASE, signer, { jobId: ` ${OPENING_ID} `, stars: 5 }),
+    ).resolves.toBe('DIGEST-R');
+    expect(calls[0]?.body).toMatchObject({
+      action: 'job-review',
+      params: { jobId: OPENING_ID, stars: 5 },
     });
   });
 

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -79,6 +79,10 @@ export interface OpenJobRow {
   buyerAgent: { agentId: number; name: string } | null;
   /** The escrow Job this opening was claimed into (claimed rows). */
   jobId: string | null;
+  /** S.1054 — who may race to claim: 0 Anyone, 1 Proven, 2 Proven · 4★+
+   *  (render with `claimPolicyLabel`, never the raw number). Absent on
+   *  pre-S.1054 rows = 0. */
+  claimPolicy?: number;
   createdAtMs: number;
   updatedAtMs: number;
 }
@@ -122,7 +126,7 @@ export async function getOpenJob(
 async function sponsoredOpeningVerb(
   base: string,
   signer: TransactionSigner,
-  action: 'open-create' | 'open-claim' | 'open-cancel' | 'open-refund',
+  action: 'open-create' | 'open-claim' | 'open-cancel' | 'open-refund' | 'job-review',
   params: Record<string, unknown>,
 ): Promise<string> {
   const address = signer.getAddress();
@@ -167,9 +171,32 @@ export function postOpenJob(
     slaMinutes?: number;
     /** How long the posting stays claimable (default 24h, max 720). */
     openHours?: number;
+    /** S.1054 — 0 Anyone (default), 1 Proven, 2 Proven · 4★+. */
+    claimPolicy?: number;
   },
 ): Promise<string> {
   return sponsoredOpeningVerb(base, signer, 'open-create', input);
+}
+
+/** Review a RELEASED job you bought — writes the STARS ON-CHAIN (S.1054:
+ *  the one public score SSOT; `a2a_escrow::reputation`). Same sponsored
+ *  rail as every job verb; the server resolves whether this is the
+ *  seller's first review (lazy score create) or an update/edit. Optional
+ *  `text` is stored off-chain by the API, keyed by jobId — text is not
+ *  the score. Returns the tx digest. */
+export function submitJobReview(
+  base: string,
+  signer: TransactionSigner,
+  input: {
+    jobId: string;
+    /** Integer 1-5. Re-submitting edits your stars in place. */
+    stars: number;
+  },
+): Promise<string> {
+  return sponsoredOpeningVerb(base, signer, 'job-review', {
+    jobId: input.jobId.trim(),
+    stars: input.stars,
+  });
 }
 
 /** Claim an open job (ASP side) — first claim wins ON-CHAIN and mints the

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -181,9 +181,11 @@ export function postOpenJob(
 /** Review a RELEASED job you bought — writes the STARS ON-CHAIN (S.1054:
  *  the one public score SSOT; `a2a_escrow::reputation`). Same sponsored
  *  rail as every job verb; the server resolves whether this is the
- *  seller's first review (lazy score create) or an update/edit. Optional
- *  `text` is stored off-chain by the API, keyed by jobId — text is not
- *  the score. Returns the tx digest. */
+ *  seller's first review (lazy score create) or an update/edit. Rare race
+ *  (brand-new seller, two simultaneous first reviews): the loser aborts
+ *  on-chain — just call this again; the retry re-reads the score and
+ *  lands as a normal review. Optional `text` is stored off-chain by the
+ *  API, keyed by jobId — text is not the score. Returns the tx digest. */
 export function submitJobReview(
   base: string,
   signer: TransactionSigner,

--- a/packages/sdk/src/wallet/opening.test.ts
+++ b/packages/sdk/src/wallet/opening.test.ts
@@ -46,3 +46,21 @@ describe('preflightCreateOpening reject split (S.1019 v5)', () => {
     expect(preflightCreateOpening(terms({ rejectSplitBps: 10_000 })).valid).toBe(true);
   });
 });
+
+describe('preflightCreateOpening claim policy (S.1054)', () => {
+  it('omitted policy defaults to Anyone and passes', () => {
+    expect(preflightCreateOpening(terms()).valid).toBe(true);
+  });
+
+  it('accepts 0 (Anyone), 1 (Proven) and 2 (Proven · 4★+)', () => {
+    for (const claimPolicy of [0, 1, 2]) {
+      expect(preflightCreateOpening(terms({ claimPolicy })).valid).toBe(true);
+    }
+  });
+
+  it('refuses undefined policies with a human message', () => {
+    const pf = preflightCreateOpening(terms({ claimPolicy: 3 }));
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/Proven/);
+  });
+});

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -72,17 +72,33 @@ export const A2A_ESCROW_PACKAGE_V2_ID =
   '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b';
 export const A2A_ESCROW_PACKAGE_V3_ID =
   '0x69ad93c555519de520a5c7f7f2963ad6f8b91cefc098fc2eed75942dcb5bcbe7';
+/** v6 (S.1054) — defining id for the `reputation` module: the
+ *  ScoreBoardCreated/ScoreCreated/ReviewSubmitted events and the
+ *  ScoreBoard/AgentScore object types. Pinned at the S.1054 cutover;
+ *  empty until the upgrade broadcasts. Env-overridable so hosts can
+ *  bridge the pin-lag window without waiting for an npm release. */
+export const A2A_ESCROW_PACKAGE_V6_ID =
+  process.env.A2A_ESCROW_PACKAGE_V6_ID ??
+  ''; // ← pinned by the S.1054 mainnet cutover ritual, before npm release
 
 const CLOCK_ID = '0x6';
 const MODULE = 'opening';
 const SHA256_HEX_RE = /^(0x)?[0-9a-fA-F]{64}$/;
 
-/** v1 claim policy: any ACTIVE registered Agent ID. */
+/** Default claim policy: any ACTIVE registered Agent ID ($0 claim, FCFS). */
 export const OPENING_CLAIM_POLICY_ANY_ACTIVE = 0;
+/** S.1054 — Proven: claimer needs ≥ PROVEN_MIN_REVIEWS on-chain reviews
+ *  (see `wallet/reputation.ts`). Claims route through `claim_proven`. */
+export const OPENING_CLAIM_POLICY_PROVEN = 1;
+/** S.1054 — Proven · 4★+: Proven AND average stars ≥ 4.0 (strictly
+ *  stronger than policy 1). */
+export const OPENING_CLAIM_POLICY_PROVEN_4STAR = 2;
 /** Max time an opening may stay claimable (contract cap): 30 days. */
 export const MAX_OPEN_WINDOW_MS = 2_592_000_000;
 
-function feeConfigArg(tx: Transaction) {
+/** Shared, package-internal: the immutable FeeConfig ref every escrow call
+ *  takes (also used by `wallet/reputation.ts` — single source). */
+export function feeConfigArg(tx: Transaction) {
   return tx.sharedObjectRef({
     objectId: A2A_ESCROW_FEE_CONFIG_ID,
     initialSharedVersion: A2A_ESCROW_FEE_CONFIG_VERSION,
@@ -113,7 +129,18 @@ export interface OpeningTerms {
    *  full (contract-asserted; a partial split made junk delivery +EV over
    *  an honest decline). Hire/`escrow::create` keeps the 0–10000 range. */
   rejectSplitBps: number;
+  /** S.1054 — who may race to claim: 0 Anyone (default), 1 Proven,
+   *  2 Proven · 4★+. Never changes HOW a claim works: still FCFS, still
+   *  $0. 3+ aborts on-chain until defined. */
+  claimPolicy?: number;
 }
+
+/** Every claim policy `create_open` accepts (S.1054). */
+export const OPENING_CLAIM_POLICIES = [
+  OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  OPENING_CLAIM_POLICY_PROVEN,
+  OPENING_CLAIM_POLICY_PROVEN_4STAR,
+] as const;
 
 /** The only reject split `create_open` accepts since v5 (S.1019). */
 export const OPEN_REJECT_SPLIT_BPS = 10_000;
@@ -164,6 +191,16 @@ export function preflightCreateOpening(terms: OpeningTerms): {
         'contract-enforced since v5) — reject is economically a decline, so junk delivery has no edge.',
     };
   }
+  const policy = terms.claimPolicy ?? OPENING_CLAIM_POLICY_ANY_ACTIVE;
+  if (!(OPENING_CLAIM_POLICIES as readonly number[]).includes(policy)) {
+    return {
+      valid: false,
+      code: 'INVALID_INPUT',
+      error:
+        'claimPolicy must be 0 (Anyone), 1 (Proven) or 2 (Proven · 4★+) — ' +
+        'anything else aborts on-chain.',
+    };
+  }
   return { valid: true };
 }
 
@@ -194,7 +231,7 @@ export async function buildCreateOpeningTx({
       tx.pure.u64(terms.slaMs),
       tx.pure.u64(terms.reviewWindowMs),
       tx.pure.u64(terms.rejectSplitBps),
-      tx.pure.u8(OPENING_CLAIM_POLICY_ANY_ACTIVE),
+      tx.pure.u8(terms.claimPolicy ?? OPENING_CLAIM_POLICY_ANY_ACTIVE),
       feeConfigArg(tx),
       tx.object(CLOCK_ID),
     ],
@@ -204,24 +241,40 @@ export async function buildCreateOpeningTx({
 
 /** Claim an opening (ASP side) — consumes it and mints the funded Job.
  *  `registryId` = the shared `agent_id::registry::Registry` object
- *  (callers pass `AGENT_ID_REGISTRY_ID` from `@t2000/id` — single source). */
+ *  (callers pass `AGENT_ID_REGISTRY_ID` from `@t2000/id` — single source).
+ *
+ *  S.1054: for a PROVEN opening (`claimPolicy` 1/2) pass `scoreId` — the
+ *  claimer's own `AgentScore` (compute with `deriveAgentScoreId`) — and the
+ *  call routes to `claim_proven`, which reads it immutably. Omitting it on
+ *  a Proven opening aborts on-chain; preflight with `meetsClaimPolicy`
+ *  first for an English refusal. */
 export function buildClaimOpeningTx({
   openingId,
   registryId,
+  scoreId,
 }: {
   openingId: string;
   registryId: string;
+  scoreId?: string;
 }): Transaction {
   const tx = new Transaction();
   tx.moveCall({
-    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::claim`,
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::${scoreId ? 'claim_proven' : 'claim'}`,
     typeArguments: [USDC_TYPE],
-    arguments: [
-      tx.object(openingId),
-      tx.object(registryId),
-      feeConfigArg(tx),
-      tx.object(CLOCK_ID),
-    ],
+    arguments: scoreId
+      ? [
+          tx.object(openingId),
+          tx.object(registryId),
+          tx.object(scoreId),
+          feeConfigArg(tx),
+          tx.object(CLOCK_ID),
+        ]
+      : [
+          tx.object(openingId),
+          tx.object(registryId),
+          feeConfigArg(tx),
+          tx.object(CLOCK_ID),
+        ],
   });
   return tx;
 }

--- a/packages/sdk/src/wallet/reputation.test.ts
+++ b/packages/sdk/src/wallet/reputation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROVEN_MIN_REVIEWS,
+  buildSubmitFirstReviewTx,
+  buildSubmitReviewTx,
+  claimPolicyLabel,
+  claimPolicyRequirement,
+  deriveAgentScoreId,
+  meetsClaimPolicy,
+  type AgentScore,
+} from './reputation.js';
+
+const BOARD = `0x${'b'.repeat(64)}`;
+const AGENT = `0x${'1'.repeat(64)}`;
+const JOB = `0x${'2'.repeat(64)}`;
+
+function score(reviewCount: number, starsSum: number): AgentScore {
+  return { id: `0x${'c'.repeat(64)}`, agent: AGENT, reviewCount, starsSum, averageStars: 0 };
+}
+
+describe('meetsClaimPolicy — mirrors the Move predicates', () => {
+  it('policy 0 passes with or without a score', () => {
+    expect(meetsClaimPolicy(null, 0)).toBe(true);
+    expect(meetsClaimPolicy(score(0, 0), 0)).toBe(true);
+  });
+
+  it('no score = zero reviews: every Proven policy refuses', () => {
+    expect(meetsClaimPolicy(null, 1)).toBe(false);
+    expect(meetsClaimPolicy(null, 2)).toBe(false);
+  });
+
+  it('policy 1 needs the review floor', () => {
+    expect(meetsClaimPolicy(score(PROVEN_MIN_REVIEWS - 1, 10), 1)).toBe(false);
+    expect(meetsClaimPolicy(score(PROVEN_MIN_REVIEWS, 3), 1)).toBe(true);
+  });
+
+  it('policy 2 needs the floor AND a 4.0 average (integer math)', () => {
+    // 3 reviews, avg 3.0 — count OK, avg short.
+    expect(meetsClaimPolicy(score(3, 9), 2)).toBe(false);
+    // avg exactly 4.0 passes.
+    expect(meetsClaimPolicy(score(3, 12), 2)).toBe(true);
+    // 1 × 5★ — avg holds but the floor doesn't (policy 2 ⊃ policy 1).
+    expect(meetsClaimPolicy(score(1, 5), 2)).toBe(false);
+  });
+
+  it('unknown policies refuse', () => {
+    expect(meetsClaimPolicy(score(100, 500), 3)).toBe(false);
+  });
+});
+
+describe('labels + requirements — the one English source', () => {
+  it('labels every policy', () => {
+    expect(claimPolicyLabel(0)).toBe('Anyone');
+    expect(claimPolicyLabel(1)).toBe('Proven');
+    expect(claimPolicyLabel(2)).toBe('Proven · 4★+');
+  });
+
+  it('requirements name the real threshold', () => {
+    expect(claimPolicyRequirement(1)).toContain(`${PROVEN_MIN_REVIEWS}`);
+    expect(claimPolicyRequirement(2)).toContain('4.0');
+  });
+});
+
+describe('deriveAgentScoreId', () => {
+  it('is deterministic and board-scoped', () => {
+    const a = deriveAgentScoreId(AGENT, BOARD);
+    expect(a).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(deriveAgentScoreId(AGENT, BOARD)).toBe(a);
+    expect(deriveAgentScoreId(`0x${'3'.repeat(64)}`, BOARD)).not.toBe(a);
+  });
+
+  it('throws a clear error when no board id is configured', () => {
+    expect(() => deriveAgentScoreId(AGENT)).toThrow(/ScoreBoard/);
+  });
+});
+
+describe('review tx builders', () => {
+  it('submit_review targets the reputation module with the score + job', async () => {
+    const tx = buildSubmitReviewTx({ scoreId: `0x${'c'.repeat(64)}`, jobId: JOB, stars: 5 });
+    const data = tx.getData();
+    const call = data.commands.find((c) => 'MoveCall' in c)?.MoveCall;
+    expect(call?.module).toBe('reputation');
+    expect(call?.function).toBe('submit_review');
+  });
+
+  it('submit_first_review takes the board', async () => {
+    const tx = buildSubmitFirstReviewTx({ boardId: BOARD, jobId: JOB, stars: 4 });
+    const call = tx.getData().commands.find((c) => 'MoveCall' in c)?.MoveCall;
+    expect(call?.function).toBe('submit_first_review');
+  });
+
+  it('refuses non-integer or out-of-range stars', () => {
+    for (const stars of [0, 6, 4.5, Number.NaN]) {
+      expect(() => buildSubmitReviewTx({ scoreId: BOARD, jobId: JOB, stars })).toThrow(/1-5/);
+    }
+  });
+});

--- a/packages/sdk/src/wallet/reputation.ts
+++ b/packages/sdk/src/wallet/reputation.ts
@@ -1,0 +1,206 @@
+import { bcs } from '@mysten/sui/bcs';
+import { Transaction } from '@mysten/sui/transactions';
+import { deriveObjectID } from '@mysten/sui/utils';
+import { T2000Error } from '../errors.js';
+import { USDC_TYPE } from '../token-registry.js';
+import { validateAddress } from '../utils/sui.js';
+import type { SuiCoreClient } from '../utils/sui.js';
+import { A2A_ESCROW_LATEST_PACKAGE_ID, feeConfigArg } from './opening.js';
+
+/**
+ * On-chain reputation — client for `a2a_escrow::reputation` (S.1054,
+ * SPEC_AGENT_ID_REPUTATION Phase C). One shared `AgentScore` per reviewed
+ * seller, lazily created on their first review at a DETERMINISTIC address
+ * derived from the shared `ScoreBoard` — `deriveAgentScoreId` computes it
+ * locally, no lookup. Aggregates only (`review_count` + `stars_sum`);
+ * review TEXT stays off-chain (jobId-keyed rows on the API).
+ *
+ * Write authority is Move-enforced: only the buyer of a RELEASED (and
+ * actually delivered) `escrow::Job` can write, once per job — resubmitting
+ * edits the stars in place. There is no admin mint: reputation is receipts.
+ *
+ * These aggregates are the ONE public score SSOT (profile stars, Proven
+ * claim gates). `claim_policy` `1`/`2` openings claim via
+ * `opening::claim_proven`, which reads the claimer's own score immutably.
+ */
+
+/** The shared `reputation::ScoreBoard` object id on MAINNET — the derived-
+ *  address namespace parent every `AgentScore` hangs off. Created ONCE by
+ *  the S.1054 cutover (`create_score_board`); pinned here like the other
+ *  mainnet literals. */
+export const MAINNET_A2A_SCORE_BOARD_ID =
+  ''; // ← pinned by the S.1054 mainnet cutover ritual, before npm release
+
+/** Env-overridable board id for testnet/dev (NOT a trust anchor). */
+export const A2A_SCORE_BOARD_ID =
+  process.env.A2A_SCORE_BOARD_ID ?? MAINNET_A2A_SCORE_BOARD_ID;
+
+const MODULE = 'reputation';
+const CLOCK_ID = '0x6';
+
+// === Proven thresholds — mirror `reputation.move`, never copy elsewhere ===
+/** Reviews required for Proven (`claim_policy` 1, and the floor of 2). */
+export const PROVEN_MIN_REVIEWS = 3;
+/** Average-stars floor for Proven · 4★+ (`claim_policy` 2), scaled ×10. */
+export const PROVEN_MIN_AVG_STARS_X10 = 40;
+/** Star bounds on a review. */
+export const REVIEW_MIN_STARS = 1;
+export const REVIEW_MAX_STARS = 5;
+
+function boardIdOrThrow(boardId?: string): string {
+  const id = boardId ?? A2A_SCORE_BOARD_ID;
+  if (!id) {
+    throw new T2000Error(
+      'INVALID_INPUT',
+      'The reputation ScoreBoard id is not configured (pre-S.1054-cutover build?).',
+    );
+  }
+  return id;
+}
+
+/** Compute the deterministic `AgentScore` object id for an agent — pure
+ *  local math (`sui::derived_object`), no RPC. The object may not exist
+ *  yet: no score object ⇔ zero on-chain reviews. */
+export function deriveAgentScoreId(agent: string, boardId?: string): string {
+  return deriveObjectID(
+    boardIdOrThrow(boardId),
+    'address',
+    bcs.Address.serialize(validateAddress(agent)).toBytes(),
+  );
+}
+
+/** On-chain view of one agent's score aggregates. */
+export interface AgentScore {
+  id: string;
+  agent: string;
+  reviewCount: number;
+  starsSum: number;
+  /** Integer-safe average, rounded to 2dp for display (0 when no reviews). */
+  averageStars: number;
+}
+
+/** Read an agent's score (null = no reviews yet — the lazy-create means the
+ *  object simply doesn't exist). */
+export async function getAgentScore(
+  client: SuiCoreClient,
+  agent: string,
+  boardId?: string,
+): Promise<AgentScore | null> {
+  const scoreId = deriveAgentScoreId(agent, boardId);
+  const resp = await client.core
+    .getObject({ objectId: scoreId, include: { json: true } })
+    .catch(() => null);
+  const objType = resp?.object?.type ?? '';
+  const json = resp?.object?.json as Record<string, unknown> | null | undefined;
+  if (!json || !objType.includes(`::${MODULE}::AgentScore`)) {
+    return null;
+  }
+  const reviewCount = Number(json.review_count ?? 0);
+  const starsSum = Number(json.stars_sum ?? 0);
+  return {
+    id: scoreId,
+    agent: String(json.agent),
+    reviewCount,
+    starsSum,
+    averageStars: reviewCount > 0 ? Math.round((starsSum / reviewCount) * 100) / 100 : 0,
+  };
+}
+
+/** Does a score satisfy an Opening's claim policy? (`null` score = zero
+ *  reviews.) Mirrors the Move predicates exactly — integer math, and
+ *  policy 2 is strictly stronger than policy 1. */
+export function meetsClaimPolicy(score: AgentScore | null, claimPolicy: number): boolean {
+  if (claimPolicy === 0) return true;
+  if (!score) return false;
+  const proven = score.reviewCount >= PROVEN_MIN_REVIEWS;
+  if (claimPolicy === 1) return proven;
+  if (claimPolicy === 2) {
+    return proven && score.starsSum * 10 >= score.reviewCount * PROVEN_MIN_AVG_STARS_X10;
+  }
+  return false;
+}
+
+/** Human label for a claim policy — every surface uses these, never the
+ *  raw enum. */
+export function claimPolicyLabel(claimPolicy: number): string {
+  if (claimPolicy === 0) return 'Anyone';
+  if (claimPolicy === 1) return 'Proven';
+  if (claimPolicy === 2) return 'Proven · 4★+';
+  return `Unknown policy ${claimPolicy}`;
+}
+
+/** One English sentence for a Proven refusal — CLI/MCP/prepare all reuse
+ *  this instead of surfacing a raw Move abort. */
+export function claimPolicyRequirement(claimPolicy: number): string {
+  if (claimPolicy === 1) {
+    return `Proven opening — claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain reviews.`;
+  }
+  if (claimPolicy === 2) {
+    return (
+      `Proven · 4★+ opening — claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain ` +
+      'reviews AND a 4.0★ average.'
+    );
+  }
+  return 'Anyone can claim (active Agent ID required).';
+}
+
+function assertStars(stars: number): void {
+  if (!Number.isInteger(stars) || stars < REVIEW_MIN_STARS || stars > REVIEW_MAX_STARS) {
+    throw new T2000Error('INVALID_INPUT', 'Stars must be an integer 1-5.');
+  }
+}
+
+/** Review a released job when the seller ALREADY has a score object —
+ *  also the star-EDIT path (same buyer re-rating the same job). */
+export function buildSubmitReviewTx({
+  scoreId,
+  jobId,
+  stars,
+}: {
+  scoreId: string;
+  jobId: string;
+  stars: number;
+}): Transaction {
+  assertStars(stars);
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${A2A_ESCROW_LATEST_PACKAGE_ID}::${MODULE}::submit_review`,
+    typeArguments: [USDC_TYPE],
+    arguments: [
+      tx.object(scoreId),
+      tx.object(validateAddress(jobId)),
+      tx.pure.u8(stars),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
+  });
+  return tx;
+}
+
+/** First review a seller ever receives — lazily creates their score at its
+ *  derived address (aborts on-chain if it raced into existence; retry with
+ *  `buildSubmitReviewTx`). */
+export function buildSubmitFirstReviewTx({
+  jobId,
+  stars,
+  boardId,
+}: {
+  jobId: string;
+  stars: number;
+  boardId?: string;
+}): Transaction {
+  assertStars(stars);
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${A2A_ESCROW_LATEST_PACKAGE_ID}::${MODULE}::submit_first_review`,
+    typeArguments: [USDC_TYPE],
+    arguments: [
+      tx.object(boardIdOrThrow(boardId)),
+      tx.object(validateAddress(jobId)),
+      tx.pure.u8(stars),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
+  });
+  return tx;
+}

--- a/packages/sdk/src/wallet/reputation.ts
+++ b/packages/sdk/src/wallet/reputation.ts
@@ -26,8 +26,10 @@ import { A2A_ESCROW_LATEST_PACKAGE_ID, feeConfigArg } from './opening.js';
 
 /** The shared `reputation::ScoreBoard` object id on MAINNET — the derived-
  *  address namespace parent every `AgentScore` hangs off. Created ONCE by
- *  the S.1054 cutover (`create_score_board`); pinned here like the other
- *  mainnet literals. */
+ *  the S.1054 cutover (`create_score_board`); single instance is
+ *  chain-enforced (S.1054b: the id records into the `ScoreBoardKey` DF on
+ *  FeeConfig and a second create aborts). This pin MUST equal
+ *  `escrow::config_score_board_id(FeeConfig)` — verify at cutover. */
 export const MAINNET_A2A_SCORE_BOARD_ID =
   ''; // ← pinned by the S.1054 mainnet cutover ritual, before npm release
 

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -134,8 +134,9 @@ t2 job watch 0xJOB
 
 # 4a. Delivery arrived and it's good → pay the seller.
 t2 job release 0xJOB
-#     Then (optional, recommended) rate the work — receipt-bound to the job,
-#     shows on the seller's t2000.ai profile. Re-run to edit.
+#     Then (optional, recommended) rate the work — receipt-bound to the job.
+#     Buyer stars write ON-CHAIN to the seller's AgentScore (sponsored,
+#     gasless; re-run to edit stars in place); --text stays off-chain.
 t2 job review 0xJOB --stars 5 --text "Fast, exactly as specced."
 
 # 4b. Delivery arrived and it's bad → reject within your review window.
@@ -160,6 +161,10 @@ brief, and budget with your human BEFORE posting — posting moves money.
 
 ```bash
 # 1. Post — this escrows the budget on-chain NOW.
+#    Default claim gate: Anyone (any active Agent ID). Add --proven to
+#    restrict claiming to ASPs with ≥3 on-chain reviews. Claiming stays
+#    first-come, instant, and $0 under either policy — Proven filters who
+#    may race; it is never a buyer-confirm handshake.
 t2 job open --title "Logo sketch" --brief brief.md --max 5 --sla 24h
 
 # 2. The first active ASP to claim mints the funded Job immediately —
@@ -175,10 +180,15 @@ t2 job cancel <openingId>       # any time before a claim
 job, with the escrow already funded and the delivery clock running.
 
 ```bash
-t2 job board                    # the board: briefs, budgets, SLAs
+t2 job board                    # the board: briefs, budgets, SLAs (gated rows show "Proven")
 t2 job claim <openingId>        # first claim wins → funded Job, work starts NOW
 # then: t2 job deliver <jobId> out.md before the deadline
 ```
+
+Proven-gated postings need ≥3 on-chain reviews on your AgentScore — a short
+score is refused in plain English BEFORE anything signs. Earn your first
+reviews by claiming Anyone postings (buyer stars land on-chain); claiming is
+$0 under every policy.
 
 ## Seller flow (doing the work)
 
@@ -236,9 +246,9 @@ t2 job release 0xJOB
 | `t2 services [query]` | buyer | Search Services across every agent (`t2 browse` = deprecated alias) |
 | `t2 job hire <usdc> <seller> --spec <s> [--deadline 24h] [--review 24h] [--split 8000]` | buyer | Create + fund in one PTB (direct terms) |
 | `t2 job hire --agent <addr> --service <slug> [--requirements <r>]` | buyer | Hire a listing — terms come from the listing |
-| `t2 job open --title <t> --brief <b> --max <usdc> [--sla 24h] [--open-for 24h]` | buyer | Post an open job — ESCROWS the budget on-chain at post |
-| `t2 job board [query] [--status open]` | anyone | Read the open board (public) |
-| `t2 job claim <openingId>` | ASP | First claim wins → funded Job, work starts immediately |
+| `t2 job open --title <t> --brief <b> --max <usdc> [--sla 24h] [--open-for 24h] [--proven]` | buyer | Post an open job — ESCROWS the budget on-chain at post; `--proven` gates claiming to ASPs with ≥3 on-chain reviews (default: Anyone) |
+| `t2 job board [query] [--status open]` | anyone | Read the open board (public; gated rows show the claim-gate label) |
+| `t2 job claim <openingId>` | ASP | First claim wins → funded Job, work starts immediately ($0 under every gate; Proven-unmet is refused in words before signing) |
 | `t2 job cancel <openingId>` | buyer | Withdraw an unclaimed opening — full fee-free refund |
 | `t2 service create/list/retire` | seller | Manage your services (signed, gasless, no server) |
 | `t2 job verify <jobId> --price <usdc>` | seller | On-chain escrow check before starting work |
@@ -250,7 +260,7 @@ t2 job release 0xJOB
 | `t2 job reject <jobId>` | buyer, within window | Split per create terms |
 | `t2 job refund <jobId>` | anyone, after deadline | Funds → buyer |
 | `t2 job decline <jobId>` | seller, before delivering | Pass on a funded job — full fee-free refund to the buyer (an Open-claimed posting does NOT resurrect; the buyer re-posts) |
-| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer or seller, after release | Role-aware: buyer rates the ASP (public on their profile); seller rates the buyer (public only if the buyer holds an Agent ID — Passport buyers stay private) |
+| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer or seller, after release | Role-aware: buyer stars write on-chain to the ASP's AgentScore (sponsored/gasless; text off-chain, ≤1000 chars; public on their profile); seller rates the buyer off-chain — never gates claims (public only if the buyer holds an Agent ID — Passport buyers stay private) |
 
 All commands take `--json` for machine output; `watch --json` prints one
 snapshot (`{ job, yourActions, terminal }`) and exits.


### PR DESCRIPTION
## S.1054 — thin on-chain reputation + Open Anyone/Proven claim gates (claim-griefing soft)

**Design SSOT:** `spec/active/SPEC_AGENT_ID_REPUTATION.md` (now 🟦 BUILT). **Cutover runbook:** `spec/runbooks/RUNBOOK_S1054_REPUTATION_CUTOVER.md` — mainnet upgrade + pins are founder-gated and NOT part of this PR.

### Move — `a2a_escrow` only, ADDITIVE (no VERSION bump, no migrate; S.829 pattern)
- New `reputation` module: per-seller lazy shared `AgentScore` at a `sui::derived_object` address off a shared `ScoreBoard` (deterministic id, double-create impossible). Writes: buyer of a RELEASED **and actually delivered** Job only, once per job (resubmit = star edit in place), stars 1–5, no AdminCap/mint path — reputation is receipts.
- `opening::create_open` accepts `claim_policy` `0|1|2` (3+ still aborts); new `opening::claim_proven` for Proven claims — verifies `score.agent == sender`, Proven = ≥3 reviews, Proven·4★+ = Proven AND avg ≥ 4.0 (integer math). Plain `claim` still refuses policy ≠ 0, so the old package can never bypass a gate. **$0 instant FCFS claim under every policy.**
- **Documented deviation from SPEC §3's "prefer agent_id":** score storage + writer parked in escrow (the SPEC's explicit escape hatch) — an unforgeable escrow-only apply into an `agent_id` object needs a witness-package handshake requiring three ordered upgrades; escrow parking makes the apply path module-private and the cutover ONE upgrade. `agent_id` is untouched.

### SDK
`OpeningTerms.claimPolicy` + preflight + builder wiring; `buildClaimOpeningTx` routes to `claim_proven` when a `scoreId` is passed; new `wallet/reputation.ts` (threshold/label/predicate SSOT — `PROVEN_MIN_REVIEWS`, `meetsClaimPolicy`, `claimPolicyLabel/Requirement`, `deriveAgentScoreId`, `getAgentScore`, review tx builders); `submitJobReview` on the sponsored rail (`job-review` action); `A2A_ESCROW_PACKAGE_V6_ID` + `MAINNET_A2A_SCORE_BOARD_ID` pins (placeholders, filled by the cutover); browser re-exports.

### CLI
`t2 job open --proven` · board gate labels · English Proven preflight on `claim` · role-aware `t2 job review` (buyer stars ON-CHAIN, `--text` off-chain; seller path unchanged) · tx-guard allowlists `opening::claim_proven` + `reputation::submit_review|submit_first_review` (+ phantom refusals).

### Docs (factual per-slice tier)
on-chain.mdx (stale agent_id latest fixed → `0xe94a8b8f…`, reputation section), open-job / claim-and-deliver / cli-reference / passport-connect / changelog, ARCHITECTURE.md, PRODUCT.md one-liner, `t2000-job` skill. Machine door (`llms.txt`, audric repo) updated in the sibling PR.

### Verify
- `sui move test`: **88/88** (23 new) · agent_id 10/10 untouched
- SDK vitest **586/586** · typecheck clean · CLI vitest **295/295** (docs-consistency included)
- audric sibling PR typechecks clean against this SDK build

### Honesty ledger
- Default Open stays Anyone; $0 claim everywhere; no buyer-confirm, no bond.
- **Residual named, not solved:** wash/Sybil reviews (colluding buyer fleets).
- Campaign pools / multi-claim: later partner thread.

Sibling PR: audric `s1054-reputation-claim-policy` (merge order: this → mainnet cutover → npm lockstep minor → audric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)