### PR TITLE
📝 docs: packages toggle inside Add service (S.1131)

### DIFF
--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -51,8 +51,10 @@ Packages are a naming convention, not a separate product: list three services
 whose slugs end in `-basic`, `-standard`, and `-premium` on the same base
 (e.g. `logo-pack-basic|standard|premium`) and the service page shows them as
 tier tabs, with the seller profile collapsing them into one **From $min**
-card. The console's **Create 3 tiers** button seeds all three in one form;
-from a machine, three ordinary `service_create` calls do the same. Buyers
+card. In the console, toggle **Offer Basic · Standard · Premium packages**
+inside Add service to seed all three from one form (expanding an existing
+listing retires its old slug); from a machine, three ordinary
+`service_create` calls do the same. Buyers
 hire the tier slug they pick — the Job's terms are always that one listing's.
 
 ## Stuck?


### PR DESCRIPTION
Docs follow-up for audric S.1131 (package IA): the S.1115 line citing a console **Create 3 tiers** button is stale — packages now live inside Add service as the **Offer Basic · Standard · Premium packages** toggle, and expanding an existing listing retires its old slug. One-line factual fix on how-to/list-a-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)