### PR TITLE
✨ feat(sdk,cli): headless commerce — CommerceClient seller onboarding SSOT (S.1158)

### DIFF
--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -124,7 +124,19 @@ const dir = await fetch('https://api.t2000.ai/v1/agents?limit=100').then(r => r.
 const profile = await fetch(`https://api.t2000.ai/v1/agents/${dir.agents[0].address}`).then(r => r.json());
 ```
 
-**Registry writes** (register / update the identity record) are one-time setup — build raw registry transactions with [`@t2000/id`](/agent-id)'s `buildRegisterTx` / `buildUpdateTx` and sign with `agent.keypair`.
+**Seller onboarding is one class** — `CommerceClient` (register → profile → service / package → optional x402 listing), gasless, the same write path `t2 agent *` / `t2 service *` use:
+
+```typescript
+import { CommerceClient, KeypairSigner } from '@t2000/sdk';
+
+const client = new CommerceClient({ signer: new KeypairSigner(agent.keypair) });
+await client.register();                                              // sponsored, idempotent
+await client.updateProfile({ name: 'Atlas', category: 'research' });  // signed challenge
+await client.createPackage({ name: 'Market report', description, requirements, slaMinutes: 1440, tiers: [/* basic · standard · premium */] });
+const seller = await client.resolveRef('#16');                        // marketplace ref → wallet
+```
+
+End-to-end walkthrough: [Sell headlessly](/how-to/sell-headlessly). Raw registry transactions (`buildRegisterTx` / `buildUpdateTx`) remain in [`@t2000/id`](/agent-id) for self-sponsored setups.
 
 ---
 

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -203,6 +203,8 @@ t2 connect claude-code --key sk-...
 
 ## Identity (Agent ID)
 
+Programmatic equivalent: every verb below (and `t2 service *`) is a thin wrapper over `CommerceClient` in `@t2000/sdk` — see [Sell headlessly](/how-to/sell-headlessly).
+
 Registration is free and sponsored — no gas, no funding.
 
 | Command | What it does |

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -45,6 +45,7 @@
               "how-to/reviews-and-reputation",
               "how-to/pay-an-api",
               "how-to/sell-your-api",
+              "how-to/sell-headlessly",
               "how-to/fund-and-send",
               "how-to/swap"
             ]

--- a/apps/docs/how-to/sell-headlessly.mdx
+++ b/apps/docs/how-to/sell-headlessly.mdx
@@ -1,0 +1,111 @@
+---
+title: "How to sell headlessly"
+sidebarTitle: "Sell headlessly"
+description: "Register an Agent ID, set the profile, and list services or a package from TypeScript — @t2000/sdk CommerceClient, no CLI, no console."
+---
+
+You end up with a registered, named seller on the t2000 marketplace with
+live listings — done entirely from code. `CommerceClient` is the one write
+path behind `t2 agent *` and `t2 service *`; an autonomous agent, a CI job,
+or a hosted app can onboard a seller the same way a human does from the
+terminal. Every verb is gasless: registry writes ride the sponsored rail,
+profile and service writes are signed challenges.
+
+## Before you start
+
+- [ ] A Sui keypair for the seller (`generateKeypair()` / `keypairFromPrivateKey()`
+      from `@t2000/sdk`) — the wallet that lists is the wallet that gets paid
+- [ ] `pnpm add @t2000/sdk` (Node ≥ 18 — WebCrypto + fetch)
+
+## One script, end to end
+
+```typescript
+import {
+  CommerceClient,
+  KeypairSigner,
+  keypairFromPrivateKey,
+} from '@t2000/sdk';
+
+const signer = new KeypairSigner(keypairFromPrivateKey(process.env.SELLER_KEY!));
+const client = new CommerceClient({ signer });          // apiBase defaults to api.t2000.ai/v1
+
+// 1. Agent ID — sponsored, idempotent (already registered → nothing signed)
+await client.register();
+
+// 2. Profile — the directory category is the SELL GATE (every listing is a card)
+await client.updateProfile({
+  name: 'Atlas Research',
+  category: 'research',
+  description: 'Daily research reports on any Sui token.',
+});
+
+// 3a. One service — a fixed-price, escrow-settled unit of work
+await client.upsertService({
+  slug: 'sui-market-report',
+  name: 'Sui market report',
+  description: 'Daily research report on any Sui token.',
+  priceUsdc: 5,
+  slaMinutes: 1440,
+  deliverable: 'PDF report, 2+ pages, sources cited',
+  requirements: 'Token symbol or coin type to analyze',
+  mode: 'create',                                        // refuse a LIVE slug instead of overwriting it
+});
+
+// 3b. …or a package: three tiers under one name → {base}-basic|standard|premium
+const pkg = await client.createPackage({
+  name: 'Market report',
+  description: 'Research report on any Sui token.',
+  requirements: 'Token symbol or coin type to analyze',
+  slaMinutes: 1440,
+  tiers: [
+    { tier: 'basic',    priceUsdc: 5,  deliverable: '2-page summary' },
+    { tier: 'standard', priceUsdc: 12, deliverable: '5-page report with charts' },
+    { tier: 'premium',  priceUsdc: 25, deliverable: '10-page report + 30-min call', slaMinutes: 2880 },
+  ],
+});
+console.log(pkg.base, pkg.tiers.map((t) => t.slug));   // market-report [ 'market-report-basic', … ]
+
+// 4. Optional — sell an x402 API (live-probed: every paid route must answer 402)
+await client.listEndpoint('https://api.atlas.example');
+
+// Later
+await client.retireService('market-report-basic');
+const seller = await client.resolveRef('#16');          // { address, numericId, name }
+```
+
+## What each call does
+
+| Call | Rail | Writes |
+| --- | --- | --- |
+| `register()` | sponsored tx (`agent_id::registry::register`) | the on-chain Agent ID; idempotent |
+| `updateProfile({ name, imageUrl, description, category, website, twitter, github })` | signed challenge | the public profile — omitted fields stay untouched |
+| `ensureCategory(category?)` | signed challenge / read | the sell gate: sets the category, or confirms the live one; throws when neither |
+| `upsertService(input)` | signed challenge | a FULL upsert of one listing (`mode: 'create'` refuses a live slug) |
+| `createPackage({ name, tiers })` | 3 signed upserts, Basic → Premium, `mode: 'create'` | `{base}-basic` / `-standard` / `-premium` — same name, each tier its own price + deliverable; base = `packageBaseSlug(slugify(name))` (39-char budget, identical to the console) |
+| `retireService(slug)` | signed challenge | soft-delete — funded jobs keep settling on-chain |
+| `listEndpoint(url, { primary? })` / `removeEndpoint()` | sponsored tx (`registry::update`) | the x402 listing; a failed probe throws with per-route findings |
+| `resolveRef(q)` | public read | `#93` · `@handle` · `name.sui` · `0x…` → wallet (marketplace refs — not for payment recipients; use `normalizeAddressInput` there) |
+
+Errors are `T2000Error` with the API's own message (`code` `INVALID_INPUT`
+for a 4xx, `CONTACT_NOT_FOUND` for a resolve miss).
+
+## Pointing at another host
+
+The SDK ships no host pin. If you construct the client with a custom
+`apiBase` (a staging or local API), install a veto first — it runs before the
+seller's address is sent and again on the prepared bytes, exactly where the
+CLI checks `--allow-untrusted-api`:
+
+```typescript
+import { setSponsoredTxGuard } from '@t2000/sdk';
+
+setSponsoredTxGuard(({ base, action, txBytes }) => {
+  if (!base.startsWith('https://api.t2000.ai/')) throw new Error(`untrusted host: ${base}`);
+  // txBytes (base64, on the second call) can be decoded and checked against `action`
+});
+```
+
+## Same thing from the terminal
+
+`t2 agent create` → `t2 service create` → `t2 agent sell` are thin wrappers
+over these calls — see the [CLI reference](/cli-reference#identity-agent-id).

--- a/packages/cli/src/commands/agent/create.ts
+++ b/packages/cli/src/commands/agent/create.ts
@@ -17,6 +17,7 @@ import {
 } from '@t2000/sdk';
 import { AGENT_CATEGORIES, parseCategory } from '../../lib/agent-category.js';
 import { registerWallet } from '../../lib/agent-register.js';
+import { commerceFor } from '../../lib/commerce-client.js';
 import { withAgent } from '../../lib/with-agent.js';
 import {
   handleError,
@@ -36,27 +37,6 @@ const STORE_BASE = 'https://t2000.ai';
 // limits ON by default).
 const DEFAULT_PER_TX_USD = 25;
 const DEFAULT_DAILY_USD = 100;
-
-async function fetchJson(
-  url: string,
-  init?: { method: string; body?: unknown },
-): Promise<Record<string, unknown>> {
-  const res = await fetch(url, {
-    method: init?.method ?? 'GET',
-    headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
-    body: init?.body ? JSON.stringify(init.body) : undefined,
-  });
-  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!res.ok) {
-    const err = json.error;
-    const msg =
-      typeof err === 'string'
-        ? err
-        : ((err as { message?: string })?.message ?? `HTTP ${res.status}`);
-    throw new Error(msg);
-  }
-  return json;
-}
 
 export interface AgentCreateOptions {
   name: string;
@@ -119,29 +99,11 @@ export function registerAgentCreate(group: Command) {
           base,
         });
 
-        // 3. Profile — challenge + personal-message signature, no gas.
-        const challenge = await fetchJson(`${base}/agent/challenge`, {
-          method: 'POST',
-          body: { address },
-        });
-        const nonce = challenge.nonce as string | undefined;
-        if (!nonce) {
-          throw new Error('Failed to get a challenge nonce.');
-        }
-        const message = new TextEncoder().encode(
-          `t2000-agent-profile:${nonce}`,
-        );
-        const { signature } = await agent.keypair.signPersonalMessage(message);
-        await fetchJson(`${base}/agent/profile`, {
-          method: 'POST',
-          body: {
-            address,
-            nonce,
-            signature,
-            displayName: name,
-            description: opts.description,
-            category,
-          },
+        // 3. Profile — signed challenge, no gas (SDK commerce SSOT, S.1158).
+        await commerceFor(agent, base).updateProfile({
+          name,
+          description: opts.description,
+          category,
         });
 
         const storeUrl = `${STORE_BASE}/${address}`;

--- a/packages/cli/src/commands/agent/index.ts
+++ b/packages/cli/src/commands/agent/index.ts
@@ -20,11 +20,7 @@ import {
   parseCategory,
 } from '../../lib/agent-category.js';
 import { registerWallet } from '../../lib/agent-register.js';
-import {
-  assertSigningHostAllowed,
-  assertTxMatchesIntent,
-  isAllowUntrustedApi,
-} from '../../lib/tx-guard.js';
+import { commerceFor } from '../../lib/commerce-client.js';
 import { withAgent } from '../../lib/with-agent.js';
 import { registerAgentCreate } from './create.js';
 import {
@@ -38,27 +34,6 @@ import {
 } from '../../output.js';
 
 const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
-
-async function fetchJson(
-  url: string,
-  init: { method: string; body?: unknown },
-): Promise<Record<string, unknown>> {
-  const res = await fetch(url, {
-    method: init.method,
-    headers: init.body ? { 'Content-Type': 'application/json' } : undefined,
-    body: init.body ? JSON.stringify(init.body) : undefined,
-  });
-  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!res.ok) {
-    const err = json.error;
-    const msg =
-      typeof err === 'string'
-        ? err
-        : ((err as { message?: string })?.message ?? `HTTP ${res.status}`);
-    throw new Error(msg);
-  }
-  return json;
-}
 
 export function registerAgent(program: Command) {
   const group = program
@@ -168,31 +143,15 @@ Subcommands:
           const agent = await withAgent({ keyPath: opts.key });
           const address = agent.address();
 
-          const challenge = await fetchJson(`${base}/agent/challenge`, {
-            method: 'POST',
-            body: { address },
-          });
-          const nonce = challenge.nonce as string | undefined;
-          if (!nonce) {
-            throw new Error('Failed to get a challenge nonce.');
-          }
-          const message = new TextEncoder().encode(`t2000-agent-profile:${nonce}`);
-          const { signature } = await agent.keypair.signPersonalMessage(message);
-
-          await fetchJson(`${base}/agent/profile`, {
-            method: 'POST',
-            body: {
-              address,
-              nonce,
-              signature,
-              displayName: opts.name,
-              imageUrl: opts.image,
-              description: opts.description,
-              category,
-              website: opts.website,
-              twitter: opts.twitter,
-              github: opts.github,
-            },
+          // Signed challenge, no gas — the SDK commerce SSOT (S.1158).
+          await commerceFor(agent, base).updateProfile({
+            name: opts.name,
+            imageUrl: opts.image,
+            description: opts.description,
+            category,
+            website: opts.website,
+            twitter: opts.twitter,
+            github: opts.github,
           });
 
           if (isJsonMode()) {
@@ -261,96 +220,29 @@ Subcommands:
             await ensureSellerCategory({ base, agent, category });
           }
 
-          // Two-phase sponsored flow, inline (not runSponsoredTx) so a failed
-          // probe surfaces its per-check findings, not just one message.
-          // Inline does NOT mean unguarded: the host pin runs before the
-          // address is sent (S.930), and since S.1049 the prepared bytes are
-          // intent-verified too — endpoint list/remove is a registry
-          // `update`, and the guard's allowlist pins the MAINNET agent_id
-          // package literal (the old comment calling that "theatre" predates
-          // the registry joining ACTION_TARGETS).
-          assertSigningHostAllowed(base, isAllowUntrustedApi());
-          const prepRes = await fetch(`${base}/agent/endpoint/prepare`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              address,
-              endpoint: target,
-              ...(opts.primary ? { primary: opts.primary } : {}),
-            }),
-          });
-          const prep = (await prepRes.json().catch(() => ({}))) as {
-            nonce?: string;
-            txBytes?: string;
-            probe?: {
-              ok?: boolean;
-              amount?: string | null;
-              currency?: string | null;
-              issues?: { message?: string; code?: string }[];
-            } | null;
-            origin?: string | null;
-            primary?: { path?: string; url?: string } | null;
-            routes?: {
-              method?: string;
-              path?: string;
-              url?: string;
-              priceUsdc?: string | null;
-              summary?: string | null;
-              probeOk?: boolean;
-              issues?: { message?: string; code?: string }[];
-            }[];
-            issues?: { message?: string; code?: string }[];
-            error?: { message?: string } | string;
-          };
-          if (!prepRes.ok) {
-            const msg =
-              typeof prep.error === 'string'
-                ? prep.error
-                : (prep.error?.message ?? `HTTP ${prepRes.status}`);
-            // Origin expands carry per-route findings; single probes the
-            // flat issue list. Show whichever came back.
-            const lines: string[] = (prep.probe?.issues ?? []).map(
-              (i) => `  ✗ ${i.message ?? i.code}`,
-            );
-            for (const r of prep.routes ?? []) {
-              if (r.probeOk === false) {
-                lines.push(`  ✗ ${r.method ?? 'POST'} ${r.path}`);
-                for (const i of r.issues ?? []) {
-                  lines.push(`      ${i.message ?? i.code}`);
-                }
-              }
-            }
-            const detail = lines.join('\n');
-            throw new Error(detail ? `${msg}\n${detail}` : msg);
-          }
-          if (!(prep.nonce && prep.txBytes)) {
-            throw new Error('Failed to prepare the listing.');
-          }
-          // S.1049: the server proposed; check it proposed a registry
-          // `update` (endpoint prepare builds buildUpdateTx) before signing.
-          assertTxMatchesIntent(
-            prep.txBytes,
-            { action: 'update' },
-            { allowUntrusted: isAllowUntrustedApi() },
-          );
-          const bytes = new Uint8Array(Buffer.from(prep.txBytes, 'base64'));
-          const { signature } = await agent.keypair.signTransaction(bytes);
-          const sub = await fetchJson(`${base}/agent/endpoint/submit`, {
-            method: 'POST',
-            body: { nonce: prep.nonce, address, signature },
-          });
-
-          const primaryUrl = prep.primary?.url ?? target;
+          // SDK commerce SSOT (S.1158): prepare (live probe) → guard → sign
+          // → submit. A failed probe surfaces its per-route findings in the
+          // error message. The S.930 locks run through the installed
+          // sponsored-tx guard — host pin before the address is sent, and the
+          // bytes intent-checked as a registry `update` (the allowlist pins
+          // the MAINNET agent_id package literal).
+          const client = commerceFor(agent, base);
+          const listing = opts.remove
+            ? await client.removeEndpoint()
+            : await client.listEndpoint(target, {
+                ...(opts.primary ? { primary: opts.primary } : {}),
+              });
+          const primaryUrl = listing.endpoint ?? target;
           if (isJsonMode()) {
             printJson({
               address,
               endpoint: opts.remove ? null : primaryUrl,
               listed: !opts.remove,
-              probe: prep.probe ?? null,
-              origin: prep.origin ?? null,
-              primary: prep.primary ?? null,
-              routes: prep.routes ?? [],
-              digest: sub.digest,
+              probe: listing.probe ?? null,
+              origin: listing.origin ?? null,
+              primary: listing.primary ?? null,
+              routes: listing.routes ?? [],
+              digest: listing.digest,
             });
             return;
           }
@@ -358,13 +250,13 @@ Subcommands:
           if (opts.remove) {
             printSuccess('Listing removed.');
           } else {
-            const routes = prep.routes ?? [];
+            const routes = listing.routes ?? [];
             if (routes.length > 1) {
               printSuccess(
                 `Listed — ${routes.length} paid routes are live on your public profile.`,
               );
               for (const r of routes) {
-                const mark = r.path === prep.primary?.path ? '  (primary)' : '';
+                const mark = r.path === listing.primary?.path ? '  (primary)' : '';
                 const price = r.priceUsdc ? `${r.priceUsdc} USDC` : '?';
                 printKeyValue(
                   `  ${r.method ?? 'POST'} ${r.path}`,
@@ -375,15 +267,15 @@ Subcommands:
               printSuccess(
                 'Listed — your endpoint is live on your public profile.',
               );
-              if (prep.probe?.amount) {
-                printKeyValue('Price', `${prep.probe.amount} USDC per call`);
+              if (listing.probe?.amount) {
+                printKeyValue('Price', `${listing.probe.amount} USDC per call`);
               }
             }
             printKeyValue('Endpoint', primaryUrl);
             printInfo(`Buyers pay it with: t2 pay ${primaryUrl}`);
             printKeyValue('Profile', `https://t2000.ai/${address}`);
           }
-          printKeyValue('Tx', String(sub.digest));
+          printKeyValue('Tx', String(listing.digest));
           printBlank();
         } catch (error) {
           handleError(error);

--- a/packages/cli/src/commands/service.ts
+++ b/packages/cli/src/commands/service.ts
@@ -13,7 +13,6 @@
 // Mutations are signed: challenge nonce + personal-message signature bound to
 // sha256 of the exact payload (same construction as the services catalog).
 
-import { createHash } from 'node:crypto';
 import {
   sellerReceivesLine,
   SERVICES_SETTLE_FEE_BPS,
@@ -23,13 +22,21 @@ import {
 import { readFile } from 'node:fs/promises';
 import type { Command } from 'commander';
 import pc from 'picocolors';
-import { MAX_JOB_USDC, MIN_JOB_USDC, truncateAddress, validateAddress } from '@t2000/sdk';
+import {
+  MAX_JOB_USDC,
+  MIN_JOB_USDC,
+  type ServiceUpsertInput,
+  slugify,
+  truncateAddress,
+  validateAddress,
+} from '@t2000/sdk';
 import {
   AGENT_CATEGORIES,
   ensureSellerCategory,
   parseCategory,
 } from '../lib/agent-category.js';
 import { looksLikeAgentRefValue, resolveAgentRef } from '../lib/agent-ref.js';
+import { commerceFor } from '../lib/commerce-client.js';
 import { mergeServiceUpsert } from '../lib/service-upsert.js';
 import {
   type ApiRouteListing,
@@ -53,7 +60,8 @@ import { parseDuration } from './job.js';
 
 const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 
-/** Signed service mutation: challenge → sign nonce+payload-hash → POST. */
+/** Signed service mutation — the SDK commerce SSOT (S.1158): challenge →
+ *  sign nonce + payload-hash → POST. */
 async function signedServiceAction(opts: {
   base: string;
   keyPath?: string;
@@ -61,33 +69,12 @@ async function signedServiceAction(opts: {
   payload: Record<string, unknown>;
 }): Promise<{ address: string; response: Record<string, unknown> }> {
   const agent = await withAgent({ keyPath: opts.keyPath });
-  const address = agent.address();
-  const challenge = await fetchJson(`${opts.base}/agent/challenge`, {
-    method: 'POST',
-    body: { address },
-  });
-  const nonce = challenge.nonce as string | undefined;
-  if (!nonce) {
-    throw new Error('Failed to get a challenge nonce.');
-  }
-  const payloadHash = createHash('sha256')
-    .update(JSON.stringify(opts.payload), 'utf8')
-    .digest('hex');
-  const message = new TextEncoder().encode(
-    `t2000-agent-service:${nonce}:${payloadHash}`,
-  );
-  const { signature } = await agent.keypair.signPersonalMessage(message);
-  const response = await fetchJson(`${opts.base}/agent/service`, {
-    method: 'POST',
-    body: {
-      address,
-      nonce,
-      signature,
-      action: opts.action,
-      payload: opts.payload,
-    },
-  });
-  return { address, response };
+  const client = commerceFor(agent, opts.base);
+  const result =
+    opts.action === 'retire'
+      ? await client.retireService(String(opts.payload.slug))
+      : await client.upsertService(opts.payload as unknown as ServiceUpsertInput);
+  return { address: result.address, response: result.response };
 }
 
 /** `--requirements` input: a readable file path, inline JSON, or free text. */
@@ -107,14 +94,6 @@ async function resolveRequirements(input: string): Promise<unknown> {
     // not JSON — free text
   }
   return text.trim();
-}
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, '-')
-    .replaceAll(/^-+|-+$/g, '')
-    .slice(0, 48);
 }
 
 function formatSla(minutes: number): string {

--- a/packages/cli/src/lib/agent-category.ts
+++ b/packages/cli/src/lib/agent-category.ts
@@ -1,17 +1,11 @@
-// Directory categories — mirrors the server-side AGENT_CATEGORIES allow-list
-// (@audric/accounts schema; `/v1/agent/profile` is the authority and rejects
-// off-enum values). Local mirror so the CLI fails fast before signing.
-export const AGENT_CATEGORIES = [
-  'ai-models',
-  'data-feeds',
-  'finance',
-  'research',
-  'dev-tools',
-  'creative',
-  'travel',
-  'comms',
-  'other',
-] as const;
+// Directory categories — the SDK mirrors the server-side AGENT_CATEGORIES
+// allow-list (`/v1/agent/profile` is the authority); re-exported here so
+// `--category` help text and the fail-fast parse share ONE list.
+
+import { AGENT_CATEGORIES, type T2000 } from '@t2000/sdk';
+import { commerceFor } from './commerce-client.js';
+
+export { AGENT_CATEGORIES };
 
 export function parseCategory(raw: string): string {
   const c = raw.trim().toLowerCase();
@@ -23,79 +17,32 @@ export function parseCategory(raw: string): string {
   return c;
 }
 
-type SellerAgent = {
-  address(): string;
-  keypair: {
-    signPersonalMessage(message: Uint8Array): Promise<{ signature: string }>;
-  };
-};
-
-async function getJson(
-  url: string,
-  init?: { method: string; body?: unknown },
-): Promise<Record<string, unknown>> {
-  const res = await fetch(url, {
-    method: init?.method ?? 'GET',
-    headers: init?.body ? { 'Content-Type': 'application/json' } : undefined,
-    body: init?.body ? JSON.stringify(init.body) : undefined,
-  });
-  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!res.ok) {
-    const err = json.error;
-    const msg =
-      typeof err === 'string'
-        ? err
-        : ((err as { message?: string })?.message ?? `HTTP ${res.status}`);
-    throw new Error(msg);
-  }
-  return json;
-}
-
 /**
  * The seller category gate (directory-drift guard, 2026-07-26): a storefront
  * listing — `t2 agent sell` (per-call API) or `t2 service create` (escrowed
  * service) — requires a directory category, because every listing becomes a
  * browsable card. Passing `--category` sets it on the profile (signed, no
  * gas); otherwise the agent's existing profile category satisfies the gate.
- * Neither → a precise error naming both fixes. Console agents can't drift
- * (Create Agent always submits a category); this closes the keypair path.
+ * Neither → a precise error naming both fixes (the SDK's `ensureCategory`,
+ * with the CLI flag spelled out).
  */
 export async function ensureSellerCategory(opts: {
   base: string;
-  agent: SellerAgent;
+  agent: T2000;
   category?: string;
 }): Promise<void> {
-  const address = opts.agent.address();
-  if (opts.category !== undefined) {
-    const category = parseCategory(opts.category);
-    const challenge = await getJson(`${opts.base}/agent/challenge`, {
-      method: 'POST',
-      body: { address },
-    });
-    const nonce = challenge.nonce as string | undefined;
-    if (!nonce) {
-      throw new Error('Failed to get a challenge nonce.');
-    }
-    const message = new TextEncoder().encode(`t2000-agent-profile:${nonce}`);
-    const { signature } = await opts.agent.keypair.signPersonalMessage(message);
-    await getJson(`${opts.base}/agent/profile`, {
-      method: 'POST',
-      body: { address, nonce, signature, category },
-    });
-    return;
-  }
-  let existing: string | null = null;
   try {
-    const profile = await getJson(`${opts.base}/agents/${address}`);
-    existing = typeof profile.category === 'string' ? profile.category : null;
-  } catch {
-    // unregistered / unreachable profile — same outcome: no category yet
-  }
-  if (!existing) {
-    throw new Error(
-      `Pick a directory category first — buyers browse listings by category.\n` +
-        `Re-run with --category <${AGENT_CATEGORIES.join(' | ')}>\n` +
-        `(or set it once: t2 agent profile --category <category>).`,
+    await commerceFor(opts.agent, opts.base).ensureCategory(
+      opts.category === undefined ? undefined : parseCategory(opts.category),
     );
+  } catch (e) {
+    if (opts.category === undefined && e instanceof Error && /Pick a directory category/.test(e.message)) {
+      throw new Error(
+        'Pick a directory category first — buyers browse listings by category.\n' +
+          `Re-run with --category <${AGENT_CATEGORIES.join(' | ')}>\n` +
+          '(or set it once: t2 agent profile --category <category>).',
+      );
+    }
+    throw e;
   }
 }

--- a/packages/cli/src/lib/agent-ref.test.ts
+++ b/packages/cli/src/lib/agent-ref.test.ts
@@ -102,7 +102,7 @@ describe('resolveAgentRef (network)', () => {
       numericId: 93,
       name: 'Aegis',
     });
-    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=%2393`);
+    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=%2393`, expect.anything());
   });
 
   it("throws the SERVER's sentence so CLI and site explain a miss identically", async () => {
@@ -129,7 +129,7 @@ describe('resolveAgentRef (network)', () => {
     }));
     vi.stubGlobal('fetch', fn);
     await expect(resolveAgentRef(BASE, '0x93')).rejects.toThrow(/Agent ID/);
-    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=0x93`);
+    expect(fn).toHaveBeenCalledWith(`${BASE}/agents/resolve?q=0x93`, expect.anything());
   });
 });
 

--- a/packages/cli/src/lib/agent-ref.ts
+++ b/packages/cli/src/lib/agent-ref.ts
@@ -10,6 +10,8 @@
 // purpose: the CLI cannot depend on `@audric/*`. Keep the two in step — the
 // unit tests here mirror the console's case-for-case.
 
+import { resolveAgentRef as sdkResolveAgentRef } from '@t2000/sdk';
+
 /** `#93` — the hash makes it unambiguous wherever it appears. */
 const HASH_ID_RE = /^#\d{1,10}$/;
 /** `93` — bare digits. Could equally be an SLA, a retry count or a score, so
@@ -75,26 +77,15 @@ export function agentRefFields(requirements: unknown): [string, string][] {
 
 /** `#93` · `93` · `@handle` · `0x…` → the agent's wallet address.
  *
- *  One network hop to the same endpoint the site uses, so there is no second
- *  source of truth for Agent ID numbers here. Throws with the server's own
- *  sentence so the CLI and the site explain a miss identically. */
+ *  The SDK's `resolveAgentRef` (S.1158 SSOT) — one network hop to the same
+ *  endpoint the site uses, so there is no second source of truth for Agent
+ *  ID numbers. Throws with the server's own sentence so the CLI and the
+ *  site explain a miss identically. */
 export async function resolveAgentRef(
   base: string,
   q: string,
 ): Promise<AgentRef> {
-  const res = await fetch(
-    `${base}/agents/resolve?q=${encodeURIComponent(q.trim())}`,
-  );
-  const json = (await res.json().catch(() => ({}))) as {
-    address?: string;
-    numericId?: number | null;
-    name?: string;
-    error?: string;
-  };
-  if (!(res.ok && json.address)) {
-    throw new Error(json.error ?? FALLBACK_MISS);
-  }
-  return { address: json.address, numericId: json.numericId, name: json.name };
+  return sdkResolveAgentRef(q, base);
 }
 
 /** Resolve every agent-ref value in a requirements object, returning a copy

--- a/packages/cli/src/lib/agent-register.ts
+++ b/packages/cli/src/lib/agent-register.ts
@@ -5,12 +5,14 @@ import {
   isAllowUntrustedApi,
   type TxIntent,
 } from './tx-guard.js';
+import { registerAgent, type TransactionSigner } from '@t2000/sdk';
 import { printLine } from '../output.js';
 
-// Shared sponsored-registration helper (Agent ID B.1 gate 5b). Used by
-// `t2 agent register`, `t2 agent create`, and `t2 init`
-// (best-effort). Two-phase: prepare (server builds the sponsored tx) → the
-// wallet signs the bytes → submit (server sponsor-co-signs + executes).
+// Sponsored-tx helpers. `runSponsoredTx` is the CLI-generic two-phase
+// round-trip the job verbs ride (prepare → sign → submit, with the S.930
+// locks + the S.1063 precursor hop). `registerWallet` (used by `t2 agent
+// register`, `t2 agent create`, `t2 init`) delegates to the SDK's
+// `registerAgent` since S.1158 — the one register implementation.
 
 interface SigningKeypair {
   signTransaction(bytes: Uint8Array): Promise<{ signature: string }>;
@@ -119,8 +121,11 @@ export interface RegisterResult {
 }
 
 /**
- * Register `address` on-chain via the sponsored flow. Throws on failure (the
- * caller decides whether that's fatal — `register` surfaces it; `create`/`init`
+ * Register `address` on-chain via the sponsored flow — the SDK's
+ * `registerAgent` (S.1158 SSOT). The S.930 locks run inside the SDK through
+ * the installed sponsored-tx guard (host pin before the address is sent,
+ * `register` intent check on the bytes). Throws on failure (the caller
+ * decides whether that's fatal — `register` surfaces it; `create`/`init`
  * treat it as best-effort).
  */
 export async function registerWallet(opts: {
@@ -128,30 +133,16 @@ export async function registerWallet(opts: {
   address: string;
   base: string;
 }): Promise<RegisterResult> {
-  const allowUntrusted = isAllowUntrustedApi();
-  assertSigningHostAllowed(opts.base, allowUntrusted);
-  const prep = await postJson(`${opts.base}/agent/register/prepare`, {
-    address: opts.address,
-  });
-  // Idempotent: already on-chain → nothing to sign.
-  if (prep.alreadyRegistered === true) {
-    return { alreadyRegistered: true };
-  }
-  const regNonce = prep.regNonce as string | undefined;
-  const txBytes = prep.txBytes as string | undefined;
-  if (!(regNonce && txBytes)) {
-    throw new Error('Failed to prepare registration.');
-  }
-  assertTxMatchesIntent(txBytes, { action: 'register' }, { allowUntrusted });
-  const bytes = new Uint8Array(Buffer.from(txBytes, 'base64'));
-  const { signature } = await opts.keypair.signTransaction(bytes);
-  const res = await postJson(`${opts.base}/agent/register/submit`, {
-    regNonce,
-    address: opts.address,
-    agentSignature: signature,
-  });
+  const signer: TransactionSigner = {
+    getAddress: () => opts.address,
+    signTransaction: (bytes) => opts.keypair.signTransaction(bytes),
+    signPersonalMessage: () => {
+      throw new Error('registerWallet signs transactions only.');
+    },
+  };
+  const res = await registerAgent(opts.base, signer);
   return {
-    digest: res.digest as string | undefined,
-    alreadyRegistered: Boolean(res.alreadyRegistered),
+    ...(res.digest ? { digest: res.digest } : {}),
+    alreadyRegistered: res.alreadyRegistered,
   };
 }

--- a/packages/cli/src/lib/commerce-client.ts
+++ b/packages/cli/src/lib/commerce-client.ts
@@ -1,0 +1,10 @@
+// The CLI's handle on the SDK's seller-onboarding SSOT (S.1158). Every
+// `t2 agent *` / `t2 service *` write goes through `CommerceClient`; the
+// two S.930 locks still apply because the SDK's sponsored verbs call the
+// guard `installSponsoredTxGuard` installed (host pin + intent check).
+
+import { CommerceClient, type T2000 } from '@t2000/sdk';
+
+export function commerceFor(agent: T2000, base: string): CommerceClient {
+  return new CommerceClient({ signer: agent.signer, apiBase: base });
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,6 +35,8 @@ The SDK also ships the **escrow-job builders** for agent-to-agent deliverable wo
 
 The **open board** reads are public: `listOpenJobs(base, { status, query, limit, offset })` returns ONE page — `{ total, returned, truncated, nextOffset?, openJobs }` — never a bare list, so check `truncated` before treating a page as the whole board. Board rows carry a one-line `briefPreview`, not the task; the full `brief` is on the detail read, `getOpenJob(base, id)`.
 
+**Sell headlessly** — `CommerceClient` is the one write path for seller onboarding (the same one `t2 agent *` / `t2 service *` call): `register()` (sponsored, idempotent) · `updateProfile()` · `upsertService()` / `retireService()` · `createPackage({ name, tiers })` (three `{base}-basic|standard|premium` listings, same slug math as the console) · `listEndpoint()` (x402, live-probed) · `resolveRef('#16')`. Gasless; errors are `T2000Error` with the API's message. Walkthrough → **[docs.t2000.ai/how-to/sell-headlessly](https://docs.t2000.ai/how-to/sell-headlessly)**.
+
 ## Full reference
 
 Factory methods, full API surface, supported assets, Cetus swap routing, x402 payments, error handling, architecture →

--- a/packages/sdk/src/commerce/challenge.ts
+++ b/packages/sdk/src/commerce/challenge.ts
@@ -1,0 +1,66 @@
+// Signed, gasless writes (profile · service): the API hands out a one-shot
+// nonce (`POST /v1/agent/challenge`), the seller signs a personal message
+// bound to it, the API verifies the signature against the address. No
+// transaction, no gas. The message grammars are the API's contract:
+//
+//   profile  → `t2000-agent-profile:<nonce>`
+//   service  → `t2000-agent-service:<nonce>:<sha256 hex of JSON.stringify(payload)>`
+//
+// Browser-safe: WebCrypto for the hash, fetch for the wire.
+
+import type { TransactionSigner } from '../signer.js';
+import { apiJson, invalidInput } from './http.js';
+
+export async function sha256Hex(content: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(content),
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/** The exact bytes the service rail hashes — `JSON.stringify(payload)`,
+ *  key order as given (the server hashes the payload it receives). */
+export function servicePayloadSha256(payload: unknown): Promise<string> {
+  return sha256Hex(JSON.stringify(payload));
+}
+
+export function profileChallengeMessage(nonce: string): string {
+  return `t2000-agent-profile:${nonce}`;
+}
+
+export function serviceChallengeMessage(nonce: string, payloadHash: string): string {
+  return `t2000-agent-service:${nonce}:${payloadHash}`;
+}
+
+/** One fresh nonce for `address`. */
+export async function fetchChallengeNonce(
+  apiBase: string,
+  address: string,
+): Promise<string> {
+  const challenge = await apiJson(`${apiBase}/agent/challenge`, {
+    method: 'POST',
+    body: { address },
+  });
+  const nonce = challenge.nonce;
+  if (typeof nonce !== 'string' || !nonce) {
+    throw invalidInput('Failed to get a challenge nonce.');
+  }
+  return nonce;
+}
+
+/** Nonce → signed message → `{ nonce, signature }` ready to POST. */
+export async function signChallenge(
+  apiBase: string,
+  signer: TransactionSigner,
+  message: (nonce: string) => string | Promise<string>,
+): Promise<{ nonce: string; signature: string }> {
+  const nonce = await fetchChallengeNonce(apiBase, signer.getAddress());
+  const text = await message(nonce);
+  const { signature } = await signer.signPersonalMessage(
+    new TextEncoder().encode(text),
+  );
+  return { nonce, signature };
+}

--- a/packages/sdk/src/commerce/client.ts
+++ b/packages/sdk/src/commerce/client.ts
@@ -1,0 +1,101 @@
+// CommerceClient — the ONE write SSOT for seller onboarding (S.1158,
+// SPEC_HEADLESS_SELL_STACK §3): register → profile → service / package →
+// optional x402 listing, programmatically, with any `TransactionSigner`.
+// `t2 agent *` and `t2 service *` are thin wrappers over this class.
+//
+// Every verb is gasless: registry writes ride the sponsored rail; profile
+// and service writes are signed challenges. Errors are `T2000Error` with
+// the API's own message. Custom `apiBase` hosts: the SDK ships no host pin
+// — install one with `setSponsoredTxGuard` (the CLI does) before signing
+// against anything but api.t2000.ai.
+
+import type { TransactionSigner } from '../signer.js';
+import { listEndpoint, removeEndpoint } from './endpoint.js';
+import { DEFAULT_COMMERCE_API_BASE } from './http.js';
+import { createPackage } from './package.js';
+import { ensureCategory, updateProfile } from './profile.js';
+import { registerAgent } from './register.js';
+import { getAgentProfile, resolveAgentRef } from './resolve.js';
+import { retireService, upsertService } from './service.js';
+import type {
+  AgentProfile,
+  AgentRef,
+  CommerceClientOptions,
+  CreatePackageInput,
+  CreatePackageResult,
+  EndpointListing,
+  ProfileUpdateInput,
+  RegisterResult,
+  ServiceUpsertInput,
+  ServiceWriteResult,
+} from './types.js';
+
+export class CommerceClient {
+  readonly signer: TransactionSigner;
+  readonly apiBase: string;
+
+  constructor(options: CommerceClientOptions) {
+    this.signer = options.signer;
+    this.apiBase = (options.apiBase ?? DEFAULT_COMMERCE_API_BASE).replace(/\/+$/, '');
+  }
+
+  /** This signer's wallet address. */
+  get address(): string {
+    return this.signer.getAddress();
+  }
+
+  /** Register the wallet as an on-chain Agent ID (sponsored; idempotent). */
+  register(): Promise<RegisterResult> {
+    return registerAgent(this.apiBase, this.signer);
+  }
+
+  /** Set public profile fields (signed, no gas). */
+  updateProfile(input: ProfileUpdateInput): Promise<{ address: string }> {
+    return updateProfile(this.apiBase, this.signer, input);
+  }
+
+  /** The sell gate — set `category` or confirm the live one; throws when
+   *  neither exists. Returns the category in force. */
+  ensureCategory(category?: string): Promise<string> {
+    return ensureCategory(this.apiBase, this.signer, category);
+  }
+
+  /** This seller's public profile (null when unregistered). */
+  profile(): Promise<AgentProfile | null> {
+    return getAgentProfile(this.address, this.apiBase);
+  }
+
+  /** List (or fully re-write) one service — `mode: "create"` refuses a live slug. */
+  upsertService(input: ServiceUpsertInput): Promise<ServiceWriteResult> {
+    return upsertService(this.apiBase, this.signer, input);
+  }
+
+  /** Take a service off the board (funded jobs keep settling on-chain). */
+  retireService(input: { slug: string } | string): Promise<ServiceWriteResult> {
+    return retireService(
+      this.apiBase,
+      this.signer,
+      typeof input === 'string' ? input : input.slug,
+    );
+  }
+
+  /** Three tiers under one name — `{base}-basic|standard|premium`. */
+  createPackage(input: CreatePackageInput): Promise<CreatePackageResult> {
+    return createPackage(this.apiBase, this.signer, input);
+  }
+
+  /** Sell an x402 API (origin or one 402 URL) — live-probed, sponsored. */
+  listEndpoint(endpoint: string, opts: { primary?: string } = {}): Promise<EndpointListing> {
+    return listEndpoint(this.apiBase, this.signer, endpoint, opts);
+  }
+
+  /** Clear the x402 listing. */
+  removeEndpoint(): Promise<EndpointListing> {
+    return removeEndpoint(this.apiBase, this.signer);
+  }
+
+  /** `#93` · `@handle` · `name.sui` · `0x…` → wallet (marketplace refs only). */
+  resolveRef(q: string): Promise<AgentRef> {
+    return resolveAgentRef(q, this.apiBase);
+  }
+}

--- a/packages/sdk/src/commerce/client.ts
+++ b/packages/sdk/src/commerce/client.ts
@@ -36,7 +36,10 @@ export class CommerceClient {
 
   constructor(options: CommerceClientOptions) {
     this.signer = options.signer;
-    this.apiBase = (options.apiBase ?? DEFAULT_COMMERCE_API_BASE).replace(/\/+$/, '');
+    let base = options.apiBase ?? DEFAULT_COMMERCE_API_BASE;
+    // Linear trailing-slash strip (a `/\/+$/` regex is polynomial — CodeQL).
+    while (base.endsWith('/')) base = base.slice(0, -1);
+    this.apiBase = base;
   }
 
   /** This signer's wallet address. */

--- a/packages/sdk/src/commerce/commerce.test.ts
+++ b/packages/sdk/src/commerce/commerce.test.ts
@@ -1,0 +1,307 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { T2000Error } from '../errors.js';
+import type { TransactionSigner } from '../signer.js';
+import { setSponsoredTxGuard } from '../sponsored-guard.js';
+import {
+  profileChallengeMessage,
+  serviceChallengeMessage,
+  servicePayloadSha256,
+} from './challenge.js';
+import { CommerceClient } from './client.js';
+import { endpointIssueLines } from './endpoint.js';
+import { planPackage } from './package.js';
+import { agentResolveUrl, resolveAgentRef } from './resolve.js';
+import { serviceUpsertPayload } from './service.js';
+
+const BASE = 'https://api.example.test/v1';
+const ADDRESS = `0x${'a'.repeat(64)}`;
+const TX_BYTES = Buffer.from('sponsored-tx').toString('base64');
+
+function stubSigner() {
+  const signed: { tx: string[]; messages: string[] } = { tx: [], messages: [] };
+  const signer: TransactionSigner = {
+    getAddress: () => ADDRESS,
+    signTransaction: async (bytes) => {
+      signed.tx.push(new TextDecoder().decode(bytes));
+      return { signature: 'tx-sig' };
+    },
+    signPersonalMessage: async (bytes) => {
+      signed.messages.push(new TextDecoder().decode(bytes));
+      return { signature: 'msg-sig' };
+    },
+  };
+  return { signer, signed };
+}
+
+function mockFetchQueue(
+  responses: { json: unknown; ok?: boolean; status?: number }[],
+) {
+  const calls: { url: string; method: string; body: Record<string, unknown> | null }[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const next = responses.shift() ?? { json: {}, ok: true };
+      calls.push({
+        url,
+        method: init?.method ?? 'GET',
+        body: init?.body ? JSON.parse(init.body) : null,
+      });
+      return {
+        ok: next.ok ?? true,
+        status: next.status ?? 200,
+        json: async () => next.json,
+      };
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setSponsoredTxGuard(null);
+});
+
+describe('payload hashing — mirrors the API (sha256 of JSON.stringify(payload))', () => {
+  it('WebCrypto hash equals node:crypto over the same bytes', async () => {
+    const payload = serviceUpsertPayload({
+      slug: ' Logo-Sketch ',
+      name: ' Logo sketch ',
+      description: 'Three concepts',
+      priceUsdc: 5,
+      slaMinutes: 1440,
+      deliverable: 'PNG',
+      requirements: 'Brand name and vibe',
+    });
+    const expected = createHash('sha256')
+      .update(JSON.stringify(payload), 'utf8')
+      .digest('hex');
+    await expect(servicePayloadSha256(payload)).resolves.toBe(expected);
+    // Key order IS the signed bytes — fixed in one place.
+    expect(Object.keys(payload)).toEqual([
+      'slug', 'name', 'description', 'priceUsdc', 'slaMinutes',
+      'reviewWindowMinutes', 'rejectSplitBps', 'requirements', 'deliverable',
+    ]);
+    expect(payload.slug).toBe('logo-sketch');
+    expect(payload.reviewWindowMinutes).toBe(1440);
+    expect(payload.rejectSplitBps).toBe(8000);
+  });
+
+  it('challenge message grammars', () => {
+    expect(profileChallengeMessage('n1')).toBe('t2000-agent-profile:n1');
+    expect(serviceChallengeMessage('n1', 'abc')).toBe('t2000-agent-service:n1:abc');
+  });
+
+  it('refuses an off-grammar slug before any network call', () => {
+    expect(() =>
+      serviceUpsertPayload({
+        slug: '-bad', name: 'x', description: 'x', priceUsdc: 1,
+        slaMinutes: 60, deliverable: 'x', requirements: 'x',
+      }),
+    ).toThrow(T2000Error);
+  });
+});
+
+describe('resolveAgentRef — the site\'s own resolver, never a second source', () => {
+  it('builds the URL and maps the row', async () => {
+    expect(agentResolveUrl(' #93 ', BASE)).toBe(`${BASE}/agents/resolve?q=%2393`);
+    mockFetchQueue([{ json: { address: ADDRESS, numericId: 93, name: 'Atlas' } }]);
+    await expect(resolveAgentRef('#93', BASE)).resolves.toEqual({
+      address: ADDRESS, numericId: 93, name: 'Atlas',
+    });
+  });
+
+  it('a miss throws T2000Error with the server sentence (or the fallback)', async () => {
+    mockFetchQueue([{ json: { error: 'No agent #9999.' }, ok: false, status: 404 }]);
+    await expect(resolveAgentRef('#9999', BASE)).rejects.toMatchObject({
+      name: 'T2000Error', code: 'CONTACT_NOT_FOUND', message: 'No agent #9999.',
+    });
+    mockFetchQueue([{ json: {}, ok: false, status: 404 }]);
+    await expect(resolveAgentRef('nope', BASE)).rejects.toThrow(/Agent ID \(#93\)/);
+  });
+});
+
+describe('planPackage — three tiers, one name, slugs from the shared math', () => {
+  const input = {
+    name: 'Market report',
+    description: 'Daily research on any Sui token',
+    requirements: 'Token symbol or coin type',
+    slaMinutes: 1440,
+    tiers: [
+      { tier: 'premium' as const, priceUsdc: 25, deliverable: '10 pages + call' },
+      { tier: 'basic' as const, priceUsdc: 5, deliverable: '2 pages' },
+      { tier: 'standard' as const, priceUsdc: 12, deliverable: '5 pages', slaMinutes: 2880 },
+    ],
+  };
+
+  it('orders basic → standard → premium with mode create and tier-own fields', () => {
+    const plan = planPackage(input);
+    expect(plan.base).toBe('market-report');
+    expect(plan.tiers.map((t) => t.slug)).toEqual([
+      'market-report-basic', 'market-report-standard', 'market-report-premium',
+    ]);
+    expect(plan.tiers.map((t) => t.input.priceUsdc)).toEqual([5, 12, 25]);
+    expect(plan.tiers.map((t) => t.input.slaMinutes)).toEqual([1440, 2880, 1440]);
+    expect(plan.tiers.every((t) => t.input.mode === 'create')).toBe(true);
+    expect(plan.tiers.every((t) => t.input.name === 'Market report')).toBe(true);
+  });
+
+  it('refuses a missing or duplicated tier, and an unusable name', () => {
+    expect(() => planPackage({ ...input, tiers: input.tiers.slice(0, 2) })).toThrow(/missing: standard/);
+    expect(() =>
+      planPackage({ ...input, tiers: [...input.tiers, input.tiers[1]] }),
+    ).toThrow(/given twice/);
+    expect(() => planPackage({ ...input, name: '!!!' })).toThrow(/baseSlug/);
+  });
+
+  it('truncates a long name to the 39-char base budget', () => {
+    const plan = planPackage({ ...input, name: 'x'.repeat(80) });
+    expect(plan.base).toHaveLength(39);
+    expect(plan.tiers[1].slug.length).toBeLessThanOrEqual(48);
+  });
+});
+
+describe('CommerceClient — the wire, end to end with a stub signer', () => {
+  it('register: prepare → guard → sign → submit (and idempotent short-circuit)', async () => {
+    const { signer, signed } = stubSigner();
+    const guardCalls: unknown[] = [];
+    setSponsoredTxGuard((ctx) => guardCalls.push(ctx));
+    const calls = mockFetchQueue([
+      { json: { regNonce: 'r-1', txBytes: TX_BYTES } },
+      { json: { digest: 'D1' } },
+      { json: { alreadyRegistered: true } },
+    ]);
+    const client = new CommerceClient({ signer, apiBase: `${BASE}/` });
+    expect(client.apiBase).toBe(BASE);
+    await expect(client.register()).resolves.toEqual({
+      address: ADDRESS, alreadyRegistered: false, digest: 'D1',
+    });
+    expect(calls[0]).toMatchObject({ url: `${BASE}/agent/register/prepare`, body: { address: ADDRESS } });
+    expect(calls[1]).toMatchObject({
+      url: `${BASE}/agent/register/submit`,
+      body: { regNonce: 'r-1', address: ADDRESS, agentSignature: 'tx-sig' },
+    });
+    expect(signed.tx).toEqual(['sponsored-tx']);
+    expect(guardCalls).toEqual([
+      { base: BASE, action: 'register' },
+      { base: BASE, action: 'register', txBytes: TX_BYTES },
+    ]);
+    await expect(client.register()).resolves.toEqual({ address: ADDRESS, alreadyRegistered: true });
+    expect(signed.tx).toHaveLength(1);
+  });
+
+  it('a guard veto aborts before the address is sent', async () => {
+    const { signer } = stubSigner();
+    setSponsoredTxGuard(() => {
+      throw new Error('untrusted host');
+    });
+    const calls = mockFetchQueue([]);
+    await expect(new CommerceClient({ signer, apiBase: BASE }).register()).rejects.toThrow(/untrusted/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('updateProfile: challenge → signed profile message → POST (category validated locally)', async () => {
+    const { signer, signed } = stubSigner();
+    const calls = mockFetchQueue([{ json: { nonce: 'n-p' } }, { json: { ok: true } }]);
+    const client = new CommerceClient({ signer, apiBase: BASE });
+    await client.updateProfile({ name: 'Atlas', category: 'Research' });
+    expect(signed.messages).toEqual(['t2000-agent-profile:n-p']);
+    expect(calls[1]).toMatchObject({
+      url: `${BASE}/agent/profile`,
+      body: { address: ADDRESS, nonce: 'n-p', signature: 'msg-sig', displayName: 'Atlas', category: 'research' },
+    });
+    await expect(client.updateProfile({ category: 'bogus' })).rejects.toThrow(/category must be one of/);
+    await expect(client.updateProfile({})).rejects.toThrow(/at least one/);
+  });
+
+  it('upsertService: the signed message binds the payload hash; API errors become T2000Error', async () => {
+    const { signer, signed } = stubSigner();
+    const calls = mockFetchQueue([
+      { json: { nonce: 'n-s' } },
+      { json: { ok: true, slug: 'logo-sketch' } },
+    ]);
+    const client = new CommerceClient({ signer, apiBase: BASE });
+    const r = await client.upsertService({
+      slug: 'logo-sketch', name: 'Logo sketch', description: 'd', priceUsdc: 5,
+      slaMinutes: 1440, deliverable: 'PNG', requirements: 'brand', mode: 'create',
+    });
+    const payload = calls[1].body?.payload as Record<string, unknown>;
+    const hash = createHash('sha256').update(JSON.stringify(payload), 'utf8').digest('hex');
+    expect(signed.messages).toEqual([`t2000-agent-service:n-s:${hash}`]);
+    expect(calls[1].body).toMatchObject({ address: ADDRESS, action: 'upsert' });
+    expect(payload.mode).toBe('create');
+    expect(r).toMatchObject({ address: ADDRESS, slug: 'logo-sketch' });
+
+    mockFetchQueue([
+      { json: { nonce: 'n-2' } },
+      { json: { error: { message: 'Slug "logo-sketch" is live — pick another name.' } }, ok: false, status: 409 },
+    ]);
+    await expect(client.retireService('logo-sketch')).rejects.toMatchObject({
+      name: 'T2000Error', code: 'INVALID_INPUT', message: /is live/,
+    });
+  });
+
+  it('createPackage: three sequential creates, collision on the second stops the set', async () => {
+    const { signer } = stubSigner();
+    const calls = mockFetchQueue([
+      { json: { nonce: 'n-a' } }, { json: { ok: true } },
+      { json: { nonce: 'n-b' } }, { json: { error: 'live slug' }, ok: false, status: 409 },
+    ]);
+    const client = new CommerceClient({ signer, apiBase: BASE });
+    await expect(
+      client.createPackage({
+        name: 'Market report', description: 'd', requirements: 'r', slaMinutes: 60,
+        tiers: [
+          { tier: 'basic', priceUsdc: 5, deliverable: 'a' },
+          { tier: 'standard', priceUsdc: 12, deliverable: 'b' },
+          { tier: 'premium', priceUsdc: 25, deliverable: 'c' },
+        ],
+      }),
+    ).rejects.toThrow(/live slug/);
+    const upserts = calls.filter((c) => c.url.endsWith('/agent/service'));
+    expect(upserts.map((c) => (c.body?.payload as { slug: string }).slug)).toEqual([
+      'market-report-basic', 'market-report-standard',
+    ]);
+  });
+
+  it('listEndpoint: probe failure carries per-route findings; success returns the CLI JSON shape', async () => {
+    const { signer } = stubSigner();
+    mockFetchQueue([
+      {
+        ok: false, status: 400,
+        json: {
+          error: { message: 'Probe failed.' },
+          routes: [{ method: 'POST', path: '/v1/x', probeOk: false, issues: [{ message: 'no 402' }] }],
+        },
+      },
+    ]);
+    const client = new CommerceClient({ signer, apiBase: BASE });
+    await expect(client.listEndpoint('https://api.me.test')).rejects.toThrow(
+      'Probe failed.\n  ✗ POST /v1/x\n      no 402',
+    );
+    expect(endpointIssueLines({ probe: { issues: [{ code: 'E1' }] } })).toEqual(['  ✗ E1']);
+
+    const calls = mockFetchQueue([
+      {
+        json: {
+          nonce: 'e-1', txBytes: TX_BYTES, origin: 'https://api.me.test',
+          primary: { path: '/v1/x', url: 'https://api.me.test/v1/x' },
+          routes: [{ method: 'POST', path: '/v1/x', priceUsdc: '0.01', probeOk: true }],
+          probe: { ok: true, amount: '0.01' },
+        },
+      },
+      { json: { digest: 'E-D' } },
+    ]);
+    const listing = await client.listEndpoint('https://api.me.test', { primary: '/v1/x' });
+    expect(calls[0].body).toEqual({ address: ADDRESS, endpoint: 'https://api.me.test', primary: '/v1/x' });
+    expect(calls[1].body).toEqual({ nonce: 'e-1', address: ADDRESS, signature: 'tx-sig' });
+    expect(listing).toMatchObject({
+      address: ADDRESS, endpoint: 'https://api.me.test/v1/x', listed: true,
+      origin: 'https://api.me.test', digest: 'E-D',
+    });
+    expect(listing.routes).toHaveLength(1);
+
+    mockFetchQueue([{ json: { nonce: 'e-2', txBytes: TX_BYTES } }, { json: { digest: 'E-R' } }]);
+    await expect(client.removeEndpoint()).resolves.toMatchObject({ endpoint: null, listed: false, digest: 'E-R' });
+  });
+});

--- a/packages/sdk/src/commerce/endpoint.ts
+++ b/packages/sdk/src/commerce/endpoint.ts
@@ -1,0 +1,104 @@
+// x402 listing ("Sell your API") — `/v1/agent/endpoint/prepare` live-probes
+// the origin (every paid route in its openapi.json must answer 402 with a
+// Sui payment challenge) or one 402 URL, builds the registry `update` tx;
+// the seller signs; `/submit` sponsor-co-signs. A failed probe surfaces its
+// per-route findings in the error message (parity with `t2 agent sell`).
+
+import { T2000Error } from '../errors.js';
+import type { TransactionSigner } from '../signer.js';
+import { runSponsoredTxGuard } from '../sponsored-guard.js';
+import { apiErrorMessage, apiJson, apiRequest, invalidInput } from './http.js';
+import { signPreparedTx } from './sponsored.js';
+import type { EndpointIssue, EndpointListing, EndpointRoute } from './types.js';
+
+type PrepareBody = {
+  nonce?: string;
+  txBytes?: string;
+  probe?: EndpointListing['probe'];
+  origin?: string | null;
+  primary?: { path?: string; url?: string } | null;
+  routes?: EndpointRoute[];
+  issues?: EndpointIssue[];
+};
+
+/** The probe findings as the lines the CLI prints — origin expands carry
+ *  per-route findings, single probes the flat issue list. */
+export function endpointIssueLines(prep: PrepareBody): string[] {
+  const lines: string[] = (prep.probe?.issues ?? []).map(
+    (i) => `  ✗ ${i.message ?? i.code}`,
+  );
+  for (const r of prep.routes ?? []) {
+    if (r.probeOk === false) {
+      lines.push(`  ✗ ${r.method ?? 'POST'} ${r.path}`);
+      for (const i of r.issues ?? []) {
+        lines.push(`      ${i.message ?? i.code}`);
+      }
+    }
+  }
+  return lines;
+}
+
+async function setEndpoint(
+  apiBase: string,
+  signer: TransactionSigner,
+  endpoint: string,
+  primary?: string,
+): Promise<EndpointListing> {
+  const address = signer.getAddress();
+  runSponsoredTxGuard({ base: apiBase, action: 'update' });
+  const res = await apiRequest(`${apiBase}/agent/endpoint/prepare`, {
+    method: 'POST',
+    body: { address, endpoint, ...(primary ? { primary } : {}) },
+  });
+  const prep = res.json as PrepareBody & Record<string, unknown>;
+  if (!res.ok) {
+    const msg = apiErrorMessage(prep, res.status);
+    const detail = endpointIssueLines(prep).join('\n');
+    throw new T2000Error(
+      'INVALID_INPUT',
+      detail ? `${msg}\n${detail}` : msg,
+      { status: res.status, probe: prep.probe ?? null, routes: prep.routes ?? [] },
+    );
+  }
+  if (!(typeof prep.nonce === 'string' && typeof prep.txBytes === 'string')) {
+    throw invalidInput('Failed to prepare the listing.');
+  }
+  const signature = await signPreparedTx(apiBase, 'update', signer, prep.txBytes);
+  const sub = await apiJson(`${apiBase}/agent/endpoint/submit`, {
+    method: 'POST',
+    body: { nonce: prep.nonce, address, signature },
+  });
+  const listed = endpoint !== '';
+  return {
+    address,
+    endpoint: listed ? (prep.primary?.url ?? endpoint) : null,
+    listed,
+    probe: prep.probe ?? null,
+    origin: prep.origin ?? null,
+    primary: prep.primary ?? null,
+    routes: prep.routes ?? [],
+    ...(typeof sub.digest === 'string' ? { digest: sub.digest } : {}),
+  };
+}
+
+/** List an API origin (expands via {origin}/openapi.json) or one 402 URL. */
+export function listEndpoint(
+  apiBase: string,
+  signer: TransactionSigner,
+  endpoint: string,
+  opts: { primary?: string } = {},
+): Promise<EndpointListing> {
+  const target = endpoint.trim();
+  if (!target) {
+    throw invalidInput('Provide your x402 endpoint URL.');
+  }
+  return setEndpoint(apiBase, signer, target, opts.primary);
+}
+
+/** Clear the listing (registry update with an empty endpoint). */
+export function removeEndpoint(
+  apiBase: string,
+  signer: TransactionSigner,
+): Promise<EndpointListing> {
+  return setEndpoint(apiBase, signer, '');
+}

--- a/packages/sdk/src/commerce/http.ts
+++ b/packages/sdk/src/commerce/http.ts
@@ -1,0 +1,76 @@
+// The one HTTP helper for the commerce write rail — every API failure
+// becomes a `T2000Error` carrying the server's own sentence (the CLI,
+// Connect, and host apps print it verbatim). Browser-safe: fetch only.
+
+import { T2000Error, type T2000ErrorCode } from '../errors.js';
+
+export const DEFAULT_COMMERCE_API_BASE = 'https://api.t2000.ai/v1';
+
+/** HTTP status → the closest SDK error code. */
+function codeForStatus(status: number): T2000ErrorCode {
+  if (status === 400 || status === 409 || status === 422) {
+    return 'INVALID_INPUT';
+  }
+  if (status === 429 || status >= 500) {
+    return 'RPC_ERROR';
+  }
+  return 'UNKNOWN';
+}
+
+/** The API's error message — `error` is a string or `{ message }`. */
+export function apiErrorMessage(
+  json: Record<string, unknown>,
+  status: number,
+): string {
+  const err = json.error;
+  if (typeof err === 'string') {
+    return err;
+  }
+  const msg = (err as { message?: unknown } | undefined)?.message;
+  return typeof msg === 'string' ? msg : `HTTP ${status}`;
+}
+
+export interface ApiResponse {
+  ok: boolean;
+  status: number;
+  json: Record<string, unknown>;
+}
+
+/** Raw request — the caller decides how a non-2xx maps (endpoint prepare
+ *  carries per-route findings the plain message would hide). */
+export async function apiRequest(
+  url: string,
+  init?: { method?: string; body?: unknown },
+): Promise<ApiResponse> {
+  const res = await fetch(url, {
+    method: init?.method ?? (init?.body === undefined ? 'GET' : 'POST'),
+    headers: {
+      accept: 'application/json',
+      ...(init?.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+  const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+  return { ok: res.ok, status: res.status, json };
+}
+
+/** Request + throw `T2000Error(<api message>)` on a non-2xx. */
+export async function apiJson(
+  url: string,
+  init?: { method?: string; body?: unknown },
+): Promise<Record<string, unknown>> {
+  const res = await apiRequest(url, init);
+  if (!res.ok) {
+    throw new T2000Error(codeForStatus(res.status), apiErrorMessage(res.json, res.status), {
+      status: res.status,
+      ...(res.json.error && typeof res.json.error === 'object'
+        ? { api: res.json.error }
+        : {}),
+    });
+  }
+  return res.json;
+}
+
+export function invalidInput(message: string): T2000Error {
+  return new T2000Error('INVALID_INPUT', message);
+}

--- a/packages/sdk/src/commerce/index.ts
+++ b/packages/sdk/src/commerce/index.ts
@@ -16,6 +16,7 @@ export {
   parseServiceTierSlug,
   SERVICE_SLUG_RE,
   slugify,
+  trimDashes,
 } from './package-slug.js';
 export { ensureCategory, parseAgentCategory, updateProfile } from './profile.js';
 export { registerAgent } from './register.js';

--- a/packages/sdk/src/commerce/index.ts
+++ b/packages/sdk/src/commerce/index.ts
@@ -1,0 +1,41 @@
+// @t2000/sdk commerce — seller onboarding, headless (S.1158).
+export { CommerceClient } from './client.js';
+export {
+  fetchChallengeNonce,
+  profileChallengeMessage,
+  serviceChallengeMessage,
+  servicePayloadSha256,
+  signChallenge,
+} from './challenge.js';
+export { endpointIssueLines, listEndpoint, removeEndpoint } from './endpoint.js';
+export { createPackage, planPackage } from './package.js';
+export {
+  MAX_TIER_BASE_LENGTH,
+  packageBaseSlug,
+  packageTierSlugs,
+  parseServiceTierSlug,
+  SERVICE_SLUG_RE,
+  slugify,
+} from './package-slug.js';
+export { ensureCategory, parseAgentCategory, updateProfile } from './profile.js';
+export { registerAgent } from './register.js';
+export { agentResolveUrl, getAgentProfile, resolveAgentRef } from './resolve.js';
+export { retireService, serviceUpsertPayload, upsertService } from './service.js';
+export { AGENT_CATEGORIES, SERVICE_TIERS } from './types.js';
+export type {
+  AgentCategory,
+  AgentProfile,
+  AgentRef,
+  CommerceClientOptions,
+  CreatePackageInput,
+  CreatePackageResult,
+  EndpointIssue,
+  EndpointListing,
+  EndpointRoute,
+  PackageTierInput,
+  ProfileUpdateInput,
+  RegisterResult,
+  ServiceTier,
+  ServiceUpsertInput,
+  ServiceWriteResult,
+} from './types.js';

--- a/packages/sdk/src/commerce/package-slug.test.ts
+++ b/packages/sdk/src/commerce/package-slug.test.ts
@@ -33,6 +33,9 @@ describe('package slug math (parity with console service-tiers)', () => {
 
   it('slugify matches the CLI rule and every tier slug passes the API grammar', () => {
     expect(slugify('  Sui Market Report!! ')).toBe('sui-market-report');
+    expect(slugify('---')).toBe('');
+    expect(slugify('a')).toBe('a');
+    expect(packageBaseSlug('---')).toBe('');
     const base = packageBaseSlug(slugify('Brand kit — logos, colours & type, the full identity system'));
     for (const { slug } of packageTierSlugs(base)) {
       expect(slug).toMatch(SERVICE_SLUG_RE);

--- a/packages/sdk/src/commerce/package-slug.test.ts
+++ b/packages/sdk/src/commerce/package-slug.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_TIER_BASE_LENGTH,
+  packageBaseSlug,
+  packageTierSlugs,
+  parseServiceTierSlug,
+  SERVICE_SLUG_RE,
+  slugify,
+} from './package-slug.js';
+
+// S.1158 — COPIED from audric `apps/console/lib/service-tiers.ts`; these
+// cases mirror the console's own tests so the two cannot drift silently.
+
+describe('package slug math (parity with console service-tiers)', () => {
+  it('parse — final segment only, empty base rejected', () => {
+    expect(parseServiceTierSlug('logo-pack-basic')).toEqual({ base: 'logo-pack', tier: 'basic' });
+    expect(parseServiceTierSlug('x-premium')).toEqual({ base: 'x', tier: 'premium' });
+    expect(parseServiceTierSlug('foo-basic-extra')).toBeNull();
+    expect(parseServiceTierSlug('basic')).toBeNull();
+    expect(parseServiceTierSlug('-basic')).toBeNull();
+    expect(parseServiceTierSlug('plain-service')).toBeNull();
+  });
+
+  it('base budget keeps {base}-standard within the 48-char slug cap', () => {
+    // 48 - '-standard'.length — the console's own value (the spec's "38" was
+    // off by one; parity with audric service-tiers.ts is the lock).
+    expect(MAX_TIER_BASE_LENGTH).toBe(39);
+    const base = packageBaseSlug('x'.repeat(80));
+    expect(base).toHaveLength(MAX_TIER_BASE_LENGTH);
+    expect(`${base}-standard`.length).toBeLessThanOrEqual(48);
+    expect(packageBaseSlug(`${'y'.repeat(MAX_TIER_BASE_LENGTH - 1)}--tail`).endsWith('-')).toBe(false);
+  });
+
+  it('slugify matches the CLI rule and every tier slug passes the API grammar', () => {
+    expect(slugify('  Sui Market Report!! ')).toBe('sui-market-report');
+    const base = packageBaseSlug(slugify('Brand kit — logos, colours & type, the full identity system'));
+    for (const { slug } of packageTierSlugs(base)) {
+      expect(slug).toMatch(SERVICE_SLUG_RE);
+    }
+    expect(packageTierSlugs('brand-kit').map((t) => t.slug)).toEqual([
+      'brand-kit-basic',
+      'brand-kit-standard',
+      'brand-kit-premium',
+    ]);
+  });
+});

--- a/packages/sdk/src/commerce/package-slug.ts
+++ b/packages/sdk/src/commerce/package-slug.ts
@@ -1,0 +1,52 @@
+// Package tier slug convention (S.1115 — SPEC_PACKAGE_TIERS): a package is
+// three ordinary service rows `{base}-basic|standard|premium` on the same
+// agent — no schema field, every row a normal listing + Hire target.
+//
+// COPIED (not imported) from audric `apps/console/lib/service-tiers.ts` —
+// the SDK cannot depend on `@audric/*`; keep the two in step (the unit
+// tests here mirror the console's budget/parse cases).
+
+import { SERVICE_TIERS, type ServiceTier } from './types.js';
+
+/** The API's slug grammar: 2–48 chars of [a-z0-9-], alphanumeric first. */
+export const SERVICE_SLUG_RE = /^[a-z0-9][a-z0-9-]{1,47}$/;
+
+/** The CLI's name → slug rule (lowercase, runs of non-alphanumerics → `-`,
+ *  trimmed, 48-char cap). */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+    .slice(0, 48);
+}
+
+// Suffix must be the FINAL segment: `logo-pack-basic` parses,
+// `foo-basic-extra` is a loner.
+const TIER_SLUG_RE = /^(.+)-(basic|standard|premium)$/;
+
+/** `{base}-standard` is the longest tier slug; slugs cap at 48 chars, so a
+ *  package base may be at most 48 - "-standard".length. */
+export const MAX_TIER_BASE_LENGTH = 48 - '-standard'.length;
+
+export function parseServiceTierSlug(
+  slug: string,
+): { base: string; tier: ServiceTier } | null {
+  const m = TIER_SLUG_RE.exec(slug);
+  if (!m) {
+    return null;
+  }
+  return { base: m[1], tier: m[2] as ServiceTier };
+}
+
+/** Truncate a slugified name into a valid package base (trailing dashes
+ *  shed so `{base}-basic` never carries `--`). Empty in → empty out —
+ *  callers validate. */
+export function packageBaseSlug(slugified: string): string {
+  return slugified.slice(0, MAX_TIER_BASE_LENGTH).replace(/-+$/, '');
+}
+
+/** The three tier slugs for a base, Basic → Standard → Premium. */
+export function packageTierSlugs(base: string): { tier: ServiceTier; slug: string }[] {
+  return SERVICE_TIERS.map((tier) => ({ tier, slug: `${base}-${tier}` }));
+}

--- a/packages/sdk/src/commerce/package-slug.ts
+++ b/packages/sdk/src/commerce/package-slug.ts
@@ -11,14 +11,20 @@ import { SERVICE_TIERS, type ServiceTier } from './types.js';
 /** The API's slug grammar: 2–48 chars of [a-z0-9-], alphanumeric first. */
 export const SERVICE_SLUG_RE = /^[a-z0-9][a-z0-9-]{1,47}$/;
 
+/** Strip leading/trailing dashes in linear time (a `^-+|-+$` regex is
+ *  polynomial on dash runs — CodeQL js/polynomial-redos). */
+export function trimDashes(s: string): string {
+  let start = 0;
+  let end = s.length;
+  while (start < end && s.charCodeAt(start) === 45) start += 1;
+  while (end > start && s.charCodeAt(end - 1) === 45) end -= 1;
+  return s.slice(start, end);
+}
+
 /** The CLI's name → slug rule (lowercase, runs of non-alphanumerics → `-`,
  *  trimmed, 48-char cap). */
 export function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/g, '-')
-    .replaceAll(/^-+|-+$/g, '')
-    .slice(0, 48);
+  return trimDashes(name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')).slice(0, 48);
 }
 
 // Suffix must be the FINAL segment: `logo-pack-basic` parses,
@@ -43,7 +49,10 @@ export function parseServiceTierSlug(
  *  shed so `{base}-basic` never carries `--`). Empty in → empty out —
  *  callers validate. */
 export function packageBaseSlug(slugified: string): string {
-  return slugified.slice(0, MAX_TIER_BASE_LENGTH).replace(/-+$/, '');
+  const cut = slugified.slice(0, MAX_TIER_BASE_LENGTH);
+  let end = cut.length;
+  while (end > 0 && cut.charCodeAt(end - 1) === 45) end -= 1;
+  return cut.slice(0, end);
 }
 
 /** The three tier slugs for a base, Basic → Standard → Premium. */

--- a/packages/sdk/src/commerce/package.ts
+++ b/packages/sdk/src/commerce/package.ts
@@ -1,0 +1,94 @@
+// Packages (S.1115 convention): ONE name, three tiers — `{base}-basic`,
+// `{base}-standard`, `{base}-premium` — each an ordinary service row with
+// its own price + deliverable. `createPackage` is three sequential upserts
+// in tier order with `mode: "create"`, so a slug that is already LIVE on
+// this seller fails loud (409) instead of silently replacing a listing.
+
+import type { TransactionSigner } from '../signer.js';
+import { invalidInput } from './http.js';
+import {
+  packageBaseSlug,
+  packageTierSlugs,
+  SERVICE_SLUG_RE,
+  slugify,
+} from './package-slug.js';
+import { upsertService } from './service.js';
+import {
+  type CreatePackageInput,
+  type CreatePackageResult,
+  type PackageTierInput,
+  SERVICE_TIERS,
+  type ServiceTier,
+} from './types.js';
+
+/** The three upsert payload inputs for a package, Basic → Premium (pure —
+ *  unit-pinned; `createPackage` only adds the signer). */
+export function planPackage(input: CreatePackageInput): {
+  base: string;
+  tiers: { tier: ServiceTier; slug: string; input: Parameters<typeof upsertService>[2] }[];
+} {
+  const name = input.name.trim();
+  if (!name) {
+    throw invalidInput('name is required.');
+  }
+  const base = packageBaseSlug((input.baseSlug ?? slugify(name)).trim().toLowerCase());
+  if (!base || !SERVICE_SLUG_RE.test(`${base}-basic`)) {
+    throw invalidInput(
+      'Could not derive a package slug from the name — pass baseSlug (a-z, 0-9, dashes).',
+    );
+  }
+  const byTier = new Map<ServiceTier, PackageTierInput>();
+  for (const t of input.tiers) {
+    if (!(SERVICE_TIERS as readonly string[]).includes(t.tier)) {
+      throw invalidInput(`Unknown tier "${t.tier}" — use basic, standard, premium.`);
+    }
+    if (byTier.has(t.tier)) {
+      throw invalidInput(`Tier "${t.tier}" given twice.`);
+    }
+    byTier.set(t.tier, t);
+  }
+  const missing = SERVICE_TIERS.filter((t) => !byTier.has(t));
+  if (missing.length > 0) {
+    throw invalidInput(
+      `A package needs all three tiers — missing: ${missing.join(', ')}.`,
+    );
+  }
+  return {
+    base,
+    tiers: packageTierSlugs(base).map(({ tier, slug }) => {
+      const t = byTier.get(tier) as PackageTierInput;
+      return {
+        tier,
+        slug,
+        input: {
+          mode: 'create' as const,
+          slug,
+          name,
+          description: (t.description ?? input.description).trim(),
+          priceUsdc: t.priceUsdc,
+          slaMinutes: t.slaMinutes ?? input.slaMinutes,
+          deliverable: t.deliverable,
+          requirements: input.requirements,
+          reviewWindowMinutes: t.reviewWindowMinutes ?? input.reviewWindowMinutes,
+          rejectSplitBps: t.rejectSplitBps ?? input.rejectSplitBps,
+        },
+      };
+    }),
+  };
+}
+
+export async function createPackage(
+  apiBase: string,
+  signer: TransactionSigner,
+  input: CreatePackageInput,
+): Promise<CreatePackageResult> {
+  const plan = planPackage(input);
+  const tiers: CreatePackageResult['tiers'] = [];
+  for (const t of plan.tiers) {
+    // Sequential on purpose: one nonce per signed write, and a collision on
+    // any tier stops the set (the API refuses a live slug under mode create).
+    await upsertService(apiBase, signer, t.input);
+    tiers.push({ tier: t.tier, slug: t.slug, priceUsdc: t.input.priceUsdc });
+  }
+  return { address: signer.getAddress(), base: plan.base, tiers };
+}

--- a/packages/sdk/src/commerce/profile.ts
+++ b/packages/sdk/src/commerce/profile.ts
@@ -1,0 +1,96 @@
+// Public profile (name · image · description · category · links) — signed
+// challenge, no gas. The directory category is also the SELL GATE: every
+// listing becomes a browsable card, so `ensureCategory` refuses to list a
+// seller with no category rather than drift the directory.
+
+import type { TransactionSigner } from '../signer.js';
+import { profileChallengeMessage, signChallenge } from './challenge.js';
+import { apiJson, invalidInput } from './http.js';
+import { getAgentProfile } from './resolve.js';
+import {
+  AGENT_CATEGORIES,
+  type ProfileUpdateInput,
+} from './types.js';
+
+export function parseAgentCategory(raw: string): string {
+  const c = raw.trim().toLowerCase();
+  if (!(AGENT_CATEGORIES as readonly string[]).includes(c)) {
+    throw invalidInput(
+      `category must be one of: ${AGENT_CATEGORIES.join(', ')} (got "${raw}").`,
+    );
+  }
+  return c;
+}
+
+export async function updateProfile(
+  apiBase: string,
+  signer: TransactionSigner,
+  input: ProfileUpdateInput,
+): Promise<{ address: string }> {
+  const hasField =
+    input.name !== undefined ||
+    input.imageUrl !== undefined ||
+    input.description !== undefined ||
+    input.category !== undefined ||
+    input.website !== undefined ||
+    input.twitter !== undefined ||
+    input.github !== undefined;
+  if (!hasField) {
+    throw invalidInput(
+      'Provide at least one of name, imageUrl, description, category, website, twitter, github.',
+    );
+  }
+  const category =
+    input.category === undefined ? undefined : parseAgentCategory(input.category);
+  const address = signer.getAddress();
+  const { nonce, signature } = await signChallenge(
+    apiBase,
+    signer,
+    profileChallengeMessage,
+  );
+  await apiJson(`${apiBase}/agent/profile`, {
+    method: 'POST',
+    body: {
+      address,
+      nonce,
+      signature,
+      displayName: input.name,
+      imageUrl: input.imageUrl,
+      description: input.description,
+      category,
+      website: input.website,
+      twitter: input.twitter,
+      github: input.github,
+    },
+  });
+  return { address };
+}
+
+/** The seller category gate: `category` given → set it (signed, no gas);
+ *  otherwise the live profile category satisfies the gate; neither → a
+ *  precise refusal naming both fixes. */
+export async function ensureCategory(
+  apiBase: string,
+  signer: TransactionSigner,
+  category?: string,
+): Promise<string> {
+  if (category !== undefined) {
+    const parsed = parseAgentCategory(category);
+    await updateProfile(apiBase, signer, { category: parsed });
+    return parsed;
+  }
+  const profile = await getAgentProfile(signer.getAddress(), apiBase).catch(
+    () => null,
+  );
+  const existing =
+    typeof profile?.category === 'string' && profile.category
+      ? profile.category
+      : null;
+  if (!existing) {
+    throw invalidInput(
+      'Pick a directory category first — buyers browse listings by category. ' +
+        `Set one of ${AGENT_CATEGORIES.join(' | ')} (updateProfile({ category }) / t2 agent profile --category).`,
+    );
+  }
+  return existing;
+}

--- a/packages/sdk/src/commerce/register.ts
+++ b/packages/sdk/src/commerce/register.ts
@@ -1,0 +1,40 @@
+// Sponsored Agent ID registration — `/v1/agent/register/prepare` builds
+// `agent_id::registry::register` (the `@t2000/id` builder, server-side),
+// the seller signs, `/submit` sponsor-co-signs. Idempotent: an address that
+// is already an Agent ID signs nothing.
+
+import type { TransactionSigner } from '../signer.js';
+import { runSponsoredTxGuard } from '../sponsored-guard.js';
+import { apiJson, invalidInput } from './http.js';
+import { signPreparedTx } from './sponsored.js';
+import type { RegisterResult } from './types.js';
+
+export async function registerAgent(
+  apiBase: string,
+  signer: TransactionSigner,
+): Promise<RegisterResult> {
+  const address = signer.getAddress();
+  runSponsoredTxGuard({ base: apiBase, action: 'register' });
+  const prep = await apiJson(`${apiBase}/agent/register/prepare`, {
+    method: 'POST',
+    body: { address },
+  });
+  if (prep.alreadyRegistered === true) {
+    return { address, alreadyRegistered: true };
+  }
+  const regNonce = prep.regNonce;
+  const txBytes = prep.txBytes;
+  if (!(typeof regNonce === 'string' && typeof txBytes === 'string')) {
+    throw invalidInput('Failed to prepare registration.');
+  }
+  const signature = await signPreparedTx(apiBase, 'register', signer, txBytes);
+  const res = await apiJson(`${apiBase}/agent/register/submit`, {
+    method: 'POST',
+    body: { regNonce, address, agentSignature: signature },
+  });
+  return {
+    address,
+    alreadyRegistered: res.alreadyRegistered === true,
+    ...(typeof res.digest === 'string' ? { digest: res.digest } : {}),
+  };
+}

--- a/packages/sdk/src/commerce/resolve.ts
+++ b/packages/sdk/src/commerce/resolve.ts
@@ -1,0 +1,62 @@
+// "Which agent do you mean?" — `#93` · `93` · `@handle` · `name.sui` ·
+// `0x…` → the wallet address, via the SAME endpoint the site uses
+// (`GET /v1/agents/resolve?q=`), so there is no second source of truth for
+// Agent ID numbers. Deliberately separate from `normalizeAddressInput`
+// (chain-only: 0x / SuiNS) — marketplace refs never leak into payment
+// recipient semantics.
+
+import { T2000Error } from '../errors.js';
+import { apiRequest, DEFAULT_COMMERCE_API_BASE } from './http.js';
+import type { AgentProfile, AgentRef } from './types.js';
+
+const FALLBACK_MISS = 'Use an Agent ID (#93), @handle, or full 0x… address.';
+
+/** The resolve URL for a ref (pure — unit-pinned). */
+export function agentResolveUrl(
+  q: string,
+  apiBase: string = DEFAULT_COMMERCE_API_BASE,
+): string {
+  return `${apiBase}/agents/resolve?q=${encodeURIComponent(q.trim())}`;
+}
+
+/** Resolve an agent ref to its wallet. Throws `T2000Error` with the server's
+ *  own sentence on a miss, so every surface explains it identically. */
+export async function resolveAgentRef(
+  q: string,
+  apiBase: string = DEFAULT_COMMERCE_API_BASE,
+): Promise<AgentRef> {
+  const res = await apiRequest(agentResolveUrl(q, apiBase));
+  const json = res.json as {
+    address?: unknown;
+    numericId?: unknown;
+    name?: unknown;
+    error?: unknown;
+  };
+  if (!(res.ok && typeof json.address === 'string')) {
+    throw new T2000Error(
+      'CONTACT_NOT_FOUND',
+      typeof json.error === 'string' ? json.error : FALLBACK_MISS,
+      { ref: q },
+    );
+  }
+  return {
+    address: json.address,
+    ...(typeof json.numericId === 'number' || json.numericId === null
+      ? { numericId: json.numericId as number | null }
+      : {}),
+    ...(typeof json.name === 'string' ? { name: json.name } : {}),
+  };
+}
+
+/** The public profile row (GET /v1/agents/:address). Null when the address
+ *  is not a registered Agent ID. */
+export async function getAgentProfile(
+  address: string,
+  apiBase: string = DEFAULT_COMMERCE_API_BASE,
+): Promise<AgentProfile | null> {
+  const res = await apiRequest(`${apiBase}/agents/${encodeURIComponent(address)}`);
+  if (!res.ok) {
+    return null;
+  }
+  return { ...(res.json as Record<string, unknown>), address } as AgentProfile;
+}

--- a/packages/sdk/src/commerce/service.ts
+++ b/packages/sdk/src/commerce/service.ts
@@ -1,0 +1,83 @@
+// Services (t2 ACP) — the seller catalog: signed FULL upsert + retire via
+// `POST /v1/agent/service` { address, nonce, signature, action, payload }.
+// The signature binds sha256(JSON.stringify(payload)) so the payload the
+// server stores is the payload the seller signed.
+
+import type { TransactionSigner } from '../signer.js';
+import {
+  serviceChallengeMessage,
+  servicePayloadSha256,
+  signChallenge,
+} from './challenge.js';
+import { apiJson, invalidInput } from './http.js';
+import { SERVICE_SLUG_RE } from './package-slug.js';
+import type { ServiceUpsertInput, ServiceWriteResult } from './types.js';
+
+/** The wire payload for an upsert — key order is the signed bytes, so it
+ *  is fixed here and nowhere else. */
+export function serviceUpsertPayload(
+  input: ServiceUpsertInput,
+): Record<string, unknown> {
+  const slug = input.slug.trim().toLowerCase();
+  if (!SERVICE_SLUG_RE.test(slug)) {
+    throw invalidInput(
+      'slug must be 2-48 chars of [a-z0-9-], starting alphanumeric.',
+    );
+  }
+  return {
+    ...(input.mode ? { mode: input.mode } : {}),
+    slug,
+    name: input.name.trim(),
+    description: input.description.trim(),
+    priceUsdc: input.priceUsdc,
+    slaMinutes: input.slaMinutes,
+    reviewWindowMinutes: input.reviewWindowMinutes ?? 1440,
+    rejectSplitBps: input.rejectSplitBps ?? 8000,
+    requirements: input.requirements,
+    deliverable: input.deliverable.trim(),
+    ...(input.examples === undefined ? {} : { examples: input.examples }),
+  };
+}
+
+async function signedServiceAction(
+  apiBase: string,
+  signer: TransactionSigner,
+  action: 'upsert' | 'retire',
+  payload: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const address = signer.getAddress();
+  const { nonce, signature } = await signChallenge(
+    apiBase,
+    signer,
+    async (n) => serviceChallengeMessage(n, await servicePayloadSha256(payload)),
+  );
+  return apiJson(`${apiBase}/agent/service`, {
+    method: 'POST',
+    body: { address, nonce, signature, action, payload },
+  });
+}
+
+export async function upsertService(
+  apiBase: string,
+  signer: TransactionSigner,
+  input: ServiceUpsertInput,
+): Promise<ServiceWriteResult> {
+  const payload = serviceUpsertPayload(input);
+  const response = await signedServiceAction(apiBase, signer, 'upsert', payload);
+  return { address: signer.getAddress(), slug: payload.slug as string, response };
+}
+
+export async function retireService(
+  apiBase: string,
+  signer: TransactionSigner,
+  slug: string,
+): Promise<ServiceWriteResult> {
+  const clean = slug.trim().toLowerCase();
+  if (!SERVICE_SLUG_RE.test(clean)) {
+    throw invalidInput('slug must be 2-48 chars of [a-z0-9-], starting alphanumeric.');
+  }
+  const response = await signedServiceAction(apiBase, signer, 'retire', {
+    slug: clean,
+  });
+  return { address: signer.getAddress(), slug: clean, response };
+}

--- a/packages/sdk/src/commerce/sponsored.ts
+++ b/packages/sdk/src/commerce/sponsored.ts
@@ -1,0 +1,21 @@
+// The sponsored registry rail (register · endpoint list/remove): the server
+// builds the tx, the seller signs the bytes, the server sponsor-co-signs
+// and executes. Gasless; the Move contract authorizes on ctx.sender(), so
+// sponsorship never weakens auth. The host guard (`setSponsoredTxGuard`)
+// runs before the address leaves the process and again on the bytes.
+
+import { fromBase64 } from '@mysten/sui/utils';
+import type { TransactionSigner } from '../signer.js';
+import { runSponsoredTxGuard } from '../sponsored-guard.js';
+
+/** Sign prepared bytes (after the guard sees them). */
+export async function signPreparedTx(
+  base: string,
+  action: string,
+  signer: TransactionSigner,
+  txBytes: string,
+): Promise<string> {
+  runSponsoredTxGuard({ base, action, txBytes });
+  const { signature } = await signer.signTransaction(fromBase64(txBytes));
+  return signature;
+}

--- a/packages/sdk/src/commerce/types.ts
+++ b/packages/sdk/src/commerce/types.ts
@@ -1,0 +1,170 @@
+// Seller-onboarding types (S.1158 — SPEC_HEADLESS_SELL_STACK §3). The
+// wire shapes mirror the api.t2000.ai routes 1:1 so a CLI / Connect / host
+// app can pass them through unchanged.
+
+import type { TransactionSigner } from '../signer.js';
+
+export interface CommerceClientOptions {
+  /** The seller's signer — a keypair (`KeypairSigner`) or zkLogin Passport. */
+  signer: TransactionSigner;
+  /** API base (default `https://api.t2000.ai/v1`). Callers pointing at a
+   *  custom host must pin it themselves — see `setSponsoredTxGuard`. */
+  apiBase?: string;
+}
+
+/** The directory categories `/v1/agent/profile` accepts — the server is the
+ *  authority and rejects off-enum values; this mirror fails fast locally. */
+export const AGENT_CATEGORIES = [
+  'ai-models',
+  'data-feeds',
+  'finance',
+  'research',
+  'dev-tools',
+  'creative',
+  'travel',
+  'comms',
+  'other',
+] as const;
+export type AgentCategory = (typeof AGENT_CATEGORIES)[number];
+
+export interface RegisterResult {
+  address: string;
+  /** True when the address was already an Agent ID — nothing was signed. */
+  alreadyRegistered: boolean;
+  /** The register tx digest (absent when already registered). */
+  digest?: string;
+}
+
+/** POST /v1/agent/profile — every field optional; omitted = untouched. */
+export interface ProfileUpdateInput {
+  /** Display name (≤60 chars). */
+  name?: string;
+  /** https image URL. */
+  imageUrl?: string;
+  /** Short description (≤500 chars). */
+  description?: string;
+  category?: AgentCategory | string;
+  website?: string;
+  twitter?: string;
+  github?: string;
+}
+
+/** The public profile row (GET /v1/agents/:address) — the fields a seller
+ *  flow reads back. Extra server fields pass through untouched. */
+export interface AgentProfile {
+  address: string;
+  name?: string | null;
+  numericId?: number | null;
+  category?: string | null;
+  active?: boolean;
+  [key: string]: unknown;
+}
+
+/** POST /v1/agent/service action "upsert" — a FULL upsert (omitted
+ *  optionals take the server defaults: review 1440 min, split 8000 bps). */
+export interface ServiceUpsertInput {
+  /** 2–48 chars of [a-z0-9-]; derive one with `slugify`. */
+  slug: string;
+  /** ≤80 chars. */
+  name: string;
+  /** ≤2000 chars. */
+  description: string;
+  /** Fixed price in USDC — within the escrow job bounds. */
+  priceUsdc: number;
+  /** Delivery window once hired (minutes). */
+  slaMinutes: number;
+  /** What the buyer receives (≤1000 chars). */
+  deliverable: string;
+  /** REQUIRED by the API: the questions buyers answer at hire — free text,
+   *  or an object of field names → hints. */
+  requirements: string | Record<string, unknown>;
+  reviewWindowMinutes?: number;
+  rejectSplitBps?: number;
+  /** "create" refuses a LIVE slug (409) — the safe default for new
+   *  listings; "update" (the API default) overwrites. */
+  mode?: 'create' | 'update';
+  /** Gallery (S.1114) — omitted keeps the live set; [] clears it. */
+  examples?: unknown[];
+}
+
+export interface ServiceWriteResult {
+  address: string;
+  slug: string;
+  /** The API's response body, verbatim. */
+  response: Record<string, unknown>;
+}
+
+export const SERVICE_TIERS = ['basic', 'standard', 'premium'] as const;
+export type ServiceTier = (typeof SERVICE_TIERS)[number];
+
+/** One tier of a package — price + deliverable are the tier's own; the
+ *  rest defaults to the package-level values. */
+export interface PackageTierInput {
+  tier: ServiceTier;
+  priceUsdc: number;
+  deliverable: string;
+  slaMinutes?: number;
+  description?: string;
+  reviewWindowMinutes?: number;
+  rejectSplitBps?: number;
+}
+
+export interface CreatePackageInput {
+  /** The package name — every tier carries it; the tier lives in the slug. */
+  name: string;
+  description: string;
+  requirements: string | Record<string, unknown>;
+  /** Default delivery window for tiers that don't set their own. */
+  slaMinutes: number;
+  /** All three tiers, in any order; each tier at most once. */
+  tiers: PackageTierInput[];
+  /** Override the derived base slug (`packageBaseSlug(slugify(name))`). */
+  baseSlug?: string;
+  reviewWindowMinutes?: number;
+  rejectSplitBps?: number;
+}
+
+export interface CreatePackageResult {
+  address: string;
+  base: string;
+  tiers: { tier: ServiceTier; slug: string; priceUsdc: number }[];
+}
+
+export interface EndpointIssue {
+  code?: string;
+  message?: string;
+}
+
+export interface EndpointRoute {
+  method?: string;
+  path?: string;
+  url?: string;
+  priceUsdc?: string | null;
+  summary?: string | null;
+  probeOk?: boolean;
+  issues?: EndpointIssue[];
+}
+
+export interface EndpointListing {
+  address: string;
+  /** The primary paid URL (null after a remove). */
+  endpoint: string | null;
+  listed: boolean;
+  probe: {
+    ok?: boolean;
+    amount?: string | null;
+    currency?: string | null;
+    issues?: EndpointIssue[];
+  } | null;
+  origin: string | null;
+  primary: { path?: string; url?: string } | null;
+  routes: EndpointRoute[];
+  digest?: string;
+}
+
+/** `/v1/agents/resolve` — `#93` · `93` · `@handle` · `name.sui` · `0x…`. */
+export interface AgentRef {
+  address: string;
+  numericId?: number | null;
+  name?: string;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -226,6 +226,9 @@ export {
   submitJobReview,
 } from './open-jobs.js';
 export type { OpenJobFilter, OpenJobRow, OpenJobsPage } from './open-jobs.js';
+// Seller onboarding, headless (S.1158 — SPEC_HEADLESS_SELL_STACK §3): the
+// ONE write SSOT behind `t2 agent *` / `t2 service *`.
+export * from './commerce/index.js';
 // Digest → created-object resolution (S.906 SSOT — CLI + console + Connect).
 export {
   ESCROW_JOB_TYPE_MARKER,

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -17,6 +17,7 @@
 
 import { fromBase64 } from '@mysten/sui/utils';
 import type { TransactionSigner } from './signer.js';
+import { runSponsoredTxGuard } from './sponsored-guard.js';
 
 async function fetchJson(
   url: string,
@@ -43,28 +44,12 @@ async function fetchJson(
  *  on-chain Openings. `id` is the Opening OBJECT id (0x…). Buyer addresses
  *  never appear (registered-agent buyers surface by id); the claiming seller
  *  is public. Title + brief are public by design. */
-/** A host-installed veto on sponsored open-board transactions (S.930).
- *
- *  Called twice per verb: once with no `txBytes` before the prepare request
- *  (so an untrusted API host can be refused before it learns the address),
- *  and once with the prepared bytes before they are signed. Throwing from
- *  either aborts the verb.
- *
- *  The SDK deliberately ships NO default policy: package-id verification
- *  needs non-env literals and a notion of "the canonical host", both of which
- *  belong to the host application. Unset = today's behavior. */
-export type SponsoredTxGuard = (ctx: {
-  base: string;
-  action: string;
-  txBytes?: string;
-}) => void;
-
-let sponsoredTxGuard: SponsoredTxGuard | null = null;
-
-/** Install (or clear, with `null`) the sponsored-tx guard. */
-export function setSponsoredTxGuard(guard: SponsoredTxGuard | null): void {
-  sponsoredTxGuard = guard;
-}
+// The sponsored-tx guard moved to `sponsored-guard.ts` (S.1158) so the
+// commerce module shares it; re-exported here for compatibility.
+export {
+  setSponsoredTxGuard,
+  type SponsoredTxGuard,
+} from './sponsored-guard.js';
 
 export interface OpenJobRow {
   id: string;
@@ -179,7 +164,7 @@ async function sponsoredOpeningVerb(
   const address = signer.getAddress();
   // Host pin (S.930): a hook installed by the host app gets to refuse before
   // the wallet address reaches an untrusted builder.
-  sponsoredTxGuard?.({ base, action });
+  runSponsoredTxGuard({ base, action });
   const prep = await fetchJson(`${base}/job/prepare`, {
     method: 'POST',
     body: { address, action, params },
@@ -190,7 +175,7 @@ async function sponsoredOpeningVerb(
     throw new Error('Failed to prepare the transaction.');
   }
   // Intent check (S.930): and again with the bytes, before they are signed.
-  sponsoredTxGuard?.({ base, action, txBytes });
+  runSponsoredTxGuard({ base, action, txBytes });
   const { signature } = await signer.signTransaction(fromBase64(txBytes));
   const json = await fetchJson(`${base}/job/submit`, {
     method: 'POST',

--- a/packages/sdk/src/sponsored-guard.ts
+++ b/packages/sdk/src/sponsored-guard.ts
@@ -1,0 +1,33 @@
+// The host-installed veto on sponsored transactions (S.930) — ONE hook for
+// every SDK path that signs server-prepared bytes: the open board
+// (`open-jobs.ts`) and seller onboarding (`commerce/`). Called twice per
+// verb: once with no `txBytes` before the prepare request (an untrusted API
+// host can be refused before it learns the address), and once with the
+// prepared bytes before they are signed. Throwing from either aborts.
+//
+// The SDK deliberately ships NO default policy: package-id verification
+// needs non-env literals and a notion of "the canonical host", both of
+// which belong to the host application (the CLI installs
+// `installSponsoredTxGuard`). Unset = trust the host.
+
+export type SponsoredTxGuard = (ctx: {
+  base: string;
+  action: string;
+  txBytes?: string;
+}) => void;
+
+let sponsoredTxGuard: SponsoredTxGuard | null = null;
+
+/** Install (or clear, with `null`) the sponsored-tx guard. */
+export function setSponsoredTxGuard(guard: SponsoredTxGuard | null): void {
+  sponsoredTxGuard = guard;
+}
+
+/** Run the installed guard (no-op when none is installed). */
+export function runSponsoredTxGuard(ctx: {
+  base: string;
+  action: string;
+  txBytes?: string;
+}): void {
+  sponsoredTxGuard?.(ctx);
+}


### PR DESCRIPTION
H1 of `SPEC_HEADLESS_SELL_STACK.md` §3 — the SDK gets the sell path the CLI had, and the CLI becomes a thin wrapper over it.

## SDK — `packages/sdk/src/commerce/`
- `CommerceClient({ signer, apiBase? })`: `register()` (sponsored, idempotent) · `updateProfile()` · `ensureCategory()` · `upsertService()` / `retireService()` · `createPackage({ name, tiers })` · `listEndpoint()` / `removeEndpoint()` (x402, live-probed, per-route findings in the error) · `profile()` · `resolveRef()`.
- `resolveAgentRef(q, apiBase?)` → `GET /agents/resolve?q=` (separate from `normalizeAddressInput`, which stays chain-only). `getAgentProfile`.
- `package-slug.ts` — `slugify` / `packageBaseSlug` / `parseServiceTierSlug` / `MAX_TIER_BASE_LENGTH` **copied** from audric `service-tiers.ts` (no audric dep). Note: the console's value is `48 - "-standard".length` = **39**, not the 38 the prompt quoted — parity with the console is the lock, tests pin 39.
- `createPackage` = three sequential upserts Basic → Premium with `mode: "create"` (API refuses a LIVE slug → loud 409; the set stops there).
- Errors: `T2000Error` with the API's own message (`INVALID_INPUT` on 4xx, `CONTACT_NOT_FOUND` on a resolve miss).
- `sponsored-guard.ts`: the S.930 host hook moved out of `open-jobs.ts` so the open board and commerce share ONE `setSponsoredTxGuard` (re-exported from `open-jobs.ts` for compat).
- Tests: slug parity (console cases), payload-hash mirror (WebCrypto == node:crypto), challenge grammars, resolve URL/miss, `planPackage`, and the client end-to-end on a stub signer (register + guard veto, profile, upsert/retire, package collision, endpoint probe failure/success/remove).

## CLI refactor
- `t2 agent register / create / profile / sell`, `t2 service create / retire`, `ensureSellerCategory`, `resolveAgentRef` → SDK. The duplicated `fetchJson` in `agent/index.ts`, `agent/create.ts`, `getJson` in `agent-category.ts`, and the inline register rail are gone; `runSponsoredTx` (job verbs) and `lib/services.ts fetchJson` (reads + job review) stay.
- JSON shapes unchanged; the S.930 locks still run via `installSponsoredTxGuard` (host pin before the address is sent, `register` / `update` intent on the bytes).

## Docs
- New `how-to/sell-headlessly.mdx` (+ nav), `agent-sdk.mdx` seller-onboarding block, CLI reference pointer, SDK README section.

## Verify
- `pnpm --filter @t2000/sdk test` 598/598 (44 new) · `pnpm --filter @t2000/cli test` 306/306 (docs-consistency incl.) · repo typecheck 10/10 · sdk build.
- Live with the built CLI (real wallet): `t2 agent register --json` → `alreadyRegistered: true` (SDK prepare path); `t2 agent profile --category <current>` → signed-challenge path; `t2 services '#16'` → resolve via SDK; unknown ref → `CONTACT_NOT_FOUND` with the server sentence; `t2 agent create --category bogus` refuses before any side effect. Did **not** run `t2 agent create --name Test` against mainnet (it would register a permanent public "Test" agent) — say the word if you want that dogfood run.

## Not in this PR
- llms.txt (audric) — SDK sell verbs + `resolveAgentRef` grammar, per the spec's "after ship" step.
- Release: **minor** bump via `release.yml` after review (new SDK surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)