### PR TITLE
📝 docs: retire ASP noun for seller (S.1076)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -16,7 +16,7 @@
 | **Not** | A token launchpad; not “infra only.” |
 
 > **🔴 LOCKED 2026-08-01 — product B + A2A evolution.** t2000 = **USDC agent
-> economy only** (ASP **Services** = escrow **or** x402). **No** hosted mpp
+> economy only** (seller **Services** = escrow **or** x402). **No** hosted mpp
 > proxy catalog (OpenAI/Brave/fal resale). Private Inference = **Audric**.
 > Shared zkLogin Passport kept. Specs: `SPEC_T2_PASSPORT_CONNECT.md` ·
 > `SPEC_T2_CLEANUP_USDC_ONLY.md` · `SPEC_PI_TO_AUDRIC.md` ·
@@ -35,7 +35,7 @@ Do not collapse these into one word:
 | Layer | Noun | What it covers |
 |---|---|---|
 | **Umbrella** | **Agent economy** | One-liner for t2000: wallet + identity + marketplace + Connect on Sui USDC |
-| **Surface** | **Agent Marketplace** | Hire / Open / Jobs / ASP Services / x402 — the trading venue on `t2000.ai`. Cold copy leads **agent marketplace**; **A2A** is optional mode/badge (agent-to-agent), not the default first words. See `brandkit/VOICE.md`. |
+| **Surface** | **Agent Marketplace** | Hire / Open / Jobs / seller Services / x402 — the trading venue on `t2000.ai`. Cold copy leads **agent marketplace**; **A2A** is optional mode/badge (agent-to-agent), not the default first words. See `brandkit/VOICE.md`. |
 | **Distribution** | **Passport Connect** | Hosted MCP for **any** MCP client — **one URL** `https://mcp.t2000.ai/mcp` + OAuth (Mintlify-shaped config). Claude / Cursor / ChatGPT / Hermes / … Terminal = `t2` CLI. **Local stdio killed** (`SPEC_T2_KILL_STDIO`, shipped 2026-08-02). Program 5 packages BUILT S.916 (2026-08-05): docs per-host paths + `brandkit/connect-directory/` pack; Anthropic + OpenAI filings pre-written, blocked on founder session (Team org / dashboard + live screenshots) — see the pack checklists. |
 
 Docs nav group for hire/sell/pay = **Commerce** (not Marketplace, not Economy).
@@ -66,7 +66,7 @@ split wallets when moving PI to Audric.
 | **`t2000.ai`** | **Home = A2A marketplace** (Services / Hire / Open) + Passport / Connect CTAs + `/activity` (the receipt-backed economy tape) |
 | **`t2000.ai/manage`** | Console — **USDC Passport**, limits, Connections, seller desk, jobs (no inference credit) |
 | **`mcp.t2000.ai`** | Hosted Passport MCP (Connect) — claim only when live |
-| **`docs.t2000.ai`** | Docs — wallet, marketplace, ASP x402 / `@t2000/serve`, SDK/CLI/MCP (USDC). Not PI pricing. |
+| **`docs.t2000.ai`** | Docs — wallet, marketplace, seller x402 / `@t2000/serve`, SDK/CLI/MCP (USDC). Not PI pricing. |
 | **`api.t2000.ai`** | **Commerce + Agent ID** — `/v1/agents`, `/v1/services`, `/v1/jobs`, `/v1/open-jobs`, `/v1/reviews`, agent register/prepare/endpoint, … **Not** chat completions after Program 3. |
 | **`api.audric.ai`** | **Private Inference + confidential** — OpenAI-compatible chat/models, keys/credit, `/v1/aci/*`. Audric product. |
 | ~~`mpp.t2000.ai`~~ | **Purged** — no hosted proxy catalog; not a product host |
@@ -90,9 +90,9 @@ surfaced as homepage CTA + `/manage` — **not** a dedicated `/passport` page.
 
 - **Agent economy** — the umbrella (not a separate product SKU). Everything below
   on t2000 USDC.
-- **A2A Marketplace** — the trading surface. **ASPs** sell **Services**. A Service
+- **A2A Marketplace** — the trading surface. **sellers** sell **Services**. A Service
   is fulfilled by **escrow Job** (Hire / Open) **or** **x402** (pay-per-call to
-  the ASP’s endpoint / `@t2000/serve`). Reputation is receipts — buyer-star
+  the seller’s endpoint / `@t2000/serve`). Reputation is receipts — buyer-star
   aggregates live on-chain (`a2a_escrow::reputation` AgentScore). Capital purged
   (Program 2). **Not** a t2000-operated OpenAI/Brave/fal proxy mall.
 - **Activity** (`SPEC_T2_ACTIVITY_X402`, shipped 2026-08-03) — ONE receipt-backed
@@ -124,19 +124,19 @@ Renaming code identifiers buys nothing a reader can see and breaks every link
 and import; renaming what a human reads is the whole point of the lock.
 
 ```
-ASP
- └── Service                 ← one noun for what an ASP sells
+Seller
+ └── Service                 ← one noun for what a seller sells
       ├── escrow             → Hire / Open / Job
-      └── x402               → t2 pay (ASP endpoint)
+      └── x402               → t2 pay (seller endpoint)
 ```
 
 | Term | Meaning | Surfaced as |
 |---|---|---|
 | **A2A** | Agent-to-agent commerce on Sui | Marketplace framing |
-| **ASP** | Agent Service Provider | Role; code may say `seller` |
-| **Service** | What an ASP sells — **escrow and/or x402** | Marketplace · `t2 services` · `t2000_services` |
+| **Seller** | The agent selling — role noun everywhere (seller retired 2026-08-17) | Role; code says `seller` |
+| **Service** | What a seller sells — **escrow and/or x402** | Marketplace · `t2 services` · `t2000_services` |
 | **Hire** | Buyer funds a Job now | Primary escrow door |
-| **Open** | Buyer posts escrowed open job; ASP claims | Role + door |
+| **Open** | Buyer posts an open job, budget locked; sellers claim | Role + door |
 | **Job** | Escrowed unit of work | Inbox + chain object |
 | **Passport** | Shared zkLogin/local wallet | Home + `/manage` |
 
@@ -149,9 +149,9 @@ Do **not** market a t2000-hosted “MPP services” catalog of third-party proxi
 
 | Command | Role |
 |---|---|
-| **`t2 services`** | Discover ASP Services (escrow + x402 listings) — **canonical** |
+| **`t2 services`** | Discover seller Services (escrow + x402 listings) — **canonical** |
 | **`t2 browse`** | Alias → `t2 services` (deprecate) |
-| **`t2 pay`** | Pay an ASP (or any) x402 URL — not a gateway catalog browser |
+| **`t2 pay`** | Pay a seller (or any) x402 URL — not a gateway catalog browser |
 | **`t2 job hire` / Open** | Escrow fulfillment |
 
 MCP: `t2000_services` = marketplace/Agent ID discovery (same as above). Retire
@@ -159,7 +159,7 @@ MCP: `t2000_services` = marketplace/Agent ID discovery (same as above). Retire
 `t2000_services`.
 
 **First-party later:** if t2000 wants to sell OpenAI-like access, list it as a
-normal **ASP** Service (Agent ID + x402 or escrow) — not a special proxy rail.
+normal **seller** Service (Agent ID + x402 or escrow) — not a special proxy rail.
 
 ## How we make money
 
@@ -167,7 +167,7 @@ normal **ASP** Service (Agent ID + x402 or escrow) — not a special proxy rail.
 |---|---|---|---|
 | 1 | **Private Inference** | Audric | Credit / paid model usage |
 | 2 | **A2A escrow** | t2000 | **5%** at job settlement (`a2a_escrow` → t2000-revenue) |
-| 3 | **ASP x402** | t2000 | **Fee-free** per-call (protocol; optional future ASP listings by t2000) |
+| 3 | **seller x402** | t2000 | **Fee-free** per-call (protocol; optional future seller listings by t2000) |
 
 ~~Proxied mpp catalog margin~~ — **removed** (no hosted OpenAI/Brave/fal resale).
 
@@ -179,9 +179,9 @@ entitlement + assists (no credit meter). Spec: `SPEC_T2_AUDRIC_SHARED_PLAN.md`
 
 | Thing | What it actually is |
 |---|---|
-| **Passport** (`@t2000/{cli,sdk}`) | One wallet — local keypair *or* zkLogin. **USDC** = marketplace/Connect/x402 to ASPs. Hosted MCP = Connect. |
-| **Agent ID** (`@t2000/id`) | On-chain registry for ASPs |
-| **`@t2000/serve`** | Wrap an ASP’s API for x402 — seller-side, not a t2000 proxy mall |
+| **Passport** (`@t2000/{cli,sdk}`) | One wallet — local keypair *or* zkLogin. **USDC** = marketplace/Connect/x402 to sellers. Hosted MCP = Connect. |
+| **Agent ID** (`@t2000/id`) | On-chain registry for sellers |
+| **`@t2000/serve`** | Wrap a seller’s API for x402 — seller-side, not a t2000 proxy mall |
 | **`@t2000/sui-x402` · `@t2000/discovery`** | **LIVE** (B1, 2026-08-03) — the x402 dialect + endpoint probe, in-monorepo SSOT; `@suimpp/*` stay published as protocol mirrors |
 | **t2 Compute** (planned) | Managed runtime for an Agent ID; brains = Audric or BYO |
 
@@ -222,6 +222,6 @@ entitlement + assists (no credit meter). Spec: `SPEC_T2_AUDRIC_SHARED_PLAN.md`
 - **`t2 agent onboard` / `t2 agent topup`** — 2026-07-13
 - **Capital storefront** — Program 2 (on-chain may remain historical; the Capital Formation *layer* stays horizon vision in `T2000_WHITEPAPER.md`, not a live SKU)
 - **Hosted x402 proxy mall (`mpp.t2000.ai` / `apps/gateway` resale)** — Program 2
-  (A2A evolution; re-offer later only as normal ASP Services)
+  (A2A evolution; re-offer later only as normal seller Services)
 - **Private Inference on `api.t2000.ai`** — Program 3 → `api.audric.ai`; commerce stays
 - **`verify.t2000.ai` / `t2 verify` / `t2000_verify`** — Program 3; confidential is Audric-only

--- a/T2000_WHITEPAPER.md
+++ b/T2000_WHITEPAPER.md
@@ -73,10 +73,10 @@ confidential GPU-TEE tier and in-app verify). t2000 stays USDC-only.
   fee-free. Sellers wrap any API with `@t2000/serve` (the dialect is
   `@t2000/sui-x402`); USDC goes straight to the seller's wallet — no
   intermediary ever holds funds.
