### PR TITLE
🐛 fix: correct ASP-retirement typos (S.1077)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -133,7 +133,7 @@ Seller
 | Term | Meaning | Surfaced as |
 |---|---|---|
 | **A2A** | Agent-to-agent commerce on Sui | Marketplace framing |
-| **Seller** | The agent selling — role noun everywhere (seller retired 2026-08-17) | Role; code says `seller` |
+| **Seller** | The agent selling — role noun everywhere (ASP retired 2026-08-17) | Role; code says `seller` |
 | **Service** | What a seller sells — **escrow and/or x402** | Marketplace · `t2 services` · `t2000_services` |
 | **Hire** | Buyer funds a Job now | Primary escrow door |
 | **Open** | Buyer posts an open job, budget locked; sellers claim | Role + door |

--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -50,7 +50,7 @@ await agent.swap({ from: 'USDC', to: 'SUI', amount: 100 });
 // Speaks both dialects: x402 `accepts[]` body (preferred) and the MPP
 // x402 accepts[] dialect only. JSON string bodies default to content-type: application/json.
 const result = await agent.pay({
-  url: 'https://api.api.example.com/v1/chat/completions',
+  url: 'https://api.example.com/v1/chat/completions',
   method: 'POST',
   body: JSON.stringify({ model: 'gpt-4o-mini', messages: [/* … */] }),
   maxPrice: 0.10,

--- a/t2000-skills/skills/t2000-pay/SKILL.md
+++ b/t2000-skills/skills/t2000-pay/SKILL.md
@@ -69,7 +69,7 @@ and `--max-price` refuses anything above your ceiling before funds move.
 
 ```bash
 # A seller's per-call Service (the URL comes from `t2 services`, or the user)
-t2 pay https://api.api.example.com/v1/brief \
+t2 pay https://api.example.com/v1/brief \
   --data '{"ticker":"SUI","window":"7d"}' \
   --max-price 0.25
 ```


### PR DESCRIPTION
S.1077 — three mechanical leftovers from the S.1076 sweep (the word-boundary regex ran over its own output):

- PRODUCT.md glossary: `(seller retired 2026-08-17)` → `(ASP retired 2026-08-17)` — the note names what was retired.
- agent-sdk.mdx + t2000-pay SKILL.md: `api.api.example.com` → `api.example.com` (the original placeholder was `api.example-asp.com`).

Verify: `seller retired|api.api.example.com` → 0; `ASP retired 2026-08-17` present once; both placeholders correct; skills validate 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)