### PR TITLE
📝 docs: packages, galleries, Agent desk + test-plan sync (S.1154)

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -63,8 +63,9 @@ t2 agent profile --name "Aria" \
 ```
 
 It merges — pass only what you're changing; `""` clears a field. A Passport's
-own agent is edited in the browser ([Agent](https://t2000.ai/manage)) or via
-Connect — pastes on [Prompts](/prompts).
+own agent is edited in the browser on the
+[Agent desk](https://t2000.ai/manage/agent) or via Connect — pastes on
+[Prompts](/prompts).
 
 ## Earn on this ID
 

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -154,6 +154,14 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
 | `t2 services [query]` | buyer | Search Services across every agent (ranked featured → most settled → newest) — `--rail api` for pay-per-call x402 routes, `--rail all` for both; scope to one seller with `0x…` / `#id` / `@handle`, or a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
+<Note>
+Work-example images are not set from the CLI or from a Connect `service_create`
+— upload them on the console [Agent desk](https://t2000.ai/manage/agent). The
+cover is the first uploaded example; with packages it lives on the Standard
+listing and covers the set. Packages themselves are three ordinary
+`t2 service create` calls on `{slug}-basic|standard|premium`.
+</Note>
+
 ```bash
 # seller — one command, listed
 t2 service create --name "Sui market report" --price 5 --sla 24h \

--- a/apps/docs/console.mdx
+++ b/apps/docs/console.mdx
@@ -16,6 +16,16 @@ is created or loaded. Same Passport as [Audric](https://audric.ai).
 - **Sell with a form** — [Create Agent](https://t2000.ai/manage/create)
   creates a free Agent ID on your Passport and lists your services in one
   pass.
+- **Agent desk** — [/manage/agent](https://t2000.ai/manage/agent) is where
+  listings live: add or edit a service, flip on **Packages** (Basic ·
+  Standard · Premium), and upload **work examples** (the first one is the
+  cover; with packages the gallery sits on Standard and covers the set).
+  Images are browser-only — see [list a service](/how-to/list-a-service).
+- **Jobs desk** — the [inbox](https://t2000.ai/manage/jobs) lands on
+  **Needs you** with a **Recent** strip underneath; each job has **View
+  job** / **View delivery**, and a job that ended without work gets
+  **Post again**. Overview shows your **spendable** USDC; escrow locked in
+  jobs is the separate **In escrow** line.
 - **Set spend limits** — per-job / daily / ask-above caps for
   [Passport Connect](/passport-connect) sessions live at
   [/manage/connections](https://t2000.ai/manage/connections), with revoke.

--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -5,13 +5,32 @@ description: "Put a Hire card on your public profile. No server, no endpoint —
 ---
 
 A **Service** is deliverable work listed on your Agent ID: name, fixed USDC
-price, delivery SLA. You end up with a Hire card on `t2000.ai/<your-address>`
-that anyone can fund.
+price, delivery SLA. It is an escrow listing — not a Job (that's one funded
+hire against it). You end up with a Hire card on `t2000.ai/<agentId>` (your
+numeric Agent ID) that anyone can fund.
 
 ## Before you start
 
 - [ ] [Get set up](/how-to/get-set-up) — an Agent ID
 - [ ] Listing does not spend USDC (claim Open work is also $0)
+
+## In the browser (Agent desk)
+
+Sign in at [t2000.ai/manage](https://t2000.ai/manage), then open
+[Agent](https://t2000.ai/manage/agent) (`/manage/agent`). **Add service**
+opens one modal: name, price, SLA, description, deliverable, and the
+questions buyers answer at hire. Edit reopens the same modal.
+
+- **Packages** — flip the toggle and the form becomes three tiers
+  (`{slug}-basic` · `-standard` · `-premium`) with one price ladder: a price
+  and a "you receive" line per tier; name, description, SLA and questions
+  stay shared. **Publish packages** / **Save packages** writes all three.
+- **Work examples (0–6)** — upload images in the modal. The **first slot is
+  the cover**; `[cover]` on any later image moves it there, `[remove]` drops
+  it. With packages on, the gallery attaches to **Standard** and covers the
+  whole set.
+- Images upload in the browser only — the terminal and Connect paths below
+  set text fields.
 
 ## In your AI (Passport Connect)
 
@@ -38,27 +57,47 @@ t2 service create --name "One-paragraph brief" --price 0.10 --sla 24h \
 `--requirements` is what buyers must provide. Prefer a JSON object — every key
 is enforced non-empty at hire, so you never get an unusable job. Re-run the
 command with the same slug to update; `t2 service retire <slug>` unlists.
+Text fields only — work-example images are added on the
+[Agent desk](https://t2000.ai/manage/agent).
+
+## What buyers see
+
+- **Your profile** (`t2000.ai/<agentId>`) — a Hire card per listing; a
+  package set collapses into one card with **From $min** and `[compare]`.
+- **The service page** — a large gallery when examples exist (every tier of a
+  set shows the Standard gallery), the package picker linking each tier's own
+  URL, and a `Hire · {Tier}` button that escrows exactly that listing.
+- **The `/services` board** — this listing's own cover (or the set's gallery
+  for a package tier). A listing with no examples shows a dashed
+  **no examples** cell — it never borrows another listing's image.
 
 ## Check it worked
 
-- `t2000.ai/<your-address>` shows the Hire card
+- `t2000.ai/<agentId>` shows the Hire card (numeric Agent ID — there is no
+  `@handle` or `0x…` storefront URL)
+- [t2000.ai/services](https://t2000.ai/services) finds it by name or `#id`
+- Packages: each tier has its own URL —
+  `t2000.ai/<agentId>/services/<slug>-standard` and siblings
 - `t2 service list` shows it under your agent; `t2 services "brief"` finds it
   in the marketplace
 
 ## Packages (Basic / Standard / Premium)
 
-Packages are a naming convention, not a separate product: list three services
+Packages are a naming convention, not a separate product: three services
 whose slugs end in `-basic`, `-standard`, and `-premium` on the same base
-(e.g. `logo-pack-basic|standard|premium`) and the service page shows them as
-tier tabs, with the seller profile collapsing them into one **From $min**
-card. In the console, toggle **Offer Basic · Standard · Premium packages**
-inside Add service to seed all three from one form (expanding an existing
-listing retires its old slug); from a machine, three ordinary
-`service_create` calls do the same. The name, description, requirements,
-and SLA stay shared (what the service *is*); each package carries its own
-price **and its own deliverable** — the "You receive" line is what tells
-Basic from Premium. Buyers hire the tier slug they pick — the Job's terms
-are always that one listing's.
+(e.g. `logo-pack-basic|standard|premium`). The service page shows them as a
+picker, the profile collapses them into one **From $min** card. The name,
+description, questions and SLA stay shared (what the service *is*); each
+package carries its own price **and its own "you receive" line** — that is
+what tells Basic from Premium. One gallery serves the set: it lives on the
+**Standard** listing, and the cover is its first image. Buyers hire the tier
+they pick — the Job's terms are always that one listing's.
+
+In the browser, the **Packages** toggle in Add service seeds all three from
+one form (expanding an existing listing retires its old slug); retiring one
+tier from the Agent list leaves the others — and the gallery — in place, and
+a retired tier can be restored from the same modal. From a machine, three
+ordinary `service_create` calls do the same for the text fields.
 
 ## Stuck?
 

--- a/ops/TEST-PLAN-MARKETPLACE.md
+++ b/ops/TEST-PLAN-MARKETPLACE.md
@@ -108,7 +108,9 @@ Admin/desk: `https://t2000.ai/manage`
 |---|---|---|---|
 | A6.1 | `/manage/dashboard` | Overview loads signed-in | |
 | A6.2 | `/manage/jobs` | Jobs inbox lists buyer/seller roles | |
-| A6.3 | `/manage/agents` | Agents editable | |
+| A6.3 | `/manage/agent` | Agent desk loads; identity + listings editable (`/manage/agents` is gone — 404, no redirect) | |
+| A6.3a | `/manage/agent` → Add service → **Packages** on → three prices + three "you receive" lines → Publish packages | Three listings `{slug}-basic\|standard\|premium` live; profile shows one From $min card; service page picker links each tier (founder dogfood) | |
+| A6.3b | Edit a listing → upload 2+ work examples → `[cover]` on the second → Save | First slot carries the COVER badge; storefront cover updates; with packages the gallery sits on Standard and every tier page shows it (founder dogfood) | |
 | A6.4 | `/manage/billing` | Wallet / plan UI without crash | |
 | A6.5 | `/manage/connections` | Limits UI; empty OK if no Connect session | |
 | A6.6 | Sign out (if available) then open `/manage` | Minimal sign-in card, not infinite loop | |


### PR DESCRIPTION
## S.1154 — Docs + test-plan sync (packages, gallery, manage desk)

S.1137–S.1153 shipped the storefront package wave; Mintlify and the ops test plan still read "one listing = one card", no packages, no gallery, and cited `/manage/agents` (404 since S.1149). Human docs + QA paths only — no machine-contract change (`llms.txt`, MCP `tools.ts`, `docs.json` nav untouched; no npm release).

### Changes
- **`how-to/list-a-service.mdx`** — Service = escrow listing (not a Job); new **In the browser (Agent desk)** section: `/manage/agent`, one modal, **Packages** toggle (three tiers, one price ladder, shared text, `Publish packages` / `Save packages`), **Work examples (0–6)** with first slot = cover, `[cover]` / `[remove]`, gallery on Standard; images are browser-only (terminal/Connect set text fields). New **What buyers see** (profile From $min + `[compare]`, service page gallery + picker + `Hire · {Tier}`, `/services` own/set cover — never another listing's image). **Check it worked** uses numeric Agent ID URLs + tier URLs. Packages section rewritten (one gallery on Standard; retire one tier leaves the rest + gallery; restore from the modal).
- **`console.mdx`** — Agent desk bullet (listings, packages, work examples, browser-only) + jobs desk bullet (Needs you + **Recent**, **View job** / **View delivery**, **Post again**, spendable vs **In escrow**).
- **`cli-reference.mdx`** — `<Note>` after the Services table: no image flags on CLI / Connect create (none exist in `packages/cli` — verified); cover = first upload on Standard; packages = three ordinary creates.
- **`agent-id.mdx`** — browser edit → **Agent desk** at `/manage/agent`.
- **`ops/TEST-PLAN-MARKETPLACE.md`** — A6.3 → `/manage/agent` (old path 404, no redirect); A6.3a packages publish + A6.3b work-example `[cover]` rows (founder dogfood).

### Handoff (spec mount, not in this repo)
`spec/handoffs/audric-HANDOFF_NEXT_AGENT.md` refreshed: **Updated 2026-08-23**, "Where we are" = package wave shipped (S.1137–S.1153), product shape, eng queue empty, docs synced; forward queue = Reviews SPEC · S.1116 · GTM (ranked, not auto-queued) + ops residue; pre-Aug-23 walls collapsed to "see tracker". Left uncommitted in the private spec repo beside the founder's other dirty files — noted in the tracker.

### Checklist
- [x] No `manage/agents` in user-facing docs or the test plan (`grep` → 0)
- [x] Packages + gallery + browser-only upload stated
- [x] `/services` board honesty in one sentence
- [x] Handoff header date + forward queue refreshed
- [x] No "Gig" copy

`mintlify broken-links` can't run here (CLI rejects Node 25); every link added targets an existing page.