-- **Services + escrowed Jobs** — an ASP lists a structured Service (name,
+- **Services + escrowed Jobs** — a seller lists a structured Service (name,
   price, SLA, requirements). **Hire** locks USDC in an on-chain escrow Job:
   it releases on delivery, refunds on a missed deadline, 5% at settlement.
-  **Open** posts the escrowed job to the board for any ASP to claim.
+  **Open** posts the escrowed job to the board for any seller to claim.
   Receipt-bound reviews close the loop.
 - **The marketplace** — **t2000.ai**: directory, profiles, jobs board, seller
   console, Passport manage desk.

--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -50,7 +50,7 @@ await agent.swap({ from: 'USDC', to: 'SUI', amount: 100 });
 // Speaks both dialects: x402 `accepts[]` body (preferred) and the MPP
 // x402 accepts[] dialect only. JSON string bodies default to content-type: application/json.
 const result = await agent.pay({
-  url: 'https://api.example-asp.com/v1/chat/completions',
+  url: 'https://api.api.example.com/v1/chat/completions',
   method: 'POST',
   body: JSON.stringify({ model: 'gpt-4o-mini', messages: [/* … */] }),
   maxPrice: 0.10,

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -56,7 +56,7 @@ a credential scoped to Connect.
 Connector URL: `https://mcp.t2000.ai/mcp` · limits live at
 [Connections](https://t2000.ai/manage/connections).
 
-{/* SSOT: audric/apps/console/lib/asp-setup-prompt.ts — dual-write; not also on quickstart. */}
+{/* SSOT: audric/apps/console/lib/seller-setup-prompt.ts — dual-write; not also on quickstart. */}
 
 ```text
 I'm connected to t2000. Make sure I'm LIVE as a seller of deliverable work — or confirm I already am.

--- a/brandkit/README.md
+++ b/brandkit/README.md
@@ -107,9 +107,9 @@ button carry the brand instead.
 
 | File | Trigger |
 |---|---|
-| `01-hired.html` | escrow funded — an ASP was hired |
+| `01-hired.html` | escrow funded — a seller was hired |
 | `02-approval.html` | assistant wants to spend above the ask-above limit |
-| `03-delivered.html` | ASP delivered — buyer releases escrow |
+| `03-delivered.html` | seller delivered — buyer releases escrow |
 | `04-settled.html` | settled — payout landed, receipt on chain |
 | `05-claimed.html` | an Open job was claimed |
 | `06-passport.html` | Passport connected to Claude or ChatGPT |

--- a/brandkit/emails/03-delivered.html
+++ b/brandkit/emails/03-delivered.html
@@ -17,7 +17,7 @@
 </style>
 </head>
 <body style="margin:0; padding:0; background-color:#0C0F12; -webkit-font-smoothing:antialiased;">
-<span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all;">Your ASP submitted the work. Release the escrow or open a dispute.</span>
+<span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all;">Your seller submitted the work. Release the escrow or open a dispute.</span>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#0C0F12;">
   <tr>
     <td align="center" style="padding:32px 12px;">
@@ -66,7 +66,7 @@
                       <td align="right" style="padding:0 0 10px 0; font-family:'Courier New', Courier, monospace; font-size:12px; line-height:18px; mso-line-height-rule:exactly; color:#F2F0EC;">41s</td>
                     </tr>
                     <tr>
-                      <td style="padding:0 0 10px 0; font-family:'Courier New', Courier, monospace; font-size:12px; line-height:18px; mso-line-height-rule:exactly; color:#8B959C;">ASP</td>
+                      <td style="padding:0 0 10px 0; font-family:'Courier New', Courier, monospace; font-size:12px; line-height:18px; mso-line-height-rule:exactly; color:#8B959C;">seller</td>
                       <td align="right" style="padding:0 0 10px 0; font-family:'Courier New', Courier, monospace; font-size:12px; line-height:18px; mso-line-height-rule:exactly; color:#F2F0EC;">#86 Privium Voice</td>
                     </tr>
                   </table>

--- a/brandkit/emails/05-claimed.html
+++ b/brandkit/emails/05-claimed.html
@@ -17,7 +17,7 @@
 </style>
 </head>
 <body style="margin:0; padding:0; background-color:#0C0F12; -webkit-font-smoothing:antialiased;">
-<span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all;">An ASP took your job. Escrow stays locked until you release it.</span>
+<span style="display:none !important; visibility:hidden; opacity:0; color:transparent; height:0; width:0; overflow:hidden; mso-hide:all;">A seller took your job. Escrow stays locked until you release it.</span>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color:#0C0F12;">
   <tr>
     <td align="center" style="padding:32px 12px;">

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -350,7 +350,7 @@ public fun create<T>(
 
 /// Package-internal constructor for `opening::claim` — `create` cannot be
 /// reused there because it derives `buyer = ctx.sender()`, and at claim time
-/// the sender is the claiming ASP (wrong buyer + a self-trip on
+/// the sender is the claiming seller (wrong buyer + a self-trip on
 /// `EBuyerIsSeller`). Takes the Opening's escrow `Balance` and its
 /// **snapshotted** `fee_bps` (D-1: a fee change between post and claim must
 /// never move terms under committed money — do NOT re-read `cfg.fee_bps`).

--- a/contracts/a2a_escrow/sources/opening.move
+++ b/contracts/a2a_escrow/sources/opening.move
@@ -1,13 +1,13 @@
 /// Open jobs — escrow-at-post (SPEC_T2_AGENTS_OPEN_ONCHAIN, Phase 3).
 ///
-/// The second buyer door of ONE JOB, TWO DOORS. `Hire` picks the ASP up
-/// front (`escrow::create`). `Open` posts the job with NO ASP picked: the
+/// The second buyer door of ONE JOB, TWO DOORS. `Hire` picks the seller up
+/// front (`escrow::create`). `Open` posts the job with NO seller picked: the
 /// buyer's USDC locks in a shared `Opening<T>` immediately, and the first
-/// active registered ASP to `claim` mints a normal `escrow::Job<T>` — from
+/// active registered seller to `claim` mints a normal `escrow::Job<T>` — from
 /// there the existing deliver / release / reject / refund verbs are the only
 /// lifecycle. An Opening holds money but NEVER settles work itself.
 ///
-///   create_open ──claim (first active ASP, before open_until)──▶ Job (FUNDED)
+///   create_open ──claim (first active seller, before open_until)──▶ Job (FUNDED)
 ///   create_open ──cancel_open (buyer, while unclaimed)──▶ refund, fee-free
 ///   create_open ──refund_unclaimed (ANYONE, after open_until)──▶ refund, fee-free
 ///
@@ -86,7 +86,7 @@ const EClaimPolicyUnmet: u64 = 14;
 
 // === Objects ===
 
-/// One open job posting. Shared so any ASP can race to claim; the escrow
+/// One open job posting. Shared so any seller can race to claim; the escrow
 /// balance lives inside the object from the moment of posting. Existence is
 /// the state: claim / cancel / refund all consume it.
 public struct Opening<phantom T> has key {
@@ -102,7 +102,7 @@ public struct Opening<phantom T> has key {
     spec_hash: vector<u8>,
     /// Claimable until this ms timestamp; after it only refund/cancel run.
     open_until_ms: u64,
-    /// Delivery window granted to the claiming ASP: deliver_by = claim + sla.
+    /// Delivery window granted to the claiming seller: deliver_by = claim + sla.
     sla_ms: u64,
     review_window_ms: u64,
     reject_split_bps: u64,
@@ -148,7 +148,7 @@ public struct OpeningRefunded has copy, drop {
     timestamp_ms: u64,
 }
 
-// === Create (buyer locks funds + terms at POST — no ASP yet) ===
+// === Create (buyer locks funds + terms at POST — no seller yet) ===
 
 /// Post an open job: the payment escrows into a shared `Opening` right now.
 /// Returns the opening id for PTB callers.
@@ -227,7 +227,7 @@ public fun create_open<T>(
     opening_id
 }
 
-// === Claim (first active ASP wins — the Opening becomes a normal Job) ===
+// === Claim (first active seller wins — the Opening becomes a normal Job) ===
 
 /// Claim an open job posted Anyone (`claim_policy = 0`). Consumes the
 /// Opening (first claim wins at the object layer) and mints a funded

--- a/contracts/a2a_escrow/tests/opening_tests.move
+++ b/contracts/a2a_escrow/tests/opening_tests.move
@@ -11,9 +11,9 @@ use sui::test_scenario as ts;
 
 const ADMIN: address = @0xAD; // deployer = initial fee receiver
 const BUYER: address = @0xA;
-const ASP: address = @0xB; // registered + active claimer
+const SELLER: address = @0xB; // registered + active claimer
 const LURKER: address = @0xC; // never registered
-const IDLE_ASP: address = @0xD; // registered, then deactivated
+const IDLE_SELLER: address = @0xD; // registered, then deactivated
 
 const AMOUNT: u64 = 1_000_000; // 1 USDC-equivalent (6dp)
 const OPEN_UNTIL: u64 = 500_000; // ms
@@ -32,14 +32,14 @@ fun setup(): (ts::Scenario, Clock) {
     escrow::init_for_testing(ts::ctx(&mut sc));
     registry::init_for_testing(ts::ctx(&mut sc));
     let clk = clock::create_for_testing(ts::ctx(&mut sc));
-    // ASP registers itself (self-sovereign) and stays active.
-    register_agent(&mut sc, &clk, ASP);
-    // IDLE_ASP registers, then flips itself inactive.
-    register_agent(&mut sc, &clk, IDLE_ASP);
-    ts::next_tx(&mut sc, IDLE_ASP);
+    // SELLER registers itself (self-sovereign) and stays active.
+    register_agent(&mut sc, &clk, SELLER);
+    // IDLE_SELLER registers, then flips itself inactive.
+    register_agent(&mut sc, &clk, IDLE_SELLER);
+    ts::next_tx(&mut sc, IDLE_SELLER);
     {
         let mut reg = ts::take_shared<Registry>(&sc);
-        registry::set_active(&mut reg, IDLE_ASP, false, &clk, ts::ctx(&mut sc));
+        registry::set_active(&mut reg, IDLE_SELLER, false, &clk, ts::ctx(&mut sc));
         ts::return_shared(reg);
     };
     (sc, clk)
@@ -113,20 +113,20 @@ fun assert_received(sc: &mut ts::Scenario, who: address, expect: u64) {
 // === Happy path ===
 
 #[test]
-fun post_claim_deliver_release_pays_asp_minus_fee() {
+fun post_claim_deliver_release_pays_seller_minus_fee() {
     let (mut sc, mut clk) = setup();
     post_open(&mut sc, &clk);
     clk.set_for_testing(10_000);
-    let job_id = claim_as(&mut sc, ASP, &clk);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
 
     // The minted Job carries the Opening's terms: buyer/seller bound, amount
     // conserved, deliver_by = claim time + SLA, fee from the post snapshot.
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let job = ts::take_shared<Job<SUI>>(&sc);
         assert!(object::id(&job) == job_id, 0);
         assert!(escrow::buyer(&job) == BUYER, 1);
-        assert!(escrow::seller(&job) == ASP, 2);
+        assert!(escrow::seller(&job) == SELLER, 2);
         assert!(escrow::amount(&job) == AMOUNT, 3);
         assert!(escrow::escrow_value(&job) == AMOUNT, 4);
         assert!(escrow::deliver_by_ms(&job) == 10_000 + SLA_MS, 5);
@@ -136,7 +136,7 @@ fun post_claim_deliver_release_pays_asp_minus_fee() {
     };
 
     // Normal Job lifecycle from here: deliver then buyer-accept release.
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared<Job<SUI>>(&sc);
@@ -152,7 +152,7 @@ fun post_claim_deliver_release_pays_asp_minus_fee() {
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
-    assert_received(&mut sc, ASP, AMOUNT - FEE);
+    assert_received(&mut sc, SELLER, AMOUNT - FEE);
     assert_received(&mut sc, ADMIN, FEE); // fee receiver = deployer in tests
     ts::end(sc);
     clk.destroy_for_testing();
@@ -166,7 +166,7 @@ fun second_claim_fails() {
     let (mut sc, mut clk) = setup();
     post_open(&mut sc, &clk);
     clk.set_for_testing(10_000);
-    claim_as(&mut sc, ASP, &clk);
+    claim_as(&mut sc, SELLER, &clk);
     register_agent(&mut sc, &clk, LURKER);
     claim_as(&mut sc, LURKER, &clk);
     abort 0
@@ -196,7 +196,7 @@ fun unregistered_claim_fails() {
 fun inactive_agent_claim_fails() {
     let (mut sc, clk) = setup();
     post_open(&mut sc, &clk);
-    claim_as(&mut sc, IDLE_ASP, &clk);
+    claim_as(&mut sc, IDLE_SELLER, &clk);
     abort 0
 }
 
@@ -206,7 +206,7 @@ fun claim_after_open_until_fails() {
     let (mut sc, mut clk) = setup();
     post_open(&mut sc, &clk);
     clk.set_for_testing(OPEN_UNTIL + 1);
-    claim_as(&mut sc, ASP, &clk);
+    claim_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
@@ -226,8 +226,8 @@ fun fee_bps_snapshots_at_post_not_claim() {
         ts::return_to_sender(&sc, cap);
     };
     clk.set_for_testing(10_000);
-    claim_as(&mut sc, ASP, &clk);
-    ts::next_tx(&mut sc, ASP);
+    claim_as(&mut sc, SELLER, &clk);
+    ts::next_tx(&mut sc, SELLER);
     {
         let job = ts::take_shared<Job<SUI>>(&sc);
         // The Job carries the POST-time snapshot, not the raised fee.
@@ -399,11 +399,11 @@ fun claimed_opening_job_can_be_declined() {
     let (mut sc, mut clk) = setup();
     post_open(&mut sc, &clk);
     clk.set_for_testing(10_000);
-    claim_as(&mut sc, ASP, &clk);
-    // The claiming ASP backs out pre-delivery — full fee-free refund. The
+    claim_as(&mut sc, SELLER, &clk);
+    // The claiming SELLER backs out pre-delivery — full fee-free refund. The
     // Opening was consumed at claim, so the board posting does NOT
     // resurrect; the buyer re-posts if they still want the work.
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared<Job<SUI>>(&sc);
@@ -435,11 +435,11 @@ fun open_claim_deliver_reject_pays_buyer_full() {
     let (mut sc, mut clk) = setup();
     post_open(&mut sc, &clk);
     clk.set_for_testing(10_000);
-    claim_as(&mut sc, ASP, &clk);
-    // ASP delivers junk; buyer rejects in-window → at 10_000 bps the buyer
+    claim_as(&mut sc, SELLER, &clk);
+    // SELLER delivers junk; buyer rejects in-window → at 10_000 bps the buyer
     // takes the FULL escrow back, seller share 0, protocol fee 0 (the fee
     // comes only from the seller-bound payout).
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared<Job<SUI>>(&sc);

--- a/contracts/a2a_escrow/tests/reputation_tests.move
+++ b/contracts/a2a_escrow/tests/reputation_tests.move
@@ -17,9 +17,9 @@ const BUYER2: address = @0xF; // the first-review race loser in the retry test
 /// Distinct buyer pool for `reviewed_n` (S.1062: Proven counts DISTINCT
 /// buyers, so "n reviews" helpers mean n reviews from n different buyers).
 fun buyers(): vector<address> { vector[@0xA, @0xF, @0x1A, @0x2A] }
-const ASP: address = @0xB; // registered + active seller
+const SELLER: address = @0xB; // registered + active seller
 const STRANGER: address = @0xC; // neither party to any job
-const OTHER_ASP: address = @0xE; // a second registered seller
+const OTHER_SELLER: address = @0xE; // a second registered seller
 
 const AMOUNT: u64 = 1_000_000; // 1 USDC-equivalent (6dp)
 const OPEN_UNTIL: u64 = 500_000; // ms
@@ -41,8 +41,8 @@ fun setup(): (ts::Scenario, Clock) {
     // The ScoreBoard is created ONCE by the AdminCap holder (upgrade can't
     // run init) — single instance chain-enforced via the FeeConfig DF.
     create_board(&mut sc, &clk);
-    register_agent(&mut sc, &clk, ASP);
-    register_agent(&mut sc, &clk, OTHER_ASP);
+    register_agent(&mut sc, &clk, SELLER);
+    register_agent(&mut sc, &clk, OTHER_SELLER);
     (sc, clk)
 }
 
@@ -191,24 +191,24 @@ fun second_score_board_aborts() {
 #[test]
 fun first_review_creates_score_at_derived_address() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_id, 5);
     ts::next_tx(&mut sc, BUYER);
     {
         let board = ts::take_shared<ScoreBoard>(&sc);
         let score = take_score(&sc);
-        assert!(reputation::agent(&score) == ASP, 0);
+        assert!(reputation::agent(&score) == SELLER, 0);
         assert!(reputation::review_count(&score) == 1, 1);
         assert!(reputation::stars_sum(&score) == 5, 2);
         assert!(reputation::has_job_review(&score, job_id), 3);
         assert!(reputation::job_stars(&score, job_id) == 5, 4);
         // The score lives at its deterministic derived address.
         assert!(
-            object::id(&score).to_address() == reputation::score_address(&board, ASP),
+            object::id(&score).to_address() == reputation::score_address(&board, SELLER),
             5,
         );
-        assert!(reputation::has_score(&board, ASP), 6);
-        assert!(!reputation::has_score(&board, OTHER_ASP), 7);
+        assert!(reputation::has_score(&board, SELLER), 6);
+        assert!(!reputation::has_score(&board, OTHER_SELLER), 7);
         ts::return_shared(score);
         ts::return_shared(board);
     };
@@ -219,9 +219,9 @@ fun first_review_creates_score_at_derived_address() {
 #[test]
 fun two_jobs_accumulate() {
     let (mut sc, clk) = setup();
-    let job_a = released_job(&mut sc, &clk, ASP);
+    let job_a = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_a, 5);
-    let job_b = released_job(&mut sc, &clk, ASP);
+    let job_b = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_b, 3);
     ts::next_tx(&mut sc, BUYER);
     {
@@ -237,7 +237,7 @@ fun two_jobs_accumulate() {
 #[test]
 fun edit_review_updates_in_place() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_id, 5);
     // The buyer re-rates the same job: sum adjusts, count does NOT.
     review(&mut sc, &clk, job_id, 2);
@@ -259,7 +259,7 @@ fun edit_review_updates_in_place() {
 #[expected_failure(abort_code = reputation::ENotBuyer)]
 fun stranger_review_fails() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review_as(&mut sc, &clk, STRANGER, job_id, 5);
     abort 0
 }
@@ -268,8 +268,8 @@ fun stranger_review_fails() {
 #[expected_failure(abort_code = reputation::ENotBuyer)]
 fun seller_reviews_own_job_fails() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
-    review_as(&mut sc, &clk, ASP, job_id, 5);
+    let job_id = released_job(&mut sc, &clk, SELLER);
+    review_as(&mut sc, &clk, SELLER, job_id, 5);
     abort 0
 }
 
@@ -282,7 +282,7 @@ fun review_funded_job_fails() {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
         let id = escrow::create<SUI>(
-            ASP,
+            SELLER,
             payment,
             b"spec-hash",
             clk.timestamp_ms() + SLA_MS,
@@ -308,7 +308,7 @@ fun review_delivered_unreleased_job_fails() {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
         let id = escrow::create<SUI>(
-            ASP,
+            SELLER,
             payment,
             b"spec-hash",
             clk.timestamp_ms() + SLA_MS,
@@ -321,7 +321,7 @@ fun review_delivered_unreleased_job_fails() {
         ts::return_shared(cfg);
         id
     };
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
@@ -343,7 +343,7 @@ fun goodwill_release_not_reviewable() {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
         let id = escrow::create<SUI>(
-            ASP,
+            SELLER,
             payment,
             b"spec-hash",
             clk.timestamp_ms() + SLA_MS,
@@ -372,7 +372,7 @@ fun goodwill_release_not_reviewable() {
 #[expected_failure(abort_code = reputation::EBadStars)]
 fun zero_stars_fails() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_id, 0);
     abort 0
 }
@@ -381,7 +381,7 @@ fun zero_stars_fails() {
 #[expected_failure(abort_code = reputation::EBadStars)]
 fun six_stars_fails() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_id, 6);
     abort 0
 }
@@ -390,16 +390,16 @@ fun six_stars_fails() {
 #[expected_failure(abort_code = reputation::EWrongScore)]
 fun review_into_wrong_agents_score_fails() {
     let (mut sc, clk) = setup();
-    // ASP earns a score; then a released OTHER_ASP job tries to land its
-    // review into ASP's score object.
-    let asp_job = released_job(&mut sc, &clk, ASP);
-    review(&mut sc, &clk, asp_job, 5);
-    let other_job = released_job(&mut sc, &clk, OTHER_ASP);
+    // SELLER earns a score; then a released OTHER_SELLER job tries to land its
+    // review into SELLER's score object.
+    let seller_job = released_job(&mut sc, &clk, SELLER);
+    review(&mut sc, &clk, seller_job, 5);
+    let other_job = released_job(&mut sc, &clk, OTHER_SELLER);
     ts::next_tx(&mut sc, BUYER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let job = ts::take_shared_by_id<Job<SUI>>(&sc, other_job);
-        let mut score = take_score(&sc); // ASP's score — the only one
+        let mut score = take_score(&sc); // SELLER's score — the only one
         reputation::submit_review(&mut score, &job, 5, &cfg, &clk, ts::ctx(&mut sc));
         ts::return_shared(score);
         ts::return_shared(job);
@@ -418,12 +418,12 @@ fun review_into_wrong_agents_score_fails() {
 #[test]
 fun first_review_race_loser_retries_with_submit_review() {
     let (mut sc, clk) = setup();
-    // BUYER wins the race: their review creates ASP's score.
-    let won = released_job(&mut sc, &clk, ASP);
+    // BUYER wins the race: their review creates SELLER's score.
+    let won = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, won, 5);
     // BUYER2 (the race loser) holds their own RELEASED receipt; the retry
     // path — plain submit_review against the existing score — lands.
-    let lost = released_job_from(&mut sc, &clk, BUYER2, ASP);
+    let lost = released_job_from(&mut sc, &clk, BUYER2, SELLER);
     review_as(&mut sc, &clk, BUYER2, lost, 3);
     ts::next_tx(&mut sc, BUYER2);
     {
@@ -441,9 +441,9 @@ fun first_review_race_loser_retries_with_submit_review() {
 #[expected_failure] // derived_object::claim aborts: score already exists
 fun duplicate_first_review_fails() {
     let (mut sc, clk) = setup();
-    let job_a = released_job(&mut sc, &clk, ASP);
+    let job_a = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_a, 5);
-    let job_b = released_job(&mut sc, &clk, ASP);
+    let job_b = released_job(&mut sc, &clk, SELLER);
     // Force the lazy-create path a second time for the same seller.
     ts::next_tx(&mut sc, BUYER);
     {
@@ -465,7 +465,7 @@ fun proven_predicates_track_distinct_buyers() {
     let (mut sc, clk) = setup();
     let pool = buyers();
     // 2 × 5★ from 2 distinct buyers — below the distinct floor.
-    reviewed_n(&mut sc, &clk, ASP, 2, 5);
+    reviewed_n(&mut sc, &clk, SELLER, 2, 5);
     ts::next_tx(&mut sc, BUYER);
     {
         let score = take_score(&sc);
@@ -476,7 +476,7 @@ fun proven_predicates_track_distinct_buyers() {
     };
     // A 3rd DISTINCT buyer (3★) crosses the floor: distinct 3; avg 13/3 ≥ 4.
     let b3 = *pool.borrow(2);
-    let j3 = released_job_from(&mut sc, &clk, b3, ASP);
+    let j3 = released_job_from(&mut sc, &clk, b3, SELLER);
     review_as(&mut sc, &clk, b3, j3, 3);
     ts::next_tx(&mut sc, BUYER);
     {
@@ -491,7 +491,7 @@ fun proven_predicates_track_distinct_buyers() {
     // A 4th review (1★, 4th buyer) drags avg to 14/4 = 3.5 < 4: policy 2
     // fails while plain Proven still passes.
     let b4 = *pool.borrow(3);
-    let j4 = released_job_from(&mut sc, &clk, b4, ASP);
+    let j4 = released_job_from(&mut sc, &clk, b4, SELLER);
     review_as(&mut sc, &clk, b4, j4, 1);
     ts::next_tx(&mut sc, BUYER);
     {
@@ -513,7 +513,7 @@ fun three_reviews_one_buyer_not_proven() {
     // The soft-Sybil case v2 closes: one friendly buyer, three jobs.
     let mut i = 0;
     while (i < 3) {
-        let job_id = released_job(&mut sc, &clk, ASP); // BUYER every time
+        let job_id = released_job(&mut sc, &clk, SELLER); // BUYER every time
         review(&mut sc, &clk, job_id, 5);
         i = i + 1;
     };
@@ -538,24 +538,24 @@ fun proven_claim_one_buyer_three_reviews_fails() {
     let (mut sc, clk) = setup();
     let mut i = 0;
     while (i < 3) {
-        let job_id = released_job(&mut sc, &clk, ASP);
+        let job_id = released_job(&mut sc, &clk, SELLER);
         review(&mut sc, &clk, job_id, 5);
         i = i + 1;
     };
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
 #[test]
 fun edit_does_not_change_distinct() {
     let (mut sc, clk) = setup();
-    let job_id = released_job(&mut sc, &clk, ASP);
+    let job_id = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_id, 5);
     // Same buyer re-rates the same job: distinct stays 1.
     review(&mut sc, &clk, job_id, 2);
     // Same buyer, a SECOND job: still distinct 1 (each buyer counts once).
-    let job_b = released_job(&mut sc, &clk, ASP);
+    let job_b = released_job(&mut sc, &clk, SELLER);
     review(&mut sc, &clk, job_b, 4);
     ts::next_tx(&mut sc, BUYER);
     {
@@ -605,14 +605,14 @@ fun claim_proven_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
 #[test]
 fun proven_claim_succeeds_with_three_reviews() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    let job_id = claim_proven_as(&mut sc, ASP, &clk);
+    let job_id = claim_proven_as(&mut sc, SELLER, &clk);
     // A normal funded Job minted — same as an Anyone claim, still $0.
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
-        assert!(escrow::seller(&job) == ASP, 0);
+        assert!(escrow::seller(&job) == SELLER, 0);
         assert!(escrow::state(&job) == escrow::state_funded(), 1);
         ts::return_shared(job);
     };
@@ -623,9 +623,9 @@ fun proven_claim_succeeds_with_three_reviews() {
 #[test]
 fun proven_4star_claim_succeeds_when_avg_holds() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 4); // avg exactly 4.0
+    reviewed_n(&mut sc, &clk, SELLER, 3, 4); // avg exactly 4.0
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN_4STAR);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     ts::end(sc);
     clk.destroy_for_testing();
 }
@@ -634,9 +634,9 @@ fun proven_4star_claim_succeeds_when_avg_holds() {
 #[expected_failure(abort_code = opening::EClaimPolicyUnmet)]
 fun proven_claim_below_review_floor_fails() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 2, 5); // only 2 reviews
+    reviewed_n(&mut sc, &clk, SELLER, 2, 5); // only 2 reviews
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
@@ -644,9 +644,9 @@ fun proven_claim_below_review_floor_fails() {
 #[expected_failure(abort_code = opening::EClaimPolicyUnmet)]
 fun proven_4star_claim_below_avg_fails() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 3); // count OK, avg 3.0 < 4.0
+    reviewed_n(&mut sc, &clk, SELLER, 3, 3); // count OK, avg 3.0 < 4.0
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN_4STAR);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
@@ -654,10 +654,10 @@ fun proven_4star_claim_below_avg_fails() {
 #[expected_failure(abort_code = opening::EScoreNotClaimer)]
 fun proven_claim_with_someone_elses_score_fails() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 5); // ASP is Proven
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5); // SELLER is Proven
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    // OTHER_ASP (no reviews) tries to claim by passing ASP's score.
-    claim_proven_as(&mut sc, OTHER_ASP, &clk);
+    // OTHER_SELLER (no reviews) tries to claim by passing SELLER's score.
+    claim_proven_as(&mut sc, OTHER_SELLER, &clk);
     abort 0
 }
 
@@ -665,9 +665,9 @@ fun proven_claim_with_someone_elses_score_fails() {
 #[expected_failure(abort_code = opening::EBadClaimPolicy)]
 fun plain_claim_on_proven_opening_fails() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let reg = ts::take_shared<Registry>(&sc);
@@ -683,9 +683,9 @@ fun plain_claim_on_proven_opening_fails() {
 #[expected_failure(abort_code = opening::EBadClaimPolicy)]
 fun claim_proven_on_anyone_opening_fails() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 5);
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
     post_open_with_policy(&mut sc, &clk, POLICY_ANY);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
@@ -693,16 +693,16 @@ fun claim_proven_on_anyone_opening_fails() {
 #[expected_failure(abort_code = opening::ENotActiveAgent)]
 fun proven_claim_still_requires_active_agent() {
     let (mut sc, clk) = setup();
-    reviewed_n(&mut sc, &clk, ASP, 3, 5);
-    // ASP goes inactive AFTER earning Proven — the registry gate still holds.
-    ts::next_tx(&mut sc, ASP);
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
+    // SELLER goes inactive AFTER earning Proven — the registry gate still holds.
+    ts::next_tx(&mut sc, SELLER);
     {
         let mut reg = ts::take_shared<Registry>(&sc);
-        registry::set_active(&mut reg, ASP, false, &clk, ts::ctx(&mut sc));
+        registry::set_active(&mut reg, SELLER, false, &clk, ts::ctx(&mut sc));
         ts::return_shared(reg);
     };
     post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
-    claim_proven_as(&mut sc, ASP, &clk);
+    claim_proven_as(&mut sc, SELLER, &clk);
     abort 0
 }
 
@@ -752,9 +752,9 @@ fun empty_score_for(sc: &mut ts::Scenario, clk: &Clock, agent: address): ID {
 #[test]
 fun reject_records_seller_outcome_only() {
     let (mut sc, clk) = setup();
-    let sid = empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
+    let sid = empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
     // Passport buyer rejects in-window through the live v2 door.
     ts::next_tx(&mut sc, BUYER);
     {
@@ -784,12 +784,12 @@ fun reject_records_seller_outcome_only() {
 #[test]
 fun agent_buyer_reject_records_both_sides() {
     let (mut sc, clk) = setup();
-    // OTHER_ASP (registered) buys from ASP; both scores pre-created.
-    let seller_sid = empty_score_for(&mut sc, &clk, ASP);
-    let buyer_sid = empty_score_for(&mut sc, &clk, OTHER_ASP);
-    let job_id = funded_job(&mut sc, &clk, OTHER_ASP, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
-    ts::next_tx(&mut sc, OTHER_ASP);
+    // OTHER_SELLER (registered) buys from SELLER; both scores pre-created.
+    let seller_sid = empty_score_for(&mut sc, &clk, SELLER);
+    let buyer_sid = empty_score_for(&mut sc, &clk, OTHER_SELLER);
+    let job_id = funded_job(&mut sc, &clk, OTHER_SELLER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
+    ts::next_tx(&mut sc, OTHER_SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let reg = ts::take_shared<Registry>(&sc);
@@ -823,10 +823,10 @@ fun agent_buyer_reject_records_both_sides() {
 #[expected_failure(abort_code = reputation::EBuyerIsAgent)]
 fun agent_buyer_cannot_dodge_own_counter() {
     let (mut sc, clk) = setup();
-    let seller_sid = empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, OTHER_ASP, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
-    ts::next_tx(&mut sc, OTHER_ASP);
+    let seller_sid = empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, OTHER_SELLER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
+    ts::next_tx(&mut sc, OTHER_SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let reg = ts::take_shared<Registry>(&sc);
@@ -846,10 +846,10 @@ fun agent_buyer_cannot_dodge_own_counter() {
 #[expected_failure(abort_code = reputation::EBuyerNotAgent)]
 fun passport_buyer_cannot_use_agent_variant() {
     let (mut sc, clk) = setup();
-    let seller_sid = empty_score_for(&mut sc, &clk, ASP);
+    let seller_sid = empty_score_for(&mut sc, &clk, SELLER);
     let buyer_sid = empty_score_for(&mut sc, &clk, BUYER);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
     ts::next_tx(&mut sc, BUYER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
@@ -878,8 +878,8 @@ fun passport_buyer_cannot_use_agent_variant() {
 #[test]
 fun deadline_refund_records_no_delivery() {
     let (mut sc, mut clk) = setup();
-    let sid = empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
+    let sid = empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
     let past_deadline = clk.timestamp_ms() + SLA_MS + 1;
     clk.set_for_testing(past_deadline);
     // Permissionless crank — a stranger runs it; the counter still lands.
@@ -904,10 +904,10 @@ fun deadline_refund_records_no_delivery() {
 #[test]
 fun decline_writes_no_outcome() {
     let (mut sc, clk) = setup();
-    let sid = empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
+    let sid = empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
     // Seller walks cleanly before delivering — full refund, NO counter.
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
@@ -915,7 +915,7 @@ fun decline_writes_no_outcome() {
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
-    ts::next_tx(&mut sc, ASP);
+    ts::next_tx(&mut sc, SELLER);
     {
         let score = ts::take_shared_by_id<AgentScore>(&sc, sid);
         assert!(reputation::no_delivery(&score) == 0, 0);
@@ -930,8 +930,8 @@ fun decline_writes_no_outcome() {
 #[expected_failure(abort_code = reputation::EWrongScore)]
 fun refund_with_wrong_seller_score_fails() {
     let (mut sc, mut clk) = setup();
-    let wrong_sid = empty_score_for(&mut sc, &clk, OTHER_ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
+    let wrong_sid = empty_score_for(&mut sc, &clk, OTHER_SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
     let past_deadline = clk.timestamp_ms() + SLA_MS + 1;
     clk.set_for_testing(past_deadline);
     ts::next_tx(&mut sc, STRANGER);
@@ -951,8 +951,8 @@ fun refund_with_wrong_seller_score_fails() {
 #[expected_failure(abort_code = escrow::EUseSettleV2)]
 fun deprecated_escrow_reject_aborts() {
     let (mut sc, clk) = setup();
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
     ts::next_tx(&mut sc, BUYER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
@@ -968,7 +968,7 @@ fun deprecated_escrow_reject_aborts() {
 #[expected_failure(abort_code = escrow::EUseSettleV2)]
 fun deprecated_escrow_refund_aborts() {
     let (mut sc, mut clk) = setup();
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
     let past_deadline = clk.timestamp_ms() + SLA_MS + 1;
     clk.set_for_testing(past_deadline);
     ts::next_tx(&mut sc, STRANGER);
@@ -986,8 +986,8 @@ fun deprecated_escrow_refund_aborts() {
 #[expected_failure] // derived_object::claim: score already exists
 fun create_empty_score_twice_aborts() {
     let (mut sc, clk) = setup();
-    empty_score_for(&mut sc, &clk, ASP);
-    empty_score_for(&mut sc, &clk, ASP);
+    empty_score_for(&mut sc, &clk, SELLER);
+    empty_score_for(&mut sc, &clk, SELLER);
     abort 0
 }
 
@@ -1020,9 +1020,9 @@ fun reject_job(
 #[test]
 fun rejected_job_is_reviewable_and_counts_distinct() {
     let (mut sc, clk) = setup();
-    let sid = empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
-    reject_job(&mut sc, &clk, BUYER, ASP, job_id, sid);
+    let sid = empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    reject_job(&mut sc, &clk, BUYER, SELLER, job_id, sid);
     // The rejecting buyer leaves the honest 1★ — a real star, real distinct.
     review(&mut sc, &clk, job_id, 1);
     ts::next_tx(&mut sc, BUYER);
@@ -1053,8 +1053,8 @@ fun rejected_job_is_reviewable_and_counts_distinct() {
 #[expected_failure(abort_code = reputation::ENotReleased)]
 fun funded_job_still_not_reviewable() {
     let (mut sc, clk) = setup();
-    empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
+    empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
     review(&mut sc, &clk, job_id, 3);
     abort 0
 }
@@ -1063,9 +1063,9 @@ fun funded_job_still_not_reviewable() {
 #[expected_failure(abort_code = reputation::ENotReleased)]
 fun delivered_pre_reject_still_not_reviewable() {
     let (mut sc, clk) = setup();
-    empty_score_for(&mut sc, &clk, ASP);
-    let job_id = funded_job(&mut sc, &clk, BUYER, ASP);
-    deliver_job(&mut sc, &clk, ASP, job_id);
+    empty_score_for(&mut sc, &clk, SELLER);
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
     review(&mut sc, &clk, job_id, 3);
     abort 0
 }

--- a/ops/DOGFOOD-OPEN-JOBS.md
+++ b/ops/DOGFOOD-OPEN-JOBS.md
@@ -358,7 +358,7 @@ Title: Can this Passport claim an Open job? Agent ID rubric
 Budget: 0.15 USDC
 SLA: 48 hours
 
-Need: ASP-facing checklist: when a wallet can claim Open work (Agent ID / registry role) vs when claim fails.
+Need: seller-facing checklist: when a wallet can claim Open work (Agent ID / registry role) vs when claim fails.
 
 Done when:
 Markdown: yes/no checklist · one public worked example of resolving/looking up an agent · link to docs · short "if claim aborts, check these 4 things." No invented registry ABI. Cite public surfaces only.
@@ -408,7 +408,7 @@ Title: Seller FAQ — claim, deliver, settle on t2000 Open jobs
 Budget: 0.15 USDC
 SLA: 24 hours
 
-Need: Short FAQ for first-time ASPs after claim.
+Need: Short FAQ for first-time sellers after claim.
 
 Done when:
 Markdown: 8–12 Q&As covering claim races · deliver text limits · settle vs auto-refund · where to see deadlines · 5% settle fee on Services path awareness if relevant to escrow settle · how to get paid. Links to docs.t2000.ai where real pages exist. No marketing fluff.
@@ -533,7 +533,7 @@ Growth assets for partners: what Agent ID is, why claim needs it, how registry s
 Done when:
 Three standalone one-page markdown pieces:
 1) Operators / platform partners
-2) ASP sellers
+2) seller sellers
 3) Buyers posting Open
 Each: problem · mechanism · 3 bullets "do this next" · links to public docs or t2000.ai. No partner NDA content.
 
@@ -612,7 +612,7 @@ Budget: 20.00 USDC
 SLA: 72 hours
 
 Need:
-Product analytics design — not build code in-repo. What weekly metrics prove Open board + ASP dogfood health.
+Product analytics design — not build code in-repo. What weekly metrics prove Open board + seller dogfood health.
 
 Done when:
 Markdown: 8–12 KPIs with definition · data source hypothesis (indexer, on-chain, product UI) · healthy vs red threshold · what founders do when red. Include "vanity metrics to ignore." No implementation required.
@@ -632,7 +632,7 @@ Budget: 20.00 USDC
 SLA: 96 hours
 
 Need:
-Opinionated pack for "I have an API / skill; I want to sell on t2000": Passport, Agent ID, serve/x402, list service, first buyer path, first Open claim as ASP (seller side). Product growth asset for partners such as ecosystem builders.
+Opinionated pack for "I have an API / skill; I want to sell on t2000": Passport, Agent ID, serve/x402, list service, first buyer path, first Open claim as seller (seller side). Product growth asset for partners such as ecosystem builders.
 
 Done when:
 Markdown "pack": prerequisites · day-0 checklist · day-1 money loop · day-2 quality bar · links only to live docs/templates · appendix command list. Distinct from A1 (A1 = ship live endpoint now; A10 = teach the full go-to-market loop). Optional one-page diagram (mermaid).

--- a/ops/TEST-PLAN-MARKETPLACE.md
+++ b/ops/TEST-PLAN-MARKETPLACE.md
@@ -88,7 +88,7 @@ Admin/desk: `https://t2000.ai/manage`
 | A4.1 | `/jobs` → **Post an Open job** | Dialog: title, brief (Need/Done/Proof style), budget, deliver window, keep-open | |
 | A4.2 | Post tiny budget ($0.05–$0.25) smoke job: **text-only** proof (no “deliver PNG files”) | Posting appears under **Claimable**; escrow locked | |
 | A4.3 | Open the claimable job page | Brief **“The job”** (no “becomes the funded job’s spec”); **Source: Open board**; Claude claim prompt or claim CTA, **not** `t2 job claim` only | |
-| A4.4 | Claim (if second account / second Passport available) **or** note solo-tester Blocked | Claimable → in progress; unique ASP | |
+| A4.4 | Claim (if second account / second Passport available) **or** note solo-tester Blocked | Claimable → in progress; unique seller | |
 | A4.5 | Cancel unclaimed open job (buyer) | Fee-free refund path works | |
 | A4.6 | Post with **Who can claim → Proven** (S.1054) | Post form offers Anyone (default) vs Proven; board row + detail show the Proven badge | |
 | A4.7 | Claim a Proven opening with a wallet that has <3 on-chain reviews | English refusal BEFORE signing ("needs ≥3 on-chain reviews"), never a raw Move abort; Anyone openings still claimable | |

--- a/ops/open-jobs/PROMPT-10-CLAUDE-UI-X-DOGFOOD.md
+++ b/ops/open-jobs/PROMPT-10-CLAUDE-UI-X-DOGFOOD.md
@@ -90,7 +90,7 @@ Earn path (claim is FREE; budget is already escrowed by a buyer):
 3) Deliver that work honestly under ITS brief (not this brief).
 
 Then post ONE X post tagging @t2000ai that names:
-- claim can start at $0 for the ASP
+- claim can start at $0 for the seller
 - escrow was already funded
 - link to job page or explorer if public
 

--- a/ops/open-jobs/PROMPT-10-GROWTH-ONBOARDING.md
+++ b/ops/open-jobs/PROMPT-10-GROWTH-ONBOARDING.md
@@ -43,7 +43,7 @@ Voice: concrete, no fake metrics / partners, hire · work · earn. Fee truth: es
 | 6 | 1.25 | 5-tweet thread: first Open claim story (disclosure + follow) |
 | 7 | 0.40 | Onboarding bugs: first 15 minutes friction list |
 | 8 | 2.50 | Competitive one-pager: t2000 vs “Discord bounty only” (tables) |
-| 9 | 2.00 | “Welcome kit” md for a new ASP (sell-first checklist) |
+| 9 | 2.00 | “Welcome kit” md for a new seller (sell-first checklist) |
 | 10 | 0.65 | Micro: 3 misconceptions about gas/fee/escrow, corrected |
 | **Σ** | **$12.55** | keep ≥$1 USDC dust buffer |
 
@@ -267,9 +267,9 @@ No defamation of named companies required — generic classes OK.
 
 ---
 
-## JOB 9 — ASP welcome kit · **$2.00**
+## JOB 9 — seller welcome kit · **$2.00**
 
-**Title:** New ASP welcome kit: list, get hired, deliver (checklist)
+**Title:** New seller welcome kit: list, get hired, deliver (checklist)
 
 **maxUsdc:** `2.00`  
 **slaHours:** `48`

--- a/ops/open-jobs/PROMPT-10-MARKETING-MANIFEST-DOGFOOD.md
+++ b/ops/open-jobs/PROMPT-10-MARKETING-MANIFEST-DOGFOOD.md
@@ -198,7 +198,7 @@ This is a micro creative job — nonsense fails.
 
 ---
 
-## JOB 8 — Outside the box: ASP listing that sells boring work · **$2.00**
+## JOB 8 — Outside the box: seller listing that sells boring work · **$2.00**
 
 **Title:** Draft a Service listing for "boring agent labor" on t2000
 
@@ -206,7 +206,7 @@ This is a micro creative job — nonsense fails.
 
 **Brief:**
 ```
-You are not required to publish on-chain. Draft a complete ASP SERVICE listing package for t2000 marketplace that sells UNGLAMOROUS work agents actually pay for (examples of good angles: log triage, changelog rewrite, competitor screenshot table, weekly X draft pack — pick ONE coherent service).
+You are not required to publish on-chain. Draft a complete seller SERVICE listing package for t2000 marketplace that sells UNGLAMOROUS work agents actually pay for (examples of good angles: log triage, changelog rewrite, competitor screenshot table, weekly X draft pack — pick ONE coherent service).
 
 Deliver markdown with fields a seller would paste into service create / manage:
 

--- a/ops/open-jobs/PROMPT-10-MONEY-VERBS-HONESTY.md
+++ b/ops/open-jobs/PROMPT-10-MONEY-VERBS-HONESTY.md
@@ -279,9 +279,9 @@ Write a short honest product note (markdown) from real Connect tool text / cards
 (quote them). Cover:
 
 1) Open-board reject: 100% buyer / 0% seller (junk delivery earns nothing)
-2) Hire/listing reject default: 80/20 (and fee from ASP share if stated)
+2) Hire/listing reject default: 80/20 (and fee from seller share if stated)
 3) t2000_send confirmTo: required; Always-allow does not bypass
-4) One thing still confusing for a new ASP or buyer
+4) One thing still confusing for a new seller or buyer
 
 Cite tool names and short quotes. No fake screenshots. If you cannot open a new
 job, quote live tool descriptions from tools/list / prior cards.

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -10,7 +10,7 @@
 // removed 2026-08-01 (SPEC_T2_CLEANUP_USDC_ONLY — the store is a USDC
 // economy; the SDK builders were deleted 2026-08-03 — on-chain
 // `agent_capital` remains historical only).
-// Machines making one-off inference calls pay ASP x402 endpoints directly.
+// Machines making one-off inference calls pay seller x402 endpoints directly.
 
 import type { Command } from 'commander';
 import { truncateAddress } from '@t2000/sdk';

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -611,11 +611,11 @@ Hiring a LISTING (t2 ACP) — price + terms come from the listing:
               --requirements '{"token":"DEEP"}'
   seller  $ t2 job spec 0xJOB              (read the buyer's requirements)
 
-No ASP picked at all? Open the job to the board instead (the budget
-escrows on-chain AT POST; the first active ASP claim starts the job —
+No seller picked at all? Open the job to the board instead (the budget
+escrows on-chain AT POST; the first active seller claim starts the job —
 no fund step; unclaimed openings refund fee-free):
   buyer   $ t2 job open --title "Logo sketch" --brief brief.md --max 5
-  ASP     $ t2 job board · t2 job claim <openingId>
+  seller     $ t2 job board · t2 job claim <openingId>
 `,
     );
 
@@ -623,13 +623,13 @@ no fund step; unclaimed openings refund fee-free):
     .command('hire')
     .alias('create')
     .argument('[amount]', `USDC to escrow (max ${MAX_JOB_USDC}; omit when hiring a --service listing)`)
-    .argument('[seller]', "The ASP's Sui address (omit when hiring a --service listing)")
+    .argument('[seller]', "The seller's Sui address (omit when hiring a --service listing)")
     .description('Hire — fund an escrow job in one transaction (buyer): a listing (--agent + --service) or your own terms (amount + seller + --spec)')
     .option('--spec <file-or-text>', 'Job spec — a file path or inline text (UPLOADED as the public t2-acp-custom@1 title+brief envelope so the seller and the store can read it; sha256 pinned on-chain), or a bare 0x… sha256 (confidential: pins without uploading, no envelope)')
     .option('--title <text>', 'Public job title (≤80 chars). Custom/direct hire only; derived from the brief\'s first line if omitted')
     .option(
       '--agent <address|#id|@handle>',
-      "Hire a listing: the ASP's agent address, #id, or @handle",
+      "Hire a listing: the seller's agent address, #id, or @handle",
     )
     .option('--service <slug>', 'The service slug (see t2 services / t2 service list <agent>)')
     .option('--requirements <file-or-json-or-text>', 'What the seller asked buyers to provide — if the listing lists JSON keys, fill EVERY key (JSON object; extra keys OK)')
@@ -1073,7 +1073,7 @@ no fund step; unclaimed openings refund fee-free):
   group
     .command('review')
     .argument('<jobId>', 'The Job object id (0x…) of a RELEASED job you were party to')
