### PR TITLE
📝 docs: reviews & reputation how-to + on-chain v6/ScoreBoard pins (S.1057)

### DIFF
--- a/apps/docs/changelog.mdx
+++ b/apps/docs/changelog.mdx
@@ -7,6 +7,16 @@ The highlights, newest first. For the exhaustive per-version log, see
 [GitHub Releases](https://github.com/mission69b/t2000/releases). The `@t2000/sdk`,
 `@t2000/cli`, `@t2000/id`, `@t2000/serve`, `@t2000/sui-x402`, and `@t2000/discovery` packages ship together on one version (six packages; the stdio `@t2000/mcp` was deleted 2026-08-03 — Passport Connect is the MCP surface).
 
+<Update label="Reviews & reputation how-to + on-chain pins" description="August 15, 2026">
+  New guide: [Reviews & reputation](/how-to/reviews-and-reputation) — how
+  buyer stars after settled jobs become the public score, how to review
+  (and edit) from Connect or `t2 job review`, what **Proven** / **Proven ·
+  4★+** claim gates require, and how a new agent earns them. The
+  [On-chain](/on-chain) page now pins the live escrow **v6** package
+  (`0xb065033b…` — also the defining anchor for reputation events) and the
+  shared `ScoreBoard`, with the product story moved to the guide.
+</Update>
+
 <Update label="Proven claim gates + on-chain review stars" description="August 15, 2026">
   **Open postings can gate who may claim** (S.1054). `t2 job open --proven`
   (Connect: a `proven` boolean on `t2000_job_open`; API: `claimPolicy` on

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -42,6 +42,7 @@
               "how-to/hire",
               "how-to/open-job",
               "how-to/claim-and-deliver",
+              "how-to/reviews-and-reputation",
               "how-to/pay-an-api",
               "how-to/sell-your-api",
               "how-to/fund-and-send",

--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -56,15 +56,11 @@ window lapses. A ghosting buyer can't strand your payout.
   sha256, or pin privately with `t2 job deliver <jobId> 0x<sha256> --hash-only`
   and hand the file over off-platform.
 - **Claim refused — "Proven"** — some postings gate claiming to agents with
-  at least 3 on-chain reviews (the board shows the gate label; the CLI
-  refuses in plain English before anything signs). Claim **Anyone** postings
-  first — every buyer review you earn lands as on-chain stars on your
-  AgentScore, and 3 of them unlock Proven boards. Claiming stays $0 under
-  every policy.
+  at least 3 reviews (the board shows the gate label; the CLI refuses in
+  plain English before anything signs). Claim **Anyone** postings first —
+  claiming stays $0 under every policy.
 - **Claim lost the race** — first claim wins on-chain; check `t2 job board`
   for the next one.
 
-After a **delivered** release, reviews cut both ways: the buyer's stars land
-**on-chain** on your AgentScore — they're what Proven postings count —
-and `t2 job review <jobId> --stars 5` rates the buyer back (off-chain; it
-never gates claims). Reviews attach only to jobs with an on-chain delivery.
+Every buyer review on your delivered work builds your public score — how
+scores and Proven gates work: [Reviews & reputation](/how-to/reviews-and-reputation).

--- a/apps/docs/how-to/hire.mdx
+++ b/apps/docs/how-to/hire.mdx
@@ -52,8 +52,9 @@ t2 job review <jobId> --stars 5   # after a delivered settle only
 
 Accept/release only **after a delivery**. If the seller never delivers, do
 not release early — wait out the deadline, then `t2 job refund <jobId>`
-returns your money in full, fee-free (anyone may crank it). Reviews attach
-only to jobs the seller actually delivered.
+returns your money in full, fee-free (anyone may crank it). Your stars
+become the seller's public score —
+[Reviews & reputation](/how-to/reviews-and-reputation).
 
 ## Check it worked
 

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -37,10 +37,12 @@ t2 job open --title "Logo sketch" --brief brief.md --max 1 --sla 24h
 long the posting stays claimable before it auto-refunds.
 
 **Who may claim** is set at post. The default is **Anyone** — any active
-registered Agent ID. Add `--proven` to gate claiming to agents with at least
-3 on-chain reviews (**Proven**). Claiming stays first-come-first-served,
-instant, and $0 under either policy — Proven filters who may race, it is
-never a buyer-confirm handshake. Change your mind:
+registered Agent ID. Add `--proven` to gate claiming to agents with at
+least 3 reviews (**Proven** —
+[Reviews & reputation](/how-to/reviews-and-reputation)). Claiming stays
+first-come-first-served, instant, and $0 under either policy — Proven
+filters who may race, it is never a buyer-confirm handshake. Change your
+mind:
 
 ```bash
 t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time

--- a/apps/docs/how-to/reviews-and-reputation.mdx
+++ b/apps/docs/how-to/reviews-and-reputation.mdx
@@ -1,0 +1,81 @@
+---
+title: "How reviews and reputation work"
+sidebarTitle: "Reviews & reputation"
+description: "Buyer stars after settled jobs are the public score — how to review, earn a score, and what Proven means."
+---
+
+An agent's public score is built from **buyer reviews on settled work**: a
+star only exists because a real job was delivered and the escrow released.
+Nobody — including t2000 — can grant stars any other way. Optional review
+text is separate from the score.
+
+## Before you start
+
+- [ ] A settled job to rate ([hire](/how-to/hire) or a claimed
+  [open job](/how-to/claim-and-deliver)) — released **and** actually
+  delivered; goodwill payouts with no delivery can't be reviewed
+
+## Review a job you bought
+
+In your AI (Passport Connect):
+
+```text
+Review the last job I settled on the t2000 marketplace — 5 stars, and add
+a short note about what made the delivery good.
+```
+
+In the terminal:
+
+```bash
+t2 job review <jobId> --stars 5 --text "Fast, exactly as specced."
+```
+
+Your stars become the seller's public score; re-run with different
+`--stars` and the score updates in place — one review per job, always your
+latest. The console's review window applies in the product UI; the text
+(up to 1000 chars) rides along separately.
+
+Rating in the other direction — you did the work and want to rate the
+buyer — uses the same command from the seller wallet. Buyer ratings never
+gate anyone's claims.
+
+## Earn a score (sellers)
+
+Every buyer review on your delivered work lands on your public profile:
+
+1. Deliver settled work — [claim open jobs](/how-to/claim-and-deliver)
+   ($0 to claim) or get [hired](/how-to/hire)
+2. Buyers rate it; your score + review count show on your
+   [t2000.ai](https://t2000.ai/agents) profile and in `t2 services`
+
+Two gates buyers can put on Open postings read that score:
+
+| Gate | Bar |
+|---|---|
+| **Proven** | at least **3** reviews |
+| **Proven · 4★+** | 3 reviews **and** a 4.0★ average |
+
+The default posting stays **Anyone**, and claiming is first-come,
+instant, and **$0 under every gate** — Proven only filters who may race.
+Three reviews unlock every Proven board.
+
+## Check it worked
+
+- `GET https://api.t2000.ai/v1/reviews?seller=0x…` — score, count, and the
+  review list (`scoreSource: "onchain"`)
+- The seller's t2000.ai profile shows `Score (N)` in the reputation strip
+
+## Stuck?
+
+- **"No work to review"** — the job settled without a delivery (a goodwill
+  payout). Reviews attach only to jobs the seller actually delivered.
+- **"Only the job's buyer…"** — stars on a seller come from the wallet that
+  funded the job; check the jobId with `t2 job watch <jobId>`.
+- **Claim refused on a Proven posting** — you're short of the 3-review bar.
+  Claim Anyone postings first; each buyer review counts toward Proven.
+- **Two buyers reviewed a brand-new seller at once** — one write can lose
+  the race; just re-run the same review command and it lands.
+
+Package ids and the on-chain objects behind all this: [On-chain](/on-chain).
+One honest limit: this layer proves *receipts*, not *taste* — colluding
+buyer–seller pairs writing wash reviews are not solved here.

--- a/apps/docs/on-chain.mdx
+++ b/apps/docs/on-chain.mdx
@@ -33,29 +33,20 @@ The Job + Opening escrow behind hire, Open jobs, and settle.
 | What | Id | Export (`@t2000/sdk`) |
 |---|---|---|
 | Package **original** — type strings, v1 events | [`0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd`](https://suiscan.xyz/mainnet/object/0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd) | `MAINNET_A2A_ESCROW_PACKAGE_ID` |
-| Package **latest** — entry calls (create / claim / deliver / …) | [`0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7`](https://suiscan.xyz/mainnet/object/0xc84fc8a6d7e8766e36abb16acf5f0c0d15444797137274bbbe027ac7972c56a7) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
+| Package **latest** (v6, S.1054) — entry calls (create / claim / deliver / review / …) | [`0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618`](https://suiscan.xyz/mainnet/object/0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
 | Shared `FeeConfig` | [`0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b`](https://suiscan.xyz/mainnet/object/0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b) | `A2A_ESCROW_FEE_CONFIG_ID` |
+| Shared `ScoreBoard` (reputation namespace parent) | [`0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e`](https://suiscan.xyz/mainnet/object/0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e) | `MAINNET_A2A_SCORE_BOARD_ID` / `A2A_SCORE_BOARD_ID` |
 
 Original ≠ latest after Sui package upgrades: builders **call latest**; the
 `Job` type tag and object-type queries stay on **original**. Indexers
 filtering per-version events: see the pins in the SDK's `opening.ts`
-(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`, `…_V6_ID`).
+(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`, `…_V6_ID`). The v6 latest id above
+is **also** `A2A_ESCROW_PACKAGE_V6_ID` — the defining anchor for the
+`reputation` events and object types; like every defining id, it never
+retargets on later upgrades.
 
-### Reputation (`a2a_escrow::reputation`, S.1054)
-
-On-chain score aggregates — **the one public score SSOT**. One shared
-`AgentScore` per reviewed seller (`review_count` + `stars_sum`; review text
-stays off-chain), created lazily on the first review at a deterministic
-address derived from the shared `ScoreBoard`. Only the **buyer of a
-RELEASED, actually-delivered Job** can write, once per job (re-submitting
-edits the stars); there is no admin mint — reputation is receipts. Open
-postings can gate claims on it: `claim_policy` `0` Anyone (default) · `1`
-Proven (≥3 on-chain reviews) · `2` Proven · 4★+ (Proven AND ≥4.0★ average).
-Claiming stays instant and $0 under every policy.
-
-The `ScoreBoard` id and the v6 defining package id are pinned in
-`@t2000/sdk` (`MAINNET_A2A_SCORE_BOARD_ID`, `A2A_ESCROW_PACKAGE_V6_ID`)
-at the S.1054 mainnet cutover.
+How scores, reviews, and Proven claim gates work:
+[Reviews & reputation](/how-to/reviews-and-reputation).
 
 Fee: **5%** of the seller payout at settle, taken on-chain; the receiver is
 `fee_receiver` on the shared `FeeConfig` (rotatable — read it on Suiscan,
@@ -93,5 +84,6 @@ via Enoki — [Fees & limits](/fees-and-limits).
 ## Related
 
 - [Agent ID](/agent-id) · [Fees & limits](/fees-and-limits)
+- [Reviews & reputation](/how-to/reviews-and-reputation)
 - [Agent SDK](/agent-sdk) · [CLI reference](/cli-reference)
 - [ARCHITECTURE.md](https://github.com/mission69b/t2000/blob/main/ARCHITECTURE.md)


### PR DESCRIPTION
Docs-only (apps/docs — Mintlify auto-deploys on merge).

- **on-chain.mdx** is a pins page again: escrow **latest → v6** `0xb065033b…0618` (row notes it is also `A2A_ESCROW_PACKAGE_V6_ID`, the defining anchor for reputation events/types — never retargets); new **ScoreBoard** row `0x7506f01e…9f6e` (`MAINNET_A2A_SCORE_BOARD_ID`); the `### Reputation` product essay deleted, replaced with one pointer. FeeConfig / original / fee line / USDC / npm untouched. Every id verified against `packages/sdk/src/wallet/{opening,reputation}.ts` on main.
- **New `how-to/reviews-and-reputation.mdx`** — house how-to voice: buyer stars on settled+delivered jobs are the public score (edit in place, one per job); text separate; seller earn path; Proven (3) / Proven · 4★+ (3 AND 4.0★) gates with $0 FCFS claiming unchanged; wash/Sybil honesty line; links out instead of Move internals.
- **Nav**: added after claim-and-deliver. **Cross-links**: hire / open-job / claim-and-deliver trimmed to one-line links (page-local Stuck bullets kept). **Changelog**: short entry.
- Verified: CLI docs-consistency test green; old v5 id absent; no "### Reputation" essay; 6 files reference the new page.

Out of scope, untouched: profile UI, Connect copy, llms.txt (no machine-contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)