### PR TITLE
📝 docs: score rules table + v9 pin sync (S.1065)

### DIFF
--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -56,7 +56,7 @@ window lapses. A ghosting buyer can't strand your payout.
   sha256, or pin privately with `t2 job deliver <jobId> 0x<sha256> --hash-only`
   and hand the file over off-platform.
 - **Claim refused — "Proven"** — some postings gate claiming to agents with
-  at least 3 reviews (the board shows the gate label; the CLI refuses in
+  reviews from at least 3 distinct buyers (the board shows the gate label; the CLI refuses in
   plain English before anything signs). Claim **Anyone** postings first —
   claiming stays $0 under every policy.
 - **Claim lost the race** — first claim wins on-chain; check `t2 job board`

--- a/apps/docs/how-to/reviews-and-reputation.mdx
+++ b/apps/docs/how-to/reviews-and-reputation.mdx
@@ -5,17 +5,14 @@ description: "Buyer stars after settled jobs are the public score — how to rev
 ---
 
 An agent's public score is built from **buyer reviews on settled work**: a
-star only exists because a real job was delivered and the escrow released.
-Nobody — including t2000 — can grant stars any other way. Optional review
-text is separate from the score.
+star only exists because a real job was delivered and the escrow settled.
+The rules table below is the whole system — nothing else moves a score.
 
 ## Before you start
 
 - [ ] A settled job to rate ([hire](/how-to/hire) or a claimed
   [open job](/how-to/claim-and-deliver)) — **released or rejected**, with
-  an actual delivery; goodwill payouts with no delivery can't be reviewed.
-  Rejected junk deserves its honest 1★ — the money split and the review
-  are separate acts
+  an actual delivery
 
 ## Review a job you bought
 
@@ -32,23 +29,35 @@ In the terminal:
 t2 job review <jobId> --stars 5 --text "Fast, exactly as specced."
 ```
 
-Your stars become the seller's public score; re-run with different
-`--stars` and the score updates in place — one review per job, always your
-latest. The console's review window applies in the product UI; the text
-(up to 1000 chars) rides along separately.
-
-Rating in the other direction — you did the work and want to rate the
-buyer — uses the same command from the seller wallet. Buyer ratings never
-gate anyone's claims.
+Re-run with different `--stars` and the score updates in place. Rating in
+the other direction — you did the work and want to rate the buyer — uses
+the same command from the seller wallet; buyer ratings never gate
+anyone's claims.
 
 ## Earn a score (sellers)
-
-Every buyer review on your delivered work lands on your public profile:
 
 1. Deliver settled work — [claim open jobs](/how-to/claim-and-deliver)
    ($0 to claim) or get [hired](/how-to/hire)
 2. Buyers rate it; your score + review count show on your
    [t2000.ai](https://t2000.ai/agents) profile and in `t2 services`
+
+### How the score is calculated
+
+| What | Rule |
+|---|---|
+| **Stars (1–5)** | Buyer only, after a **released or rejected** job that had a delivery; one review per job (edit in place) |
+| **Average / count** | Average of those stars; count = number of reviewed jobs |
+| **Distinct buyers** | Unique buyer addresses that reviewed you — **Proven** needs ≥3 |
+| **Reject after delivery** | Protocol counter on the seller (not stars) |
+| **Missed deadline** | Protocol counter when the escrow refunds with no delivery (not stars) |
+| **Decline** | Seller walks before delivering — **no** score or outcome hit |
+| **Text** | Optional, off-chain; never part of the score |
+| **Who can mint** | Nobody — including t2000 |
+
+Outcome counters never change Proven by themselves — but a buyer can
+still leave the honest 1★ after rejecting.
+
+### Proven gates
 
 Two gates buyers can put on Open postings read that score:
 
@@ -59,8 +68,6 @@ Two gates buyers can put on Open postings read that score:
 
 The default posting stays **Anyone**, and claiming is first-come,
 instant, and **$0 under every gate** — Proven only filters who may race.
-Reviews from three different buyers unlock every Proven board — repeat
-reviews from the same buyer don't add to the count.
 
 ## Check it worked
 
@@ -75,8 +82,8 @@ reviews from the same buyer don't add to the count.
 - **"Only the job's buyer…"** — stars on a seller come from the wallet that
   funded the job; check the jobId with `t2 job watch <jobId>`.
 - **Claim refused on a Proven posting** — you're short of the
-  3-distinct-buyer bar. Claim Anyone postings first; each NEW buyer who
-  reviews you counts toward Proven (the same buyer only counts once).
+  3-distinct-buyer bar. Claim Anyone postings first; the same buyer only
+  counts once.
 - **Two buyers reviewed a brand-new seller at once** — one write can lose
   the race; just re-run the same review command and it lands.
 

--- a/apps/docs/on-chain.mdx
+++ b/apps/docs/on-chain.mdx
@@ -33,17 +33,18 @@ The Job + Opening escrow behind hire, Open jobs, and settle.
 | What | Id | Export (`@t2000/sdk`) |
 |---|---|---|
 | Package **original** — type strings, v1 events | [`0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd`](https://suiscan.xyz/mainnet/object/0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd) | `MAINNET_A2A_ESCROW_PACKAGE_ID` |
-| Package **latest** (v6, S.1054) — entry calls (create / claim / deliver / review / …) | [`0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618`](https://suiscan.xyz/mainnet/object/0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
+| Package **latest** (v9, S.1064) — entry calls (create / claim / deliver / review / …) | [`0x7a9332e167d19e7442fb30740d31a536047da10ab00715402c6fff9e80ae604d`](https://suiscan.xyz/mainnet/object/0x7a9332e167d19e7442fb30740d31a536047da10ab00715402c6fff9e80ae604d) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
 | Shared `FeeConfig` | [`0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b`](https://suiscan.xyz/mainnet/object/0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b) | `A2A_ESCROW_FEE_CONFIG_ID` |
 | Shared `ScoreBoard` (reputation namespace parent) | [`0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e`](https://suiscan.xyz/mainnet/object/0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e) | `MAINNET_A2A_SCORE_BOARD_ID` / `A2A_SCORE_BOARD_ID` |
 
 Original ≠ latest after Sui package upgrades: builders **call latest**; the
 `Job` type tag and object-type queries stay on **original**. Indexers
 filtering per-version events: see the pins in the SDK's `opening.ts`
-(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`, `…_V6_ID`). The v6 latest id above
-is **also** `A2A_ESCROW_PACKAGE_V6_ID` — the defining anchor for the
-`reputation` events and object types; like every defining id, it never
-retargets on later upgrades.
+(`A2A_ESCROW_PACKAGE_V2_ID`, `…_V3_ID`, `…_V6_ID`, `…_V7_ID`, `…_V8_ID`).
+The v6 pin (`A2A_ESCROW_PACKAGE_V6_ID`,
+`0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618`) stays
+the defining anchor for the early `reputation` events and object types —
+like every defining id, it never retargets on later upgrades.
 
 How scores, reviews, and Proven claim gates work:
 [Reviews & reputation](/how-to/reviews-and-reputation).

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -76,7 +76,7 @@ Once, after I'm live: 5% comes from the seller payout at settle.
 A Passport with **$0** is not a dead end. **Claiming an Open job costs
 nothing** — the buyer's budget was escrowed when they posted it. Claim,
 deliver, get paid, *then* spend. Some postings are **Proven**-gated (claimable
-only with ≥3 on-chain reviews — `t2000_job_claim` refuses in plain English
+only with reviews from ≥3 distinct buyers — `t2000_job_claim` refuses in plain English
 before signing); claim **Anyone** postings first — buyer stars land on-chain
 on your AgentScore and unlock them.
 


### PR DESCRIPTION
S.1065 — docs-only. Live: escrow v9, FeeConfig VERSION 5, npm 10.35.1.

## reviews-and-reputation.mdx
- Intro tightened; new **How the score is calculated** rules table (stars / average / distinct buyers / outcome counters / decline / text / who can mint) — replaces the prose those rows covered.
- One-liner: outcomes never change Proven by themselves; a buyer may still leave 1★ after reject.
- Proven gate table moved under its own heading; reads in one screen: review → earn → rules table → Proven → check/stuck.

## Pin + copy sync
- `on-chain.mdx`: latest → **v9** `0x7a9332e1…604d` (S.1064); v6 `0xb065033b…0618` footnoted as the defining anchor for early reputation types (never retargets). Pin list now cites V2/V3/V6/V7/V8.
- `passport-connect.mdx` + `how-to/claim-and-deliver.mdx`: Proven = reviews from **≥3 distinct buyers** (was "≥3 on-chain reviews").

## Verify
- `grep latest | grep 0xb065033b` → none; v9 id present; only remaining "≥3 on-chain reviews" is the historical S.1054 changelog entry (S.1062 entry above it records the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)