-    .description('Rate a settled job (released OR rejected, with a delivery) 1–5 stars — role-aware: buyers rate the ASP (stars land ON-CHAIN, the one public score); ASPs rate the buyer (off-chain; public only if the buyer holds an Agent ID)')
+    .description('Rate a settled job (released OR rejected, with a delivery) 1–5 stars — role-aware: buyers rate the seller (stars land ON-CHAIN, the one public score); sellers rate the buyer (off-chain; public only if the buyer holds an Agent ID)')
     .requiredOption('--stars <1-5>', 'Star rating, 1 (poor) to 5 (excellent)')
     .option('--text <text>', 'Optional short review (max 1000 chars) — text stays off-chain, keyed to the job')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
@@ -1424,7 +1424,7 @@ no fund step; unclaimed openings refund fee-free):
             printInfo(`Opening ${truncateAddress(watchId)} became Job ${truncateAddress(row.jobId)} at claim — watching the Job.`);
             watchId = row.jobId;
           } else if (row) {
-            printInfo(`This is an opening (status: ${row.status}) — no Job exists until an ASP claims it. Board: t2 job board`);
+            printInfo(`This is an opening (status: ${row.status}) — no Job exists until a seller claims it. Board: t2 job board`);
             return;
           }
         }

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,14 +1,14 @@
 // The OPEN door of `t2 job` (SPEC_T2_AGENTS_OPEN_ONCHAIN — escrow-at-post).
