### PR TITLE
✨ feat(sdk,cli): open-jobs page envelope + t2 job board --offset (S.1156.1)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -123,7 +123,7 @@ listing's own split.
 | Command | Who | What it does |
 | --- | --- | --- |
 | `t2 job open --title <t> --brief <file-or-text> --max <usdc>` | buyer | Post an opening — **escrows the budget now**. `--sla 24h` (delivery window once claimed) · `--open-for 24h` (claim window before auto-refund) · `--proven` gates claiming to agents reviewed by ≥3 distinct buyers (default: **Anyone** with an active Agent ID; claiming stays first-come, $0 under either policy). |
-| `t2 job board [query]` | anyone | Read the board — the work, budgets, status; gated rows show the claim-gate label ("Proven" / "Proven · 4★+"). `--status open\|claimed\|cancelled\|refunded`. Public, no wallet. |
+| `t2 job board [query]` | anyone | Read the board, one page at a time — the work, budgets, status; gated rows show the claim-gate label ("Proven" / "Proven · 4★+"). `--status open\|claimed\|cancelled\|refunded` · `--limit 24` (default) · `--offset <n>` (the previous page's `nextOffset`). Rows carry a one-line `briefPreview`, not the task — read the full brief at `GET /v1/open-jobs/:id` before claiming. `--json` emits the API page verbatim: `{ total, returned, truncated, nextOffset?, openJobs }`. Public, no wallet. |
 | `t2 job claim <openingId>` | Seller | First claim wins (on-chain, atomic) → a funded Job, work starts NOW. Requires an active Agent ID. Proven-gated postings preflight your on-chain score — a short score is refused in plain English before anything signs. |
 | `t2 job cancel <openingId>` | buyer | Withdraw an unclaimed opening — full refund, fee-free, any time before a claim. |
 
@@ -132,6 +132,7 @@ listing's own split.
 t2 job open --title "Logo sketch" --brief brief.md --max 5 --sla 24h
 # Seller
 t2 job board && t2 job claim <openingId>   # → a funded Job: deliver before the deadline
+t2 job board --offset 24                   # next page when the first says "Showing 1–24 of N"
 # buyer (changed your mind, still unclaimed)
 t2 job cancel <openingId>                  # → full fee-free refund
 ```

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -188,18 +188,24 @@ export function registerOpenVerbs(group: Command) {
     .argument('[query]', 'Free-text filter across titles + briefs')
     .description('Read the open board — claimable postings first (public, no wallet)')
     .option('--status <status>', 'open | claimed | cancelled | refunded', 'open')
-    .option('--limit <n>', 'Max rows (default 24)', '24')
+    .option('--limit <n>', 'Rows per page (default 24)', '24')
+    .option('--offset <n>', 'Page start — feed a page\'s nextOffset back in', '0')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(async (query: string | undefined, opts: { status: string; limit: string; api?: string }) => {
+    .action(async (query: string | undefined, opts: { status: string; limit: string; offset: string; api?: string }) => {
       try {
         const base = opts.api ?? DEFAULT_API_BASE;
-        const rows = await listOpenJobs(base, {
+        const offset = Number(opts.offset) || 0;
+        // S.1156: ONE page with honest counts — the API says what it holds
+        // (total / truncated / nextOffset); the CLI never invents a total.
+        const page = await listOpenJobs(base, {
           status: opts.status as OpenJobRow['status'] & OpenJobRow['status'],
           query,
           limit: Number(opts.limit),
+          offset,
         } as never);
+        const rows = page.openJobs;
         if (isJsonMode()) {
-          printJson({ total: rows.length, openJobs: rows });
+          printJson(page);
           return;
         }
         printBlank();
@@ -212,6 +218,12 @@ export function registerOpenVerbs(group: Command) {
           printBlank();
           return;
         }
+        if (page.truncated) {
+          printInfo(
+            `Showing ${offset + 1}–${offset + rows.length} of ${page.total} ${opts.status} jobs`,
+          );
+          printBlank();
+        }
         for (const row of rows) {
           // Surface the claim gate BEFORE anyone burns a claim attempt on it.
           const gate =
@@ -222,9 +234,11 @@ export function registerOpenVerbs(group: Command) {
             `  ${pc.bold(row.title ?? 'Untitled opening')}  ${pc.dim(`$${row.maxUsdc.toFixed(2)}`)}  ${statusColor(row.status)}${gate}` +
               (row.status === 'open' ? pc.dim(`  ${fmtLeft(row.openUntilMs)} left`) : ''),
           );
-          const brief = (row.brief ?? '').replace(/\s+/g, ' ');
-          if (brief) {
-            printLine(`    ${pc.dim(brief.length > 100 ? `${brief.slice(0, 100)}…` : brief)}`);
+          // Board rows carry a one-line preview (S.1156), never the task —
+          // the full brief is GET /v1/open-jobs/:id (`getOpenJob`).
+          const preview = (row.briefPreview ?? '').replace(/\s+/g, ' ').trim();
+          if (preview) {
+            printLine(`    ${pc.dim(preview)}`);
           }
           printLine(`    ${pc.dim(row.id)}`);
           printBlank();
@@ -232,6 +246,17 @@ export function registerOpenVerbs(group: Command) {
         printInfo(
           'Claim one: t2 job claim <id> — the budget is already escrowed; claiming starts the job.',
         );
+        if (page.nextOffset != null) {
+          // The hint reproduces the page's own filters — following it must
+          // land on the SAME board, not the default one.
+          const flags = [
+            ...(query ? [JSON.stringify(query)] : []),
+            ...(opts.status !== 'open' ? [`--status ${opts.status}`] : []),
+            ...(opts.limit !== '24' ? [`--limit ${opts.limit}`] : []),
+            `--offset ${page.nextOffset}`,
+          ];
+          printInfo(`Next page: t2 job board ${flags.join(' ')}`);
+        }
         printBlank();
       } catch (error) {
         handleError(error);

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -33,6 +33,8 @@ USDC + USDsui sends and x402 USDC payments are gasless (Sui foundation's `0x2::b
 
 The SDK also ships the **escrow-job builders** for agent-to-agent deliverable work (`t2000::a2a_escrow` on Sui mainnet): `buildCreateJobTx` / `buildDeliverJobTx` / `buildReleaseJobTx` / `buildRejectJobTx` / `buildRefundJobTx`, plus `getJob`, `jobActionsFor`, and `verifyJobForSeller`. 5% protocol fee on the seller payout at settlement; refunds fee-free.
 
+The **open board** reads are public: `listOpenJobs(base, { status, query, limit, offset })` returns ONE page — `{ total, returned, truncated, nextOffset?, openJobs }` — never a bare list, so check `truncated` before treating a page as the whole board. Board rows carry a one-line `briefPreview`, not the task; the full `brief` is on the detail read, `getOpenJob(base, id)`.
+
 ## Full reference
 
 Factory methods, full API surface, supported assets, Cetus swap routing, x402 payments, error handling, architecture →

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -225,7 +225,7 @@ export {
   refundOpenJob,
   submitJobReview,
 } from './open-jobs.js';
-export type { OpenJobFilter, OpenJobRow } from './open-jobs.js';
+export type { OpenJobFilter, OpenJobRow, OpenJobsPage } from './open-jobs.js';
 // Digest → created-object resolution (S.906 SSOT — CLI + console + Connect).
 export {
   ESCROW_JOB_TYPE_MARKER,

--- a/packages/sdk/src/open-jobs.test.ts
+++ b/packages/sdk/src/open-jobs.test.ts
@@ -13,10 +13,12 @@ import {
 const BASE = 'https://api.example.test/v1';
 const ADDRESS = `0x${'a'.repeat(64)}`;
 const OPENING_ID = `0x${'f'.repeat(64)}`;
+// S.1156: BOARD rows carry a one-line briefPreview, never `brief` — the
+// full brief lives on the detail route only.
 const ROW = {
   id: OPENING_ID,
   title: 'Logo sketch',
-  brief: 'Three concepts, PNG',
+  briefPreview: 'Three concepts, PNG',
   maxUsdc: 5,
   slaMinutes: 1440,
   status: 'open',
@@ -64,20 +66,74 @@ afterEach(() => {
 });
 
 describe('listOpenJobs / getOpenJob — public board reads', () => {
-  it('builds the query string from the filter', async () => {
-    const calls = mockFetchQueue([{ json: { openJobs: [ROW] } }]);
-    const rows = await listOpenJobs(BASE, {
+  it('builds the query string from the filter and returns the page envelope (S.1156)', async () => {
+    const calls = mockFetchQueue([
+      {
+        json: {
+          total: 544,
+          returned: 1,
+          truncated: true,
+          nextOffset: 49,
+          openJobs: [ROW],
+        },
+      },
+    ]);
+    const page = await listOpenJobs(BASE, {
       status: 'open',
       query: 'logo',
       limit: 10,
+      offset: 48,
     });
-    expect(rows).toEqual([ROW]);
-    expect(calls[0]?.url).toBe(`${BASE}/open-jobs?status=open&q=logo&limit=10`);
+    expect(page).toEqual({
+      total: 544,
+      returned: 1,
+      truncated: true,
+      nextOffset: 49,
+      openJobs: [ROW],
+    });
+    expect(page.openJobs[0]).not.toHaveProperty('brief');
+    expect(page.openJobs[0]?.briefPreview).toBe('Three concepts, PNG');
+    expect(calls[0]?.url).toBe(
+      `${BASE}/open-jobs?status=open&q=logo&limit=10&offset=48`,
+    );
   });
 
-  it('getOpenJob unwraps the row', async () => {
-    mockFetchQueue([{ json: { openJob: ROW } }]);
-    await expect(getOpenJob(BASE, OPENING_ID)).resolves.toEqual(ROW);
+  it('omits offset from the query when unset; last page is not truncated', async () => {
+    const calls = mockFetchQueue([
+      { json: { total: 1, returned: 1, truncated: false, openJobs: [ROW] } },
+    ]);
+    const page = await listOpenJobs(BASE);
+    expect(page).toEqual({
+      total: 1,
+      returned: 1,
+      truncated: false,
+      openJobs: [ROW],
+    });
+    expect(page).not.toHaveProperty('nextOffset');
+    expect(calls[0]?.url).toBe(`${BASE}/open-jobs`);
+  });
+
+  it('degraded body (no counts) → total = returned, never invented', async () => {
+    mockFetchQueue([{ json: { openJobs: [ROW, ROW] } }]);
+    await expect(listOpenJobs(BASE)).resolves.toEqual({
+      total: 2,
+      returned: 2,
+      truncated: false,
+      openJobs: [ROW, ROW],
+    });
+    mockFetchQueue([{ json: {} }]);
+    await expect(listOpenJobs(BASE)).resolves.toEqual({
+      total: 0,
+      returned: 0,
+      truncated: false,
+      openJobs: [],
+    });
+  });
+
+  it('getOpenJob unwraps the row — the detail keeps the full brief', async () => {
+    const detail = { ...ROW, brief: 'Three concepts, PNG — transparent background.' };
+    mockFetchQueue([{ json: { openJob: detail } }]);
+    await expect(getOpenJob(BASE, OPENING_ID)).resolves.toEqual(detail);
   });
 
   it('surfaces the API error message', async () => {

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -69,7 +69,12 @@ export function setSponsoredTxGuard(guard: SponsoredTxGuard | null): void {
 export interface OpenJobRow {
   id: string;
   title: string | null;
-  brief: string | null;
+  /** The full task — DETAIL-ROUTE ONLY (S.1156): present on `getOpenJob`,
+   *  absent on `listOpenJobs` rows (the board stays bounded). */
+  brief?: string | null;
+  /** One bounded line of the brief (≤140 chars) on BOARD rows — a gist for
+   *  picking which opening to read, never the task itself. */
+  briefPreview?: string | null;
   maxUsdc: number;
   slaMinutes: number;
   status: 'open' | 'claimed' | 'cancelled' | 'refunded' | 'expired';
@@ -92,21 +97,63 @@ export interface OpenJobFilter {
   query?: string;
   buyer?: string;
   limit?: number;
+  /** Page start (0-based) — feed a page's `nextOffset` back in. */
+  offset?: number;
 }
 
-/** Browse the Open board (GET /v1/open-jobs — public, no key needed). */
+/** One page of the board (S.1156) — HONEST about the rest: `total` counts
+ *  every matching opening, `returned` the rows in this page, `truncated` +
+ *  `nextOffset` say how to page. One page is never the whole board. */
+export interface OpenJobsPage {
+  total: number;
+  returned: number;
+  truncated: boolean;
+  nextOffset?: number;
+  openJobs: OpenJobRow[];
+}
+
+/** Browse the Open board (GET /v1/open-jobs — public, no key needed).
+ *  Returns the page envelope, not a bare list — read `truncated` before
+ *  treating the rows as the whole board. A degraded body (no counts)
+ *  normalizes to `total = returned`, never an invented total. */
 export async function listOpenJobs(
   base: string,
   filter: OpenJobFilter = {},
-): Promise<OpenJobRow[]> {
+): Promise<OpenJobsPage> {
   const params = new URLSearchParams();
   if (filter.status) params.set('status', filter.status);
   if (filter.query) params.set('q', filter.query);
   if (filter.buyer) params.set('buyer', filter.buyer);
   if (filter.limit) params.set('limit', String(filter.limit));
+  if (filter.offset) params.set('offset', String(filter.offset));
   const qs = params.size > 0 ? `?${params.toString()}` : '';
   const json = await fetchJson(`${base}/open-jobs${qs}`);
-  return (json.openJobs ?? []) as OpenJobRow[];
+  const openJobs = Array.isArray(json.openJobs)
+    ? (json.openJobs as OpenJobRow[])
+    : [];
+  const returned = openJobs.length;
+  const total =
+    typeof json.total === 'number' && json.total >= returned
+      ? json.total
+      : returned;
+  const startAt = filter.offset ?? 0;
+  const truncated =
+    typeof json.truncated === 'boolean'
+      ? json.truncated
+      : startAt + returned < total;
+  const nextOffset =
+    typeof json.nextOffset === 'number'
+      ? json.nextOffset
+      : truncated
+        ? startAt + returned
+        : undefined;
+  return {
+    total,
+    returned,
+    truncated,
+    ...(nextOffset === undefined ? {} : { nextOffset }),
+    openJobs,
+  };
 }
 
 /** Fetch one opening by id (0x… object id; legacy UUIDs still resolve


### PR DESCRIPTION
Parity with audric S.1156 ([#455](https://github.com/mission69b/audric/pull/455) + [#456](https://github.com/mission69b/audric/pull/456)): the API's `GET /v1/open-jobs` now returns `{ total, returned, truncated, nextOffset?, openJobs }` with `briefPreview` rows (no `brief` on the list).

**SDK** (`packages/sdk/src/open-jobs.ts`)
- `listOpenJobs(base, filter)` → `Promise<OpenJobsPage>` (breaking: was `OpenJobRow[]`; sole caller `open.ts` updated). `OpenJobFilter.offset`. Degraded body (no counts) normalizes to `total = returned`, never an invented total.
- `OpenJobRow`: `brief?` (detail-route only, JSDoc'd) + `briefPreview?`. `OpenJobsPage` exported from the index.

**CLI** (`t2 job board`)
- `--offset <n>`; default `--limit 24` (Connect page size after #456).
- `--json` → `printJson(page)` — the API page verbatim.
- Human: `Showing 49–72 of 544 claimed jobs` when truncated; `briefPreview` dim line; `Next page: t2 job board [query] [--status …] [--limit …] --offset N` reproducing the page's own filters.

**Docs**: `packages/sdk/README.md` (list vs detail brief, page envelope), `apps/docs/cli-reference.mdx` (`--offset`, JSON shape, default 24).

## Verify
- `pnpm --filter @t2000/sdk test` 581/581 (3 new cases: envelope + offset query, degraded body, detail keeps brief)
- `pnpm --filter @t2000/cli test` 306/306 (incl. docs-consistency)
- build / lint (0 errors) / typecheck clean
- Live against api.t2000.ai with the built CLI: `t2 job board --status claimed --limit 2 --json` → `total 544, truncated true, nextOffset 2`, rows have `briefPreview`, no `brief`; `--limit 24 --offset 48` → "Showing 49–72 of 544" + next-page hint. Open board is empty right now (every dogfood job claimed) → unchanged empty copy.

**No version bump / no publish** — founder runs `release.yml` after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)