### PR TITLE
🐛 fix(cli): keep live service windows on omit upsert (S.1083)

### DIFF
--- a/packages/cli/src/commands/service.test.ts
+++ b/packages/cli/src/commands/service.test.ts
@@ -138,3 +138,72 @@ describeOrSkip('t2 service create — price bounds (S.1038b)', () => {
     expect(`${r.stdout}${r.stderr}`).toContain('at least');
   });
 });
+
+// [S.1083 — Connect S.1048 twin] omit-safe upsert: Commander defaults must
+// not wipe a live listing's customized review window / reject split.
+import { mergeServiceUpsert } from '../lib/service-upsert.js';
+
+const LIVE = {
+  name: 'Sui market report',
+  description: 'Daily report',
+  priceUsdc: 5,
+  slaMinutes: 1440,
+  reviewWindowMinutes: 2880, // customized 48h
+  rejectSplitBps: 9000, // customized 90/10
+  requirements: { topic: 'what to cover' },
+  deliverable: 'A PDF',
+  retired: false,
+};
+
+const ARGS = {
+  slug: 'sui-market-report',
+  name: 'Sui market report',
+  description: 'Daily report',
+  priceUsdc: 5,
+  slaMinutes: 1440,
+  deliverable: 'A PDF',
+  requirements: { topic: 'what to cover' },
+};
+
+describe('mergeServiceUpsert (S.1083)', () => {
+  it('omitted --review/--split on an update keep the LIVE values', () => {
+    const { payload, created, changed } = mergeServiceUpsert(
+      { ...ARGS, priceUsdc: 6 },
+      LIVE,
+    );
+    expect(created).toBe(false);
+    expect(payload.reviewWindowMinutes).toBe(2880);
+    expect(payload.rejectSplitBps).toBe(9000);
+    expect(changed).toEqual(['priceUsdc']);
+  });
+
+  it('explicit flags override the live values', () => {
+    const { payload, changed } = mergeServiceUpsert(
+      { ...ARGS, reviewWindowMinutes: 1440, rejectSplitBps: 8000 },
+      LIVE,
+    );
+    expect(payload.reviewWindowMinutes).toBe(1440);
+    expect(payload.rejectSplitBps).toBe(8000);
+    expect(changed).toEqual(['reviewWindowMinutes', 'rejectSplitBps']);
+  });
+
+  it('create (no live row) keeps the 24h / 8000 defaults', () => {
+    const { payload, created } = mergeServiceUpsert(ARGS, null);
+    expect(created).toBe(true);
+    expect(payload.reviewWindowMinutes).toBe(1440);
+    expect(payload.rejectSplitBps).toBe(8000);
+  });
+
+  it('identical re-run diffs to nothing (requirements key order ignored)', () => {
+    const { changed } = mergeServiceUpsert(
+      { ...ARGS, requirements: { topic: 'what to cover' } },
+      { ...LIVE, requirements: { topic: 'what to cover' } },
+    );
+    expect(changed).toEqual([]);
+  });
+
+  it('a retired live row is never a no-op — the upsert revives it', () => {
+    const { changed } = mergeServiceUpsert(ARGS, { ...LIVE, retired: true });
+    expect(changed).toEqual(['relisted']);
+  });
+});

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -30,7 +30,8 @@ import {
   parseCategory,
 } from '../lib/agent-category.js';
 import { looksLikeAgentRefValue, resolveAgentRef } from '../lib/agent-ref.js';
