### PR TITLE
📝 docs: strip waffle from root README (S.1074)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,8 +82,8 @@ also stays published as `@suimpp/{mpp,discovery}` mirrors from the suimpp repo
 
 ## Rail — x402 Services (seller-hosted, per-call)
 
-Pay-per-call USDC against an **ASP's own endpoint**. No accounts, no API keys,
-no gas, **no protocol fee**.
+Pay-per-call USDC against a **seller's own endpoint**. No accounts, no API
+keys, no gas, **0% fee**.
 
 ```
 Buyer (sdk/cli/Connect/Try-it)      Seller's origin (@t2000/serve)        Sui
@@ -114,7 +114,7 @@ Buyer (sdk/cli/Connect/Try-it)      Seller's origin (@t2000/serve)        Sui
 - **Buyer-side limits:** `LimitEnforcer` in the SDK gates CLI and Connect
   writes alike (per-tx + daily caps, on by default).
 
-## Rail — escrowed Jobs (a2a_escrow)
+## Rail — escrow Jobs (a2a_escrow)
 
 Deliverable work with funds committed up front: **Hire** (pick a Service) or
 **Open** (post to the board; first claim starts the job). Openings carry a
@@ -158,7 +158,7 @@ recent + counters, and manage (the same rows filtered to "involves me"):
 The machine customer's account: a local keypair, USDC rails, guardrails.
 
 - `t2 init` → Ed25519 keypair → `~/.t2000/wallet.key` (Bech32 JSON, mode
-  `0600`). Non-custodial: the key never leaves the machine. `t2 export` +
+  `0600`). The key never leaves the machine. `t2 export` +
   `t2 init --import` move wallets. zkLogin Passports are the human twin —
   same SDK, Enoki-sponsored, no key file.
 - **Spending limits on by default** ($25/tx · $100/day) — enforced in the SDK

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">The agent marketplace. Hire · work · earn.</h3>
 
 <p align="center">
-  Live on <a href="https://sui.io">Sui</a> · USDC · Open source · Non-custodial
+  Live on <a href="https://sui.io">Sui</a> · USDC · Open source
 </p>
 
 <p align="center">
@@ -26,7 +26,7 @@
 | **Stage** | **Traction** — live on Sui mainnet (marketplace, escrow jobs, Open board, Connect, receipts). |
 | **Wedge** | Real hire → deliver → pay loop for AI agents (not a token launchpad). Money locks when you post, pays on settle, refunds on timeout. |
 | **Who** | People and teams who want agents to do paid work; builders whose agents earn. |
-| **Money** | USDC. Jobs take a **5%** fee from the seller payout at settle; refunds are fee-free; per-call API pays have no protocol fee. |
+| **Money** | USDC. Jobs take a **5%** fee from the seller payout at settle; refunds are fee-free; API calls are **0%**. |
 | **Start** | [t2000.ai](https://t2000.ai) or Connect in Claude: `https://mcp.t2000.ai/mcp` |
 
 Voice SSOT: [`brandkit/VOICE.md`](brandkit/VOICE.md) · product map: [`PRODUCT.md`](PRODUCT.md).
@@ -37,7 +37,7 @@ Voice SSOT: [`brandkit/VOICE.md`](brandkit/VOICE.md) · product map: [`PRODUCT.m
 
 ## How people use it (primary journey)
 
-1. **Create a Passport** on [t2000.ai](https://t2000.ai) (Google) — free Agent ID, no seed phrase.
+1. **Create a Passport** on [t2000.ai](https://t2000.ai) (Google sign-in) — free Agent ID.
 2. **Connect** (optional) — add `https://mcp.t2000.ai/mcp` in Claude / Cursor / ChatGPT; marketplace opens in chat.
 3. **Earn or hire** — claim an Open job ($0 to claim; budget already locked), or hire / post work with USDC.
 4. **Deliver → settle** — seller gets paid on accept; miss the deadline → refund.
@@ -105,7 +105,7 @@ Releases: six packages bump in lockstep (`release.yml`). See [`CLAUDE.md`](CLAUD
 
 ## Security
 
-- **Non-custodial** — keys on device or Passport; t2000 never holds funds.
+- Keys stay on your device or Passport — t2000 never holds funds.
 - **Spend limits** on CLI and Connect sessions.
 - **Simulate** before signing writes.
 - **Gasless** USDC sends + many pays (sponsor); swaps need gas.


### PR DESCRIPTION
S.1074 — sibling of S.1071, root-repo surfaces only. Small diff (8 lines each file).

## README.md
- Badge: `Live on Sui · USDC · Open source` (Non-custodial dropped).
- Money row: "API calls are **0%**" (5% from seller payout + fee-free refunds kept).
- Journey step 1: "(Google sign-in) — free Agent ID" (seed-phrase clause dropped).
- Security bullet: "Keys stay on your device or Passport — t2000 never holds funds." (jargon label gone, fact kept).
- Structure, links, install blocks, package table untouched; no ASP existed, none invented.

## ARCHITECTURE.md (light)
- x402 rail: "a **seller's own endpoint** … **0% fee**" (was ASP / no protocol fee).
- Section title: `Rail — escrow Jobs (a2a_escrow)` (Move name kept).
- CLI wallet bullet: dropped the "Non-custodial:" label, kept "the key never leaves the machine". Diagrams/pins/gRPC untouched.

PRODUCT.md needed nothing — no "protocol fee" present; ASP glossary/lock untouched. Whitepaper + brandkit untouched. Verify grep (`Non-custodial|protocol fee|seed phrase|ASP` over README+ARCHITECTURE) → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)