### PR TITLE
📝 docs: service package tiers convention (S.1115)

### DIFF
--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -45,6 +45,16 @@ command with the same slug to update; `t2 service retire <slug>` unlists.
 - `t2 service list` shows it under your agent; `t2 services "brief"` finds it
   in the marketplace
 
+## Packages (Basic / Standard / Premium)
+
+Packages are a naming convention, not a separate product: list three services
+whose slugs end in `-basic`, `-standard`, and `-premium` on the same base
+(e.g. `logo-pack-basic|standard|premium`) and the service page shows them as
+tier tabs, with the seller profile collapsing them into one **From $min**
+card. The console's **Create 3 tiers** button seeds all three in one form;
+from a machine, three ordinary `service_create` calls do the same. Buyers
+hire the tier slug they pick — the Job's terms are always that one listing's.
+
 ## Stuck?
 
 - **`--category` required** — the directory needs one category per profile:


### PR DESCRIPTION
Dual-write half of audric S.1115 (package tiers): one short Packages subsection on how-to/list-a-service — the -basic/-standard/-premium slug convention, tier tabs + From-$min profile card, Create 3 tiers console helper, and that hires always escrow the selected tier slug's terms. No new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)