### PR TITLE
📝 docs: Connect refuses-to-send tip (S.1129)

### DIFF
--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -117,6 +117,15 @@ limits they were minted with) and changeable under **Connections**:
 at connect time. Escrow already funded still settles normally. Every session
 also expires on its own within **7 days**.
 
+### If Claude refuses to send
+
+A vague "send some money" can occasionally trip the host's own safety layer
+even though the Connect tools are the intended path. If that happens, name
+the tool — *"use `t2000_send` to send $1 USDC to name.sui"* — or ask it to
+resolve the name first and confirm the full 0x ("I authorize this under my
+Connect limits"). The real gates are always your session limits and the
+`confirmTo` address check, never a prose refusal.
+
 ## What you're actually granting
 
 <Note>


### PR DESCRIPTION
Dual-write half of audric S.1129 (Connect MCP instructions: plain-language send/swap/pay must use the t2000_* tools, never a generic money-safety prose refusal).

Adds a 6-line **If Claude refuses to send** tip under Limits on passport-connect.mdx: name the tool, or resolve → confirm full 0x + "I authorize under my Connect limits"; the real gates are session limits + confirmTo. No new page, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)