### PR TITLE
✨ feat(cli): browse x402 via t2 services --rail api (S.1084)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -51,7 +51,7 @@ t2 swap 100 USDC SUI --quote
 | Command | What it does |
 | --- | --- |
 | `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
-| `t2 services [query]` | Discover Services in the Agent Marketplace — escrow work + seller x402 endpoints. Market browse is ranked featured → most settled USDC → newest. Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller (active listings only); free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | Discover Services in the Agent Marketplace — hire (escrow) and instant (pay-per-call x402). `--rail hire\|api\|all` picks the block (default hire); `kind:"api"` rows carry the absolute URL for `t2 pay`. Market browse is ranked featured → most settled USDC → newest (api rows: seller paid-call volume). Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller; free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 t2 services "chat"
@@ -152,7 +152,7 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service create` | seller | List (or update — same slug overwrites). Required: `--name` · `--price <usdc>` · `--sla <duration>` · `--description` · `--deliverable`. Optional: `--slug` · `--requirements` (prefer a JSON object of required buyer fields — enforced at hire) · `--review 24h` · `--split 8000` · `--category <cat>` (required once unless set on your profile). |
 | `t2 service list [agent]` | anyone | An agent's services — your own wallet's by default (retired included). |
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
-| `t2 services [query]` | buyer | Search Services across every agent (ranked featured → most settled → newest) — scope to one seller with `0x…` / `#id` / `@handle`, or to a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | buyer | Search Services across every agent (ranked featured → most settled → newest) — `--rail api` for pay-per-call x402 routes, `--rail all` for both; scope to one seller with `0x…` / `#id` / `@handle`, or a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 # seller — one command, listed

--- a/apps/docs/how-to/pay-an-api.mdx
+++ b/apps/docs/how-to/pay-an-api.mdx
@@ -13,7 +13,7 @@ proxied or resold.
 
 - [ ] [Get set up](/how-to/get-set-up) and funded with a little USDC
       ([fund →](/how-to/fund-and-send))
-- [ ] A target: find one with `t2 services`, or bring any x402 URL
+- [ ] A target: find one with `t2 services --rail api`, or bring any x402 URL
 
 ## In your AI (Passport Connect)
 
@@ -27,9 +27,12 @@ exactly what it cost.
 ## In the terminal (`t2`)
 
 ```bash
-t2 services "search"                     # what agents actually sell — free
+t2 services --rail api                   # live pay-per-call routes — method, URL, price
 t2 pay <url> --estimate                  # price one endpoint without paying
 ```
+
+Paid calls settle straight to the seller and never move a seller's score or
+Proven — reputation is escrow-only.
 
 Then pay — always with a cap:
 

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -31,7 +31,13 @@ import {
 } from '../lib/agent-category.js';
 import { looksLikeAgentRefValue, resolveAgentRef } from '../lib/agent-ref.js';
 import { mergeServiceUpsert } from '../lib/service-upsert.js';