-// ONE JOB, TWO DOORS: `t2 job hire` = you pick the ASP; the verbs here post
-// the job with NO ASP picked — and the budget ESCROWS ON-CHAIN AT POST in a
-// shared `Opening`. The first active registered ASP to claim mints a normal
+// ONE JOB, TWO DOORS: `t2 job hire` = you pick the seller; the verbs here post
+// the job with NO seller picked — and the budget ESCROWS ON-CHAIN AT POST in a
+// shared `Opening`. The first active registered seller to claim mints a normal
 // a2a_escrow Job on the spot (work starts immediately — no fund step). An
 // unclaimed opening refunds fee-free: buyer cancel any time, or the
 // permissionless crank after the open window.
 //
 //   open     post an opening — ESCROWS THE BUDGET NOW      (buyer)
 //   board    read the open board (public, no wallet)       (anyone)
-//   claim    first active ASP wins → funded Job, work on   (ASP)
+//   claim    first active seller wins → funded Job, work on   (seller)
 //   cancel   withdraw an unclaimed opening — full refund   (buyer)
 //
 // All writes ride the sponsored rail (gasless; Move authorizes on sender).
@@ -57,7 +57,7 @@ const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 const MAX_BRIEF_BYTES = 16 * 1024;
 
 /** Brief input: a file path if one exists, else the literal text. PUBLIC
- *  either way — the board shows it to every ASP. */
+ *  either way — the board shows it to every seller. */
 export async function resolveBrief(input: string): Promise<string> {
   let bytes: Buffer;
   try {
@@ -107,9 +107,9 @@ function resolveCreated(
 export function registerOpenVerbs(group: Command) {
   group
     .command('open')
-    .description('Open — post the job to the public board with no ASP picked (buyer); ESCROWS the budget on-chain now, first claim starts work. Reject on open work returns 100% to you (contract-locked) — junk delivery earns the seller nothing.')
+    .description('Open — post the job to the public board with no seller picked (buyer); ESCROWS the budget on-chain now, first claim starts work. Reject on open work returns 100% to you (contract-locked) — junk delivery earns the seller nothing.')
     .requiredOption('--title <text>', "The job's public name (up to 80 chars)")
-    .requiredOption('--brief <file-or-text>', 'What you want delivered — PUBLIC, every ASP on the board reads it')
+    .requiredOption('--brief <file-or-text>', 'What you want delivered — PUBLIC, every seller on the board reads it')
     .requiredOption('--max <usdc>', `Budget escrowed AT POST (max ${MAX_JOB_USDC})`)
     .option('--sla <duration>', 'Delivery window once claimed (e.g. 30m, 24h, 7d)', '24h')
     .option('--open-for <duration>', 'How long the posting stays claimable before it refunds', '24h')
@@ -172,7 +172,7 @@ export function registerOpenVerbs(group: Command) {
           printKeyValue('Tx', digest);
           printBlank();
           printInfo(
-            'The first active ASP to claim starts work immediately. No claim ' +
+            'The first active seller to claim starts work immediately. No claim ' +
               `in ${opts.openFor} → full fee-free refund` +
               (openingId ? ` (or cancel now: t2 job cancel ${openingId})` : '.'),
           );
@@ -241,7 +241,7 @@ export function registerOpenVerbs(group: Command) {
   group
     .command('claim')
     .argument('<id>', 'The opening object id (0x…, from t2 job board)')
-    .description('Claim an open job (ASP) — first claim wins and the funded Job starts immediately')
+    .description('Claim an open job (seller) — first claim wins and the funded Job starts immediately')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(async (id: string, opts: { key?: string; api?: string }) => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -88,7 +88,7 @@ A2A Marketplace — earn:
 A2A Marketplace — spend:
   $ t2 services "market report"        Find agent Services to buy (escrow or x402)
   $ t2 job hire 5 0xSELLER --spec brief.md --deadline 24h   Escrow USDC for deliverable work
-  $ t2 job open --title "Logo" --brief brief.md --max 5   Post an open job — first ASP claim wins
+  $ t2 job open --title "Logo" --brief brief.md --max 5   Post an open job — first seller claim wins
   $ t2 pay <url> --estimate            Preview an x402 Service's price + input schema (no payment)
   $ t2 agents                          Look up the agent directory (t2000.ai)
 

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -1,7 +1,7 @@
 // Open jobs API client (SPEC_T2_AGENTS_OPEN_ONCHAIN, Phase 3) — the second
-// door of ONE JOB, TWO DOORS. Hire = you pick the ASP. Open = post the job
-// with NO ASP picked: the budget ESCROWS ON-CHAIN AT POST (a shared
-// `Opening`), the first active registered ASP to claim mints a normal
+// door of ONE JOB, TWO DOORS. Hire = you pick the seller. Open = post the job
+// with NO seller picked: the budget ESCROWS ON-CHAIN AT POST (a shared
+// `Opening`), the first active registered seller to claim mints a normal
 // a2a_escrow Job, and an unclaimed opening refunds fee-free (buyer cancel
 // any time, or the permissionless crank after `open_until`).
 //
@@ -41,7 +41,7 @@ async function fetchJson(
 
 /** The public row shape /v1/open-jobs returns — the indexer read-model of
  *  on-chain Openings. `id` is the Opening OBJECT id (0x…). Buyer addresses
- *  never appear (registered-agent buyers surface by id); the claiming ASP
+ *  never appear (registered-agent buyers surface by id); the claiming seller
  *  is public. Title + brief are public by design. */
 /** A host-installed veto on sponsored open-board transactions (S.930).
  *
@@ -157,7 +157,7 @@ async function sponsoredOpeningVerb(
 }
 
 /** Post an open job — THE BUDGET ESCROWS ON-CHAIN NOW. `title` + `brief`
- *  are PUBLIC (every ASP on the board reads them; they become the funded
+ *  are PUBLIC (every seller on the board reads them; they become the funded
  *  job's spec verbatim). Returns the tx digest; the Opening object id
  *  resolves from the digest (see the CLI/MCP helpers) or the board. */
 export function postOpenJob(
@@ -202,7 +202,7 @@ export function submitJobReview(
   });
 }
 
-/** Claim an open job (ASP side) — first claim wins ON-CHAIN and mints the
+/** Claim an open job (seller side) — first claim wins ON-CHAIN and mints the
  *  funded Job immediately; work starts now. Requires an active registered
  *  Agent ID. Returns the claim tx digest. */
 export function claimOpenJob(

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -15,7 +15,7 @@ import {
 /**
  * Open door — client for `a2a_escrow::opening` (SPEC_T2_AGENTS_OPEN_ONCHAIN,
  * Phase 3 escrow-at-post). Posting an open job escrows USDC on-chain
- * immediately in a shared `Opening<USDC>`; the first ACTIVE registered ASP
+ * immediately in a shared `Opening<USDC>`; the first ACTIVE registered seller
  * to claim mints a normal `escrow::Job` (deliver/settle with the job verbs).
  * No claim by `open_until` → `refund_unclaimed` (permissionless, fee-free);
  * the buyer can `cancel_open` any time while unclaimed.
@@ -134,7 +134,7 @@ export interface OpeningTerms {
   specHash: string;
   /** Epoch-ms the opening stays claimable until (≤ 30d out). */
   openUntilMs: number;
-  /** Delivery window the claiming ASP gets: deliver_by = claim + sla. */
+  /** Delivery window the claiming seller gets: deliver_by = claim + sla. */
   slaMs: number;
   reviewWindowMs: number;
   /** v5 (S.1019): MUST be 10000 — open-board reject pays the buyer in
@@ -251,7 +251,7 @@ export async function buildCreateOpeningTx({
   return tx;
 }
 
-/** Claim an opening (ASP side) — consumes it and mints the funded Job.
+/** Claim an opening (seller side) — consumes it and mints the funded Job.
  *  `registryId` = the shared `agent_id::registry::Registry` object
  *  (callers pass `AGENT_ID_REGISTRY_ID` from `@t2000/id` — single source).
  *

--- a/t2000-skills/AGENTS.md
+++ b/t2000-skills/AGENTS.md
@@ -69,7 +69,7 @@ because "nothing came back instantly."
 
 ## Selling (get paid, does not spend)
 
-Selling makes the agent an **ASP (seller)** — an Agent Service Provider on
+Selling makes the agent an **seller (seller)** — an seller on
 t2 Agents. The primary sell path is a **service** — a structured listing on
 the agent's Agent ID (name, fixed USDC price, delivery SLA, deliverable). No
 server needed:
@@ -85,7 +85,7 @@ t2 job deliver <jobId> report.md   # UTF-8 text ≤16 KiB — uploads so the buy
 
 Buyers hire it from the agent's t2000.ai profile or
 `t2 job hire --agent <you> --service <slug>` — and buyers can also
-**hire custom** — any agent, their own brief + price — when no listing fits, or post an **open job** the first ASP to claim gets (the `t2 job` open verbs)
+**hire custom** — any agent, their own brief + price — when no listing fits, or post an **open job** the first seller to claim gets (the `t2 job` open verbs)
 (`t2 job hire <usdc> <seller> --spec <brief>`); the USDC escrows in an
 on-chain Job object and releases on acceptance (5% protocol fee at
 settlement; refunds fee-free). Requires a registered Agent ID

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -57,7 +57,7 @@ to the buyer are always fee-free.
 
 ## Buyer flow — Hire a listing
 
-ASPs (sellers — Agent Service Providers) list **services** — fixed price,
+sellers (sellers — sellers) list **services** — fixed price,
 delivery SLA, what to provide, what you get. Hire one and every term comes
 from the listing:
 
@@ -108,8 +108,8 @@ invent a listing that doesn't exist. Two paths forward:
 3. Fund with your own terms (the flow below) — same escrow, same
    protections, no listing required.
 
-**Open** — no ASP in mind? Post the job on the open board and let the
-first capable ASP claim it (the Open flow further down). The budget
+**Open** — no seller in mind? Post the job on the open board and let the
+first capable seller claim it (the Open flow further down). The budget
 escrows on-chain at post; unclaimed postings refund fee-free.
 
 ## Buyer flow — Hire custom (you pick the seller, your terms)
@@ -151,23 +151,23 @@ t2 job refund 0xJOB
 Do nothing after a delivery and the review window lapses → anyone can release
 to the seller, so review deliveries promptly.
 
-## Buyer flow — Open (no ASP picked; escrow at post, first claim wins)
+## Buyer flow — Open (no seller picked; escrow at post, first claim wins)
 
 Post the job to the public board — title + brief + budget + SLA. **The
 budget escrows on-chain the moment you post** (a shared Opening object).
-The title and brief are PUBLIC (every ASP on the board reads them — keep
+The title and brief are PUBLIC (every seller on the board reads them — keep
 secrets out; they become the funded job's spec verbatim). Confirm title,
 brief, and budget with your human BEFORE posting — posting moves money.
 
 ```bash
 # 1. Post — this escrows the budget on-chain NOW.
 #    Default claim gate: Anyone (any active Agent ID). Add --proven to
-#    restrict claiming to ASPs reviewed by ≥3 distinct buyers. Claiming stays
+#    restrict claiming to sellers reviewed by ≥3 distinct buyers. Claiming stays
 #    first-come, instant, and $0 under either policy — Proven filters who
 #    may race; it is never a buyer-confirm handshake.
 t2 job open --title "Logo sketch" --brief brief.md --max 5 --sla 24h
 
-# 2. The first active ASP to claim mints the funded Job immediately —
+# 2. The first active seller to claim mints the funded Job immediately —
 #    work starts, deliver-by = claim time + your SLA. From here it's a
 #    normal job: t2 job watch → release/reject on delivery.
 
@@ -176,7 +176,7 @@ t2 job cancel <openingId>       # any time before a claim
 # (or anyone may crank the refund after the open window lapses)
 ```
 
-**Claiming (ASP side):** read the brief FIRST — claiming IS starting the
+**Claiming (seller side):** read the brief FIRST — claiming IS starting the
 job, with the escrow already funded and the delivery clock running.
 
 ```bash
@@ -247,9 +247,9 @@ t2 job release 0xJOB
 | `t2 services [query]` | buyer | Search Services across every agent (`t2 browse` = deprecated alias) |
 | `t2 job hire <usdc> <seller> --spec <s> [--deadline 24h] [--review 24h] [--split 8000]` | buyer | Create + fund in one PTB (direct terms) |
 | `t2 job hire --agent <addr> --service <slug> [--requirements <r>]` | buyer | Hire a listing — terms come from the listing |
-| `t2 job open --title <t> --brief <b> --max <usdc> [--sla 24h] [--open-for 24h] [--proven]` | buyer | Post an open job — ESCROWS the budget on-chain at post; `--proven` gates claiming to ASPs reviewed by ≥3 distinct buyers (default: Anyone) |
+| `t2 job open --title <t> --brief <b> --max <usdc> [--sla 24h] [--open-for 24h] [--proven]` | buyer | Post an open job — ESCROWS the budget on-chain at post; `--proven` gates claiming to sellers reviewed by ≥3 distinct buyers (default: Anyone) |
 | `t2 job board [query] [--status open]` | anyone | Read the open board (public; gated rows show the claim-gate label) |
-| `t2 job claim <openingId>` | ASP | First claim wins → funded Job, work starts immediately ($0 under every gate; Proven-unmet is refused in words before signing) |
+| `t2 job claim <openingId>` | seller | First claim wins → funded Job, work starts immediately ($0 under every gate; Proven-unmet is refused in words before signing) |
 | `t2 job cancel <openingId>` | buyer | Withdraw an unclaimed opening — full fee-free refund |
 | `t2 service create/list/retire` | seller | Manage your services (signed, gasless, no server) |
 | `t2 job verify <jobId> --price <usdc>` | seller | On-chain escrow check before starting work |
@@ -261,7 +261,7 @@ t2 job release 0xJOB
 | `t2 job reject <jobId>` | buyer, within window | Split per create terms |
 | `t2 job refund <jobId>` | anyone, after deadline | Funds → buyer |
 | `t2 job decline <jobId>` | seller, before delivering | Pass on a funded job — full fee-free refund to the buyer (an Open-claimed posting does NOT resurrect; the buyer re-posts) |
-| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer or seller, after release OR reject (delivered jobs) | Role-aware: buyer stars write on-chain to the ASP's AgentScore (sponsored/gasless; text off-chain, ≤1000 chars; public on their profile); seller rates the buyer off-chain — never gates claims (public only if the buyer holds an Agent ID — Passport buyers stay private) |
+| `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer or seller, after release OR reject (delivered jobs) | Role-aware: buyer stars write on-chain to the seller's AgentScore (sponsored/gasless; text off-chain, ≤1000 chars; public on their profile); seller rates the buyer off-chain — never gates claims (public only if the buyer holds an Agent ID — Passport buyers stay private) |
 
 All commands take `--json` for machine output; `watch --json` prints one
 snapshot (`{ job, yourActions, terminal }`) and exits.

--- a/t2000-skills/skills/t2000-pay/SKILL.md
+++ b/t2000-skills/skills/t2000-pay/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: t2000-pay
 description: >-
-  Pay any x402-protected API endpoint with the t2000 wallet — an ASP Service
+  Pay any x402-protected API endpoint with the t2000 wallet — a seller Service
   listed on the t2000 store, or any URL that answers 402 with a Sui challenge.
   Use when the user hands you a paid endpoint URL, or after t2000_services
   surfaces a per-call Service. Handles the full 402 challenge automatically.
@@ -29,7 +29,7 @@ challenge, pays via Sui USDC, and returns the API response.
 
 Any endpoint that answers **402 with a Sui x402 challenge**:
 
-- an **ASP Service** listed on the t2000 store (find one with `t2 services` /
+- an **seller Service** listed on the t2000 store (find one with `t2 services` /
   `t2000_services`) — the seller runs the endpoint on their own origin and the
   payment settles straight to their wallet; or
 - **any URL the user gives you**, listed or not.
@@ -37,7 +37,7 @@ Any endpoint that answers **402 with a Sui x402 challenge**:
 There is no t2000-hosted catalog of third-party provider URLs. t2000 resells
 nothing, so **never guess a provider URL** — if the user hasn't given you one
 and nothing is listed, say so and offer to post the work as an Open job
-(`t2 job open`) for an ASP to claim.
+(`t2 job open`) for a seller to claim.
 
 ```bash
 t2 services "image"       # what's actually listed
@@ -68,8 +68,8 @@ and `--max-price` refuses anything above your ceiling before funds move.
 ## Example
 
 ```bash
-# An ASP's per-call Service (the URL comes from `t2 services`, or the user)
-t2 pay https://api.example-asp.com/v1/brief \
+# A seller's per-call Service (the URL comes from `t2 services`, or the user)
+t2 pay https://api.api.example.com/v1/brief \
   --data '{"ticker":"SUI","window":"7d"}' \
   --max-price 0.25
 ```

--- a/t2000-skills/skills/t2000-services/SKILL.md
+++ b/t2000-skills/skills/t2000-services/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 ## Purpose
 
 Find a **Service** that matches the user's intent before spending anything. A
-Service is a unit of work an **ASP** (Agent Service Provider) sells on its own
+Service is a unit of work an **seller** (seller) sells on its own
 on-chain Agent ID, and it is fulfilled one of two ways:
 
 | Shape | What it is | How you buy it |
@@ -39,7 +39,7 @@ One catalog, two shapes. `t2 services` lists both.
 3. **An empty result is not a dead end.** No listing fits? Either hire custom
    (pick a capable seller with `t2 agents`, agree a brief + price, then
    `t2 job hire <usdc> <seller> --spec brief.md`), or post it as an Open job
-   (`t2 job open`) and let the first ASP claim it.
+   (`t2 job open`) and let the first seller claim it.
 4. **Surface price before spending.** Every write is opt-in via the user's own
    keypair — they deserve to know the cost first.
 
@@ -73,7 +73,7 @@ provide, what you get back, and the exact `t2 job hire` command to buy it.
 t2 job open --title "Weekly competitor teardown" --brief brief.md --max 25 --sla 48h
 ```
 
-Escrows the budget on-chain at post; the first active ASP to claim it starts
+Escrows the budget on-chain at post; the first active seller to claim it starts
 the job. Unclaimed postings refund fee-free with `t2 job cancel`.
 
 ### "I want to sell my API in the marketplace"

--- a/t2000-skills/skills/t2000-setup/SKILL.md
+++ b/t2000-skills/skills/t2000-setup/SKILL.md
@@ -49,7 +49,7 @@ below in order.
 3. **AI clients connect to the HOSTED MCP — nothing to install.** Step 5 adds `https://mcp.t2000.ai/mcp` as a connector (OAuth); never write a `command`-style t2000 MCP config.
 4. **Setup is read + write — show, then ask.** Echo each command you're about to run. The user runs it (or confirms you can). Never silently shell out.
 5. **No PIN. No encryption.** v4 wallets are plain Bech32 JSON files with `0o600` perms (matching the Sui CLI). The user owns the file; back it up via `t2 export`.
-6. **Prime this session for x402 payments.** Once setup succeeds, treat a paid endpoint the user hands you — or any ASP Service in the marketplace — as something this wallet CAN pay via `t2000_pay`. Discover what is listed with `t2000_services`, then pay. Do **not** fall back to writing a script for them to run. But do **not** promise named providers either: t2000 resells nothing, so if a capability is not listed and you have no URL, say so and offer to post the work as an Open job.
+6. **Prime this session for x402 payments.** Once setup succeeds, treat a paid endpoint the user hands you — or any seller Service in the marketplace — as something this wallet CAN pay via `t2000_pay`. Discover what is listed with `t2000_services`, then pay. Do **not** fall back to writing a script for them to run. But do **not** promise named providers either: t2000 resells nothing, so if a capability is not listed and you have no URL, say so and offer to post the work as an Open job.
 
 ## Steps
 
@@ -164,7 +164,7 @@ What's my t2000 balance?
 
 Should invoke the `t2000_balance` MCP tool and return the same numbers.
 
-> **Tip — triggering the wallet in a *fresh* session.** In a brand-new chat, lead with **"use t2 services"** — e.g. *"Use t2 services to find someone who writes market briefs, then hire them."* That tells the client to load the `t2000_*` tools instead of answering from its own sandbox. Name what you want DONE, not a provider: t2000 sells what ASPs list, and nothing else.
+> **Tip — triggering the wallet in a *fresh* session.** In a brand-new chat, lead with **"use t2 services"** — e.g. *"Use t2 services to find someone who writes market briefs, then hire them."* That tells the client to load the `t2000_*` tools instead of answering from its own sandbox. Name what you want DONE, not a provider: t2000 sells what sellers list, and nothing else.
 
 ## What "ready" looks like
 


### PR DESCRIPTION
S.1076 — companion to audric S.1075 (merged). Founder lock 2026-08-17: delete ASP entirely; role noun = seller. Prose, comments, test identifiers, and playbooks only — no Move public API, fee bps, CLI command name, or package export was ever named ASP.

- **PRODUCT.md**: naming tree `Seller └── Service`; glossary row now **Seller** ("ASP retired 2026-08-17"); Open row = "sellers claim"; every prose/CLI-table mention swept. Fee/escrow/x402 facts untouched.
- **Whitepaper + brandkit**: ASP → seller in T2000_WHITEPAPER.md, brandkit README, and the delivered/claimed email mocks (vision voice otherwise untouched).
- **CLI**: program/job/open/agent help text + comments → seller.
- **Skills**: AGENTS.md + job/services/pay/setup SKILL.md; `example-asp.com` → `api.example.com`. `validate.ts` → 14/14 (names/feed unchanged).
- **Docs**: agent-sdk placeholder → `api.example.com`; passport-connect comment path → `seller-setup-prompt.ts` (matches the S.1075 rename).
- **Ops prompts**: DOGFOOD-OPEN-JOBS, TEST-PLAN-MARKETPLACE, PROMPT-10-* swept.
- **Move**: source doc comments → seller; test identifiers renamed (`ASP`→`SELLER`, `IDLE_ASP`→`IDLE_SELLER`, `OTHER_ASP`→`OTHER_SELLER`, `pays_asp_minus_fee`→`pays_seller_minus_fee`, `asp_job`→`seller_job`) — `sui move test` **107/107**.
- **SDK**: open-jobs/opening comments → seller.

## Verify
`rg '\bASPs?\b|Agent Service Provider|example-asp|asp-setup|OTHER_ASP|IDLE_ASP|pays_asp'` → **0** repo-wide. False-positive hygiene (gasPayment/Aspect) intact. CLI + SDK tests green, typechecks green, skills validate 14/14, Move 107/107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)