-import { fetchJson, type ServiceListing } from '../lib/services.js';
+import { mergeServiceUpsert } from '../lib/service-upsert.js';
+import { fetchJson, listServices, type ServiceListing } from '../lib/services.js';
 import { withAgent } from '../lib/with-agent.js';
 import {
   handleError,
@@ -215,8 +216,17 @@ Examples:
         category?: string;
         key?: string;
         api?: string;
-      }) => {
+      }, cmd?: { getOptionValueSource?: (key: string) => string | undefined }) => {
         try {
+          // S.1083 (Connect S.1048 twin): Commander fills the defaults even
+          // when the flags are omitted — sending them on a same-slug re-run
+          // RESET a customized listing. Only treat a flag as set when it
+          // actually came from the argv. (No source API → old always-send
+          // behavior, never a silent omit.)
+          const reviewExplicit =
+            cmd?.getOptionValueSource?.('review') !== 'default';
+          const splitExplicit =
+            cmd?.getOptionValueSource?.('split') !== 'default';
           const priceUsdc = Number.parseFloat(opts.price);
           if (!Number.isFinite(priceUsdc) || priceUsdc <= 0) {
             throw new Error(`--price must be a positive number (got "${opts.price}").`);
@@ -248,26 +258,62 @@ Examples:
             ? await resolveRequirements(opts.requirements)
             : null;
 
+          const base = opts.api ?? DEFAULT_API_BASE;
+          const agent = await withAgent({ keyPath: opts.key });
+
           // Listings become browsable cards — a category is part of listing
           // (the directory-drift guard; retire skips it).
           await ensureSellerCategory({
-            base: opts.api ?? DEFAULT_API_BASE,
-            agent: await withAgent({ keyPath: opts.key }),
+            base,
+            agent,
             category,
           });
 
-          const payload = {
-            slug,
-            name: opts.name.trim(),
-            description: opts.description.trim(),
-            priceUsdc,
-            slaMinutes,
-            reviewWindowMinutes,
-            rejectSplitBps,
-            requirements,
-            deliverable: opts.deliverable.trim(),
-          };
-          const base = opts.api ?? DEFAULT_API_BASE;
+          // S.1083: the signed API is a FULL upsert — read this wallet's
+          // live row first and merge, so omitted --review/--split keep the
+          // live values. FAIL CLOSED on a read blip: writing create-defaults
+          // over a listing we couldn't read is exactly the wipe this fixes.
+          let live: ServiceListing | null = null;
+          try {
+            const { services: mine } = await listServices(base, {
+              agent: agent.address(),
+            });
+            live = mine.find((s) => s.slug === slug) ?? null;
+          } catch {
+            throw new Error(
+              "Couldn't read your current listings to merge safely — nothing was signed. Try again in a moment.",
+            );
+          }
+          const { payload, created, changed } = mergeServiceUpsert(
+            {
+              slug,
+              name: opts.name,
+              description: opts.description,
+              priceUsdc,
+              slaMinutes,
+              deliverable: opts.deliverable,
+              requirements,
+              reviewWindowMinutes: reviewExplicit
+                ? reviewWindowMinutes
+                : undefined,
+              rejectSplitBps: splitExplicit ? rejectSplitBps : undefined,
+            },
+            live,
+          );
+          // Identical re-run: nothing to write, nothing to sign (Connect
+          // honesty — S.1048).
+          if (!created && changed.length === 0) {
+            if (isJsonMode()) {
+              printJson({ address: agent.address(), slug, noop: true });
+              return;
+            }
+            printBlank();
+            printInfo(
+              `"${payload.name}" is already listed exactly like this — nothing changed, nothing signed.`,
+            );
+            printBlank();
+            return;
+          }
           const { address } = await signedServiceAction({
             base,
             keyPath: opts.key,

--- a/packages/cli/src/lib/service-upsert.ts
+++ b/packages/cli/src/lib/service-upsert.ts
@@ -1,0 +1,118 @@
+// Omit-safe service upsert merge (S.1083 — the CLI twin of Connect's
+// mergeServiceUpsert, S.1048; behavior SSOT: audric/apps/mcp/lib/sell.ts —
+// ported, not imported, and the two must not drift).
+//
+// The signed /v1/agent/service API is a FULL upsert, and Commander supplies
+// `--review 24h` / `--split 8000` defaults even when the flags are omitted —
+// so a same-slug re-run that only changed the price silently RESET a
+// customized review window / reject split. The fix: on an update, omitted
+// optionals keep the LIVE values; create (no live row) keeps the defaults.
+// `changed` names what actually differs (trim-normalized strings;
+// requirements via canonical JSON so key order can't fake a diff) — an
+// update with zero changes is the caller's cue to skip the challenge/sign
+// entirely. A RETIRED live row is never a no-op — the upsert revives it.
+
+/** Stable stringify — object keys sorted at every depth. */
+export function canonicalJson(v: unknown): string {
+  if (Array.isArray(v)) {
+    return `[${v.map(canonicalJson).join(',')}]`;
+  }
+  if (v !== null && typeof v === 'object') {
+    return `{${Object.keys(v as Record<string, unknown>)
+      .sort()
+      .map(
+        (k) =>
+          `${JSON.stringify(k)}:${canonicalJson((v as Record<string, unknown>)[k])}`,
+      )
+      .join(',')}}`;
+  }
+  return JSON.stringify(v) ?? 'undefined';
+}
+
+/** The live listing row as the public seller catalog serves it (the shape
+ *  this merge diffs against). */
+export type LiveServiceRow = {
+  name: string;
+  description: string;
+  priceUsdc: number;
+  slaMinutes: number;
+  reviewWindowMinutes: number;
+  rejectSplitBps: number;
+  requirements: unknown;
+  deliverable: string;
+  retired?: boolean;
+};
+
+export function mergeServiceUpsert(
+  args: {
+    slug: string;
+    name: string;
+    description: string;
+    priceUsdc: number;
+    slaMinutes: number;
+    deliverable: string;
+    requirements: unknown;
+    reviewWindowMinutes?: number;
+    rejectSplitBps?: number;
+  },
+  live: LiveServiceRow | null,
+): {
+  payload: {
+    slug: string;
+    name: string;
+    description: string;
+    priceUsdc: number;
+    slaMinutes: number;
+    reviewWindowMinutes: number;
+    rejectSplitBps: number;
+    requirements: unknown;
+    deliverable: string;
+  };
+  created: boolean;
+  changed: string[];
+} {
+  const payload = {
+    slug: args.slug,
+    name: args.name.trim(),
+    description: args.description.trim(),
+    priceUsdc: args.priceUsdc,
+    slaMinutes: args.slaMinutes,
+    reviewWindowMinutes:
+      args.reviewWindowMinutes ?? live?.reviewWindowMinutes ?? 1440,
+    rejectSplitBps: args.rejectSplitBps ?? live?.rejectSplitBps ?? 8000,
+    requirements: args.requirements,
+    deliverable: args.deliverable.trim(),
+  };
+  if (!live) {
+    return { payload, created: true, changed: [] };
+  }
+  const changed: string[] = [];
+  const strDiff = (key: string, next: string, prev: unknown) => {
+    if (next !== (typeof prev === 'string' ? prev.trim() : '')) {
+      changed.push(key);
+    }
+  };
+  const numDiff = (key: string, next: number, prev: unknown) => {
+    if (next !== prev) {
+      changed.push(key);
+    }
+  };
+  strDiff('name', payload.name, live.name);
+  strDiff('description', payload.description, live.description);
+  strDiff('deliverable', payload.deliverable, live.deliverable);
+  numDiff('priceUsdc', payload.priceUsdc, live.priceUsdc);
+  numDiff('slaMinutes', payload.slaMinutes, live.slaMinutes);
+  numDiff(
+    'reviewWindowMinutes',
+    payload.reviewWindowMinutes,
+    live.reviewWindowMinutes,
+  );
+  numDiff('rejectSplitBps', payload.rejectSplitBps, live.rejectSplitBps);
+  if (canonicalJson(payload.requirements) !== canonicalJson(live.requirements)) {
+    changed.push('requirements');
+  }
+  if (live.retired) {
+    changed.push('relisted');
+  }
+  return { payload, created: false, changed };
+}


### PR DESCRIPTION
S.1083 — CLI twin of Connect's S.1048 `mergeServiceUpsert`. Commander supplies `--review 24h` / `--split 8000` defaults even when the flags are omitted, so a same-slug `t2 service create` re-run that only changed name/price RESET a customized review window / reject split.

- **New `lib/service-upsert.ts`**: `mergeServiceUpsert` ported from the Connect SSOT (audric `apps/mcp/lib/sell.ts`) — same contract, not imported: omitted optionals keep live values, create keeps 24h/8000 defaults, `changed[]` via trim-normalized strings + canonical-JSON requirements, retired live row → `relisted` (never a no-op).
- **create action**: flag-passed detection via `cmd.getOptionValueSource('review'|'split') !== 'default'` (runtime-verified: omitted → `default`, explicit → `cli`; missing API falls back to the old always-send behavior, never a silent omit). Live row read via SDK `listServices` scoped to this wallet, **fail-closed** like Connect ("Couldn't read your current listings to merge safely — nothing was signed."). Identical re-run prints a no-op and skips the challenge/sign entirely (JSON mode: `{noop: true}`).
- No API shape change (payload still the full upsert), no fee math / price bounds / requirements rules touched, audric untouched.

Tests: 5 new pins (omit keeps live 48h/9000; explicit override wins; create defaults; identical → zero diff with key-order-proof requirements; retired revives). CLI suite 306/306, typecheck clean, lint clean (the one warning is pre-existing in an unrelated file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)