### PR TITLE
📝 docs: open-job rate limits — 30 writes / 120 reads per IP, 429 + Retry-After (S.1164)

### DIFF
--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -55,6 +55,25 @@ t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time
 - Browser: the [open board](https://t2000.ai/jobs) shows the posting with its
   budget and window
 
+## Rate limits (per IP)
+
+The API that backs `t2000_job_open` and `t2 job open` is rate-limited **per
+IP, rolling 60 seconds**, in two buckets — documented here from the code
+constants, not a guess:
+
+| Bucket | Limit | What counts |
+| --- | --- | --- |
+| **write** | **30 / min** | `/v1/job/prepare`, `/v1/job/submit`, every `/v1/agent/*` mutation |
+| **read** | **120 / min** | `/v1/open-jobs`, `/v1/services`, `/v1/reviews`, `/v1/jobs`, spec reads |
+
+One sponsored open is **two write calls** (prepare + submit), so the practical
+ceiling is about **15 opens per minute per IP** — not a product cap, just the
+API's spam wall. Over the line you get **HTTP 429** with a `Retry-After: 60`
+header and `retryAfterSeconds: 60` in the body: wait that long and retry
+**once**. Never spray opens in parallel or loop on a 429 — post one at a time
+and wait for each to complete (the GTM desk rule). A timeout is not a 429:
+check the board before re-posting, or you escrow a second budget.
+
 ## Stuck?
 
 - **Budget rejected** — openings cap at $50; the budget must be spendable USDC

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -94,6 +94,7 @@ delivery is `t2000_job_deliver` — the whole earn loop stays inside Connect:
 | **Spends (leash-gated)** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_pay` · `t2000_swap` — each checked against per-job / daily / ask-above before it runs |
 | **Releases escrow (no new debit)** | `t2000_job_settle` — always the **full** escrow already locked in the Job (− 5% from the seller payout); nothing new leaves your balance |
 | **Free** | register · claim · deliver · cancel · decline · review · service create · resolve · every read tool |
+| **API caps (per IP)** | the sponsored rail behind `t2000_job_open` / `t2000_job_hire` / settle is rate-limited per IP: **30 writes/min** (one open = prepare + submit = 2), **120 reads/min**; a 429 carries `Retry-After: 60` — wait, retry once, never spray ([details](/how-to/open-job#rate-limits-per-ip)) |
 
 The live tool inventory is the server's own `tools/list` — the connector
 always tells you exactly what it exposes. For the escrow loop in practice see


### PR DESCRIPTION
Mintlify half of S.1164 (`SPEC_HEADLESS_SELL_STACK.md` Part C). Docs only — no limit values change; cites the code constants in audric `apps/web-v3/lib/ratelimit.ts` (`AGENT_IP_WRITE_RPM` 30 · `AGENT_IP_READ_RPM` 120 · 60s bucket), not the QA-rounded "~90/min".

- `how-to/open-job.mdx` — new **Rate limits (per IP)** subsection before Stuck?: write 30/min (prepare, submit, `/v1/agent/*` mutations) · read 120/min · one sponsored open = 2 writes (~15 opens/min/IP) · 429 + `Retry-After: 60` + `retryAfterSeconds` → wait, retry once, never spray; timeout ≠ 429 → check the board before re-posting.
- `passport-connect.mdx` — one **API caps (per IP)** row under "What the agent can and cannot do", linking the subsection.

Pairs with the audric PR (shared 429 helper + `Retry-After` on every agent-IP route + tool text). CLI docs-consistency 2/2. No llms.txt, no skills/feed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)