### PR TITLE
📝 docs(ops): Featured pin copy lock — plan perk, not volume; rank among the rest (S.1163)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -51,7 +51,7 @@ t2 swap 100 USDC SUI --quote
 | Command | What it does |
 | --- | --- |
 | `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
-| `t2 services [query]` | Discover Services in the Agent Marketplace — hire (escrow) and instant (pay-per-call x402). `--rail hire\|api\|all` picks the block (default hire); `kind:"api"` rows carry the absolute URL for `t2 pay`. Market browse is ranked featured → most settled USDC → newest (api rows: seller paid-call volume). Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller; free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | Discover Services in the Agent Marketplace — hire (escrow) and instant (pay-per-call x402). `--rail hire\|api\|all` picks the block (default hire); `kind:"api"` rows carry the absolute URL for `t2 pay`. Market browse is two-step: **Featured pins** (a paid-plan perk, `featured: true` on the row — never earned by volume) sort first; the **remaining rows** rank by seller lifetime settled USDC → newest (api rows: seller paid-call volume). Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller; free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 t2 services "chat"
@@ -153,7 +153,7 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service create` | seller | List (or update — same slug overwrites). Required: `--name` · `--price <usdc>` · `--sla <duration>` · `--description` · `--deliverable`. Optional: `--slug` · `--requirements` (prefer a JSON object of required buyer fields — enforced at hire) · `--review 24h` · `--split 8000` · `--category <cat>` (required once unless set on your profile). |
 | `t2 service list [agent]` | anyone | An agent's services — your own wallet's by default (retired included). |
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
-| `t2 services [query]` | buyer | Search Services across every agent (ranked featured → most settled → newest) — `--rail api` for pay-per-call x402 routes, `--rail all` for both; scope to one seller with `0x…` / `#id` / `@handle`, or a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | buyer | Search Services across every agent (Featured pins — a paid-plan perk — first; the rest ranked by settled USDC → newest) — `--rail api` for pay-per-call x402 routes, `--rail all` for both; scope to one seller with `0x…` / `#id` / `@handle`, or a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
 <Note>
 Work-example images are not set from the CLI or from a Connect `service_create`

--- a/apps/docs/how-to/sell-headlessly.mdx
+++ b/apps/docs/how-to/sell-headlessly.mdx
@@ -89,6 +89,14 @@ const seller = await client.resolveRef('#16');          // { address, numericId,
 Errors are `T2000Error` with the API's own message (`code` `INVALID_INPUT`
 for a 4xx, `CONTACT_NOT_FOUND` for a resolve miss).
 
+## Market browse (pin vs rank)
+
+**Featured pin** is a paid plan perk — `featured: true` on a listing row, not
+earned by settle volume. Among **non-pinned** rows, `/services` (and
+`t2 services` / `t2000_services`) ranks by seller lifetime settled USDC, then
+newest. Two things, one sentence: pinned rows first, then the rest by what
+they've settled.
+
 ## Pointing at another host
 
 The SDK ships no host pin. If you construct the client with a custom

--- a/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
+++ b/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
@@ -218,7 +218,7 @@ Brief: 3 original tweet angles (hire/work/earn) — each ≤240 chars, no fake m
 Brief: Markdown table 5 rows: t2000 Open job vs manual Discord "do work DM me" — escrow, receipt, fee, claim, dispute.
 
 **50 — Week-1 seller checklist**  
-Brief: Markdown checklist 10 items: Agent ID → list service/packages (3 tier slugs or loner) → work examples on Standard tier → **Featured pin is a plan perk; rank otherwise follows settled volume** → first Open or hire test → review window truth → headless path = 3× `t2000_service_create` or SDK `createPackage` when shipped.
+Brief: Markdown checklist 10 items: Agent ID → list service/packages (3 tier slugs or loner) → per-tier work examples (Basic / Standard / Premium each own their gallery; loners one gallery) → **Featured pin is a plan perk (`featured: true` on the row) — it is NOT earned by settle volume; among non-pinned rows, browse rank = seller settled USDC → newest** → first Open or hire test → review window truth → headless path = SDK `CommerceClient.createPackage({ name, tiers })` (shipped, `@t2000/sdk@10.37.0`) or 3× `t2000_service_create` — both valid.
 
 ---
 


### PR DESCRIPTION
`SPEC_HEADLESS_SELL_STACK.md` Part C S.1163 · §2.1 founder lock — copy only, t2000 repo only.

**Canon (one sentence):** **Featured pin** = paid-plan perk (`featured: true` on a service row). **Among non-pinned rows**, market browse rank = seller lifetime settled USDC → newest.

## Changes
- `ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md` **job #50** — S.1165 reality: per-tier work examples (Basic / Standard / Premium each own a gallery); headless path = SDK `CommerceClient.createPackage` (shipped, `@t2000/sdk@10.37.0`) or 3× `t2000_service_create`; the Featured line now says explicitly "NOT earned by settle volume". Job #44 untouched (already correct).
- `apps/docs/cli-reference.mdx` — both `t2 services` rows: Featured pins (plan perk) sort first; the remaining rows rank by settled USDC → newest.
- `apps/docs/how-to/sell-headlessly.mdx` — new **Market browse (pin vs rank)** subsection with the canon sentence.

## Sweep
`rg -i "volume earn|earn…pin|settled…pin|earns featured"` over `ops/`, `apps/docs/`, README, PRODUCT, skills → only job #44 (correct) and job #50 (fixed). GTM desk/settle prompts carry no Featured copy (N/A). audric `t2000_services` / chat tool text says "ranked Featured → most settled → newest" — an order statement, not a cause — so no audric commit.

## Verify
- `rg -n "plan perk|non-pinned"` → sell-headlessly + cli-reference hits; `rg -n "per-tier|createPackage"` → PROMPT-50 job #50.
- CLI `docs-consistency` test 2/2.
- No rank code, no llms.txt, no npm. S.1164 / S.1166 not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)