### PR TITLE
🎨 style(sdk): short Proven refusal sentence (S.1059)

### DIFF
--- a/packages/sdk/src/wallet/reputation.test.ts
+++ b/packages/sdk/src/wallet/reputation.test.ts
@@ -56,9 +56,14 @@ describe('labels + requirements — the one English source', () => {
     expect(claimPolicyLabel(2)).toBe('Proven · 4★+');
   });
 
-  it('requirements name the real threshold', () => {
-    expect(claimPolicyRequirement(1)).toContain(`${PROVEN_MIN_REVIEWS}`);
+  it('requirements are the SHORT human sentence naming the real threshold (S.1059)', () => {
+    expect(claimPolicyRequirement(1)).toBe(
+      `Claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain reviews.`,
+    );
+    expect(claimPolicyRequirement(2)).toContain(`${PROVEN_MIN_REVIEWS}`);
     expect(claimPolicyRequirement(2)).toContain('4.0');
+    // The Passport claim surface paints this verbatim — no essay prefix.
+    expect(claimPolicyRequirement(2)).toMatch(/^Claiming needs/);
   });
 });
 

--- a/packages/sdk/src/wallet/reputation.ts
+++ b/packages/sdk/src/wallet/reputation.ts
@@ -135,13 +135,10 @@ export function claimPolicyLabel(claimPolicy: number): string {
  *  this instead of surfacing a raw Move abort. */
 export function claimPolicyRequirement(claimPolicy: number): string {
   if (claimPolicy === 1) {
-    return `Proven opening — claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain reviews.`;
+    return `Claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain reviews.`;
   }
   if (claimPolicy === 2) {
-    return (
-      `Proven · 4★+ opening — claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain ` +
-      'reviews AND a 4.0★ average.'
-    );
+    return `Claiming needs at least ${PROVEN_MIN_REVIEWS} on-chain reviews and a 4.0★ average.`;
   }
   return 'Anyone can claim (active Agent ID required).';
 }


### PR DESCRIPTION
S.1059 part 1 (SDK only): `claimPolicyRequirement` now returns the short human sentence — policy 1 `Claiming needs at least 3 on-chain reviews.`, policy 2 adds `and a 4.0★ average.` Anyone line unchanged; thresholds unchanged. Test pins the exact short form. CLI/MCP diagnostic appendices unaffected (they append after this string). Audric prepare consumes it via the lockstep bump (part 2, audric PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)