-import { fetchJson, listServices, type ServiceListing } from '../lib/services.js';
+import {
+  type ApiRouteListing,
+  fetchJson,
+  listServices,
+  type ServiceListing,
+  type ServicesRow,
+} from '../lib/services.js';
 import { withAgent } from '../lib/with-agent.js';
 import {
   handleError,
@@ -123,6 +129,25 @@ function formatSla(minutes: number): string {
 export function serviceSellerLabel(o: Pick<ServiceListing, 'agentName' | 'agentNumericId' | 'agent'>): string {
   const id = o.agentNumericId != null ? ` #${o.agentNumericId}` : '';
   return `${o.agentName ?? 'unnamed'}${id} ${truncateAddress(o.agent)}`;
+}
+
+/** A kind:"api" row (S.1084) — pay-per-call; paid with `t2 pay`, never a
+ *  hire verb (no slug, no escrow fields). */
+function printApiRoute(o: ApiRouteListing) {
+  printLine(`${pc.bold(`${o.method} ${o.path}`)} ${pc.dim('· pay per call')}`);
+  printKeyValue('Price', `$${o.priceUsdc.toFixed(2)} USDC / call`);
+  {
+    const id = o.agentNumericId != null ? ` #${o.agentNumericId}` : '';
+    printKeyValue(
+      'Seller',
+      `${o.agentName ?? 'unnamed'}${pc.bold(id)} ${pc.dim(truncateAddress(o.agent))}`,
+    );
+  }
+  if (o.summary) {
+    printKeyValue('What', o.summary);
+  }
+  printKeyValue('URL', o.url);
+  printKeyValue('Pay', `t2 pay ${o.url} --estimate`);
 }
 
 function printService(o: ServiceListing) {
@@ -278,7 +303,10 @@ Examples:
             const { services: mine } = await listServices(base, {
               agent: agent.address(),
             });
-            live = mine.find((s) => s.slug === slug) ?? null;
+            live =
+              mine.find(
+                (s): s is ServiceListing => s.kind !== 'api' && s.slug === slug,
+              ) ?? null;
           } catch {
             throw new Error(
               "Couldn't read your current listings to merge safely — nothing was signed. Try again in a moment.",
@@ -435,11 +463,17 @@ export async function resolveServicesQuery(
   base: string,
   query: string | undefined,
   category?: string,
+  rail?: 'hire' | 'api' | 'all',
 ): Promise<{ url: string; scope: ServicesScope }> {
-  const withCategory = (url: string): string =>
-    category
+  const withCategory = (url: string): string => {
+    const withCat = category
       ? `${url}${url.includes('?') ? '&' : '?'}category=${encodeURIComponent(category)}`
       : url;
+    // S.1084: omitted rail stays hire-only (the compat default).
+    return rail
+      ? `${withCat}${withCat.includes('?') ? '&' : '?'}rail=${rail}`
+      : withCat;
+  };
   const q = query?.trim();
   if (!q) {
     return { url: withCategory(`${base}/services`), scope: { kind: 'all' } };
@@ -482,20 +516,40 @@ function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
   command
     .argument('[query]', 'What you need — free text, or a SELLER scope: 0x… address, #id, or @handle (empty = everything, ranked featured → most settled → newest)')
     .option('--category <category>', `Seller directory category (${AGENT_CATEGORIES.join(' | ')}) — ANDs with the query`)
+    .option(
+      '--rail <rail>',
+      'hire = escrow services (default) · api = instant pay-per-call x402 routes · all = both',
+    )
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(async (query: string | undefined, cmdOpts: { api?: string; category?: string }) => {
+    .action(async (query: string | undefined, cmdOpts: { api?: string; category?: string; rail?: string }) => {
       try {
         const base = cmdOpts.api ?? DEFAULT_API_BASE;
         // Fail fast on an off-enum category (same local mirror the sell
         // gate uses) — the API would 400 with the same allow-list.
         const category = cmdOpts.category ? parseCategory(cmdOpts.category) : undefined;
-        const { url, scope } = await resolveServicesQuery(base, query, category);
+        // S.1084: the x402 rail. Off-enum fails fast, same as the API would.
+        const rail = cmdOpts.rail?.trim().toLowerCase();
+        if (rail && !['hire', 'api', 'all'].includes(rail)) {
+          throw new Error(
+            `--rail must be hire, api, or all (got "${cmdOpts.rail}").`,
+          );
+        }
+        const { url, scope } = await resolveServicesQuery(
+          base,
+          query,
+          category,
+          rail as 'hire' | 'api' | 'all' | undefined,
+        );
         const json = await fetchJson(url);
-        const all = (json.services ?? []) as ServiceListing[];
+        const all = (json.services ?? []) as ServicesRow[];
         // Buyer discovery is the ACTIVE board: `?agent=` serves the seller's
         // management view retired-included — hide retired here with an
         // honest note (`t2 service list` keeps the full management dump).
-        const rows = scope.kind === 'agent' ? all.filter((o) => !o.retired) : all;
+        // (kind:"api" rows are live-only and carry no retired flag.)
+        const rows =
+          scope.kind === 'agent'
+            ? all.filter((o) => o.kind === 'api' || !o.retired)
+            : all;
         const retiredHidden = all.length - rows.length;
         if (isJsonMode()) {
           printJson({
@@ -526,7 +580,11 @@ function registerDiscovery(command: Command, opts?: { deprecated?: boolean }) {
           return;
         }
         for (const o of rows) {
-          printService(o);
+          if (o.kind === 'api') {
+            printApiRoute(o);
+          } else {
+            printService(o);
+          }
           printBlank();
         }
         if (retiredHidden > 0) {

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -8,12 +8,14 @@
 // (used by the signed-mutation flows in `t2 service` / `t2 job review`).
 
 export {
+  type ApiRouteListing,
   assertBuyerRequirements,
   fetchService,
   getJobSpec,
   listServices,
   putJobSpec,
   type ServiceListing,
+  type ServicesRow,
 } from '@t2000/sdk';
 
 export async function fetchJson(

--- a/packages/sdk/src/commerce.ts
+++ b/packages/sdk/src/commerce.ts
@@ -33,6 +33,8 @@ async function commerceFetchJson(
 
 /** The shape the API returns from GET /v1/services. */
 export interface ServiceListing {
+  /** Row discriminator (S.1084) — hire rows; absent on pre-S.1084 servers. */
+  kind?: 'hire';
   agent: string;
   agentName: string | null;
   agentNumericId: number | null;
@@ -59,6 +61,34 @@ export interface ServiceListing {
   settledUsdc: number;
 }
 
+/** One live pay-per-call x402 route (S.1084 — `kind: "api"` rows from
+ *  GET /v1/services?rail=api|all). Paid with `t2 pay` / `agent.pay` at
+ *  `url` — NEVER hired (no slug, no SLA, no escrow fields). Ranked by the
+ *  seller's paid-call volume, never escrow settledUsdc. */
+export interface ApiRouteListing {
+  kind: 'api';
+  agent: string;
+  agentName: string | null;
+  agentNumericId: number | null;
+  method: string;
+  path: string;
+  /** Absolute endpoint URL (origin + path) — what `t2 pay` takes. */
+  url: string;
+  priceUsdc: number;
+  summary: string | null;
+  category: string | null;
+  probeOk: boolean;
+  paidCalls?: number;
+  paidVolumeUsdc?: number;
+}
+
+export type ServicesRow = ServiceListing | ApiRouteListing;
+
+/** Rail selector for listServices (S.1084): omitted = hire only (the
+ *  compat default old callers rely on) · api = pay-per-call routes ·
+ *  all = both blocks, hire first, kind-discriminated. */
+export type ServicesRail = 'hire' | 'api' | 'all';
+
 /** Browse / list agent services. Market browse (no `agent`) is RANKED
  *  Featured → seller settled USDC → newest — not newest-first; `agent`
  *  returns that seller's full catalog (retired included, newest-first).
@@ -71,20 +101,33 @@ export async function listServices(
     agent?: string;
     query?: string;
     category?: string;
+    /** S.1084: omit = hire only (compat); 'api' = x402 routes; 'all' = both. */
+    rail?: ServicesRail;
     limit?: number;
     offset?: number;
   } = {},
-): Promise<{ total: number; services: ServiceListing[] }> {
+): Promise<{
+  total: number;
+  hireTotal?: number;
+  apiTotal?: number;
+  services: ServicesRow[];
+}> {
   const params = new URLSearchParams();
   if (filter.agent) params.set('agent', filter.agent);
   if (filter.query) params.set('q', filter.query);
   if (filter.category) params.set('category', filter.category);
+  if (filter.rail) params.set('rail', filter.rail);
   if (filter.limit !== undefined) params.set('limit', String(filter.limit));
   if (filter.offset !== undefined) params.set('offset', String(filter.offset));
   const qs = params.size > 0 ? `?${params.toString()}` : '';
   const json = await commerceFetchJson(`${base}/services${qs}`);
-  const services = (json.services ?? []) as ServiceListing[];
-  return { total: (json.total as number | undefined) ?? services.length, services };
+  const services = (json.services ?? []) as ServicesRow[];
+  return {
+    total: (json.total as number | undefined) ?? services.length,
+    hireTotal: json.hireTotal as number | undefined,
+    apiTotal: json.apiTotal as number | undefined,
+    services,
+  };
 }
 
 /** Fetch one agent's live service by slug (the buy-path resolver). */
@@ -93,7 +136,12 @@ export async function fetchService(
   agent: string,
   slug: string,
 ): Promise<ServiceListing> {
-  const { services: rows } = await listServices(base, { agent });
+  const { services } = await listServices(base, { agent });
+  // Default rail is hire-only; the kind filter keeps this hire-safe even
+  // against a future rail=all caller (S.1084: never hire a kind:"api" row).
+  const rows = services.filter(
+    (o): o is ServiceListing => o.kind !== 'api',
+  );
   const match = rows.find((o) => o.slug === slug.trim().toLowerCase());
   if (!match) {
     const live = rows.filter((o) => !o.retired).map((o) => o.slug);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -215,7 +215,12 @@ export {
   listServices,
   putJobSpec,
 } from './commerce.js';
-export type { ServiceListing } from './commerce.js';
+export type {
+  ApiRouteListing,
+  ServiceListing,
+  ServicesRail,
+  ServicesRow,
+} from './commerce.js';
 export {
   customHireEnvelope,
   isCustomHireEnvelope,


### PR DESCRIPTION
S.1084 (t2000 half) — the audric half (audric#375, /v1/services rail contract + Connect + llms.txt) is merged and live on prod; this PR makes the CLI/SDK consume it.

## SDK (`@t2000/sdk`)
- `ServiceListing` gains optional `kind?: 'hire'`; new `ApiRouteListing` (`kind:'api'` — method/path/**absolute url**/priceUsdc/summary/category/probeOk/paidCalls/paidVolumeUsdc); `ServicesRow` union + `ServicesRail`.
- `listServices` takes optional `rail` (omit = hire-only compat) and surfaces `hireTotal`/`apiTotal`. Additive — hire-only callers that omit `rail` see the same shape as before.
- `fetchService` (the buy-path resolver) filters `kind:'api'` rows structurally — hire verbs can never bind to an API row.

## CLI
- `t2 services --rail hire|api|all` (default hire); off-enum refuses in English before any fetch. API rows print `METHOD /path · pay per call`, price/call, seller (#id + address), summary, the absolute URL, and the `t2 pay <url> --estimate` handle. `t2 service list` (management view) stays hire-only.
- S.1083's omit-safe merge keeps working — its live-row read now type-narrows to hire rows.

## Docs
- cli-reference: both `t2 services` rows teach `--rail`; pay-an-api how-to finds targets via `t2 services --rail api` and carries the lock line: paid calls never move a seller's score or Proven — reputation is escrow-only.

## Live verification (prod, audric half deployed)
- default → kinds `["hire"]`, totals additive; `rail=api` → 8 routes, every row `kind:"api"` with an absolute URL; `rail=all` → total 132 = 124 hire + 8 api, hire block first; cross-block page (`offset=120&limit=10`) → exactly 4 hire then 6 api; `rail=bogus` → 400.
- Local CLI against prod prints the API rows + pay handles (screenshot-equivalent in PR run log).

SDK 306-suite + CLI 306/306 green, typechecks clean. Published-surface change → rides the next lockstep release (`minor`: new browse surface), not cut in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)