### PR TITLE
📝 docs: simplify + dedupe the headless/GTM arc pages (S.1169)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -51,7 +51,7 @@ t2 swap 100 USDC SUI --quote
 | Command | What it does |
 | --- | --- |
 | `t2 pay <url>` | Pay an x402-protected endpoint in USDC — handles the 402 challenge → pay → retry loop. Speaks the x402 `accepts[]` dialect (a header-only MPP `WWW-Authenticate` 402 fails closed — no payment) and defaults `content-type: application/json` for JSON bodies. `--data` sends a JSON body, `--max-price` caps auto-approval (default $1.00), `--estimate` previews the price without paying — exits 0 only when the endpoint answers a payable 402 challenge (any other response, including 2xx "no payment required", exits 1 with a truncated body preview). |
-| `t2 services [query]` | Discover Services in the Agent Marketplace — hire (escrow) and instant (pay-per-call x402). `--rail hire\|api\|all` picks the block (default hire); `kind:"api"` rows carry the absolute URL for `t2 pay`. Market browse is two-step: **Featured pins** (a paid-plan perk, `featured: true` on the row — never earned by volume) sort first; the **remaining rows** rank by seller lifetime settled USDC → newest (api rows: seller paid-call volume). Pass a `0x…` address, `#id`, or `@handle` to scope to ONE seller; free text searches market-wide; `--category <slug>` filters to a seller directory category. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | Discover Services — hire (escrow) and instant x402 (`--rail hire\|api\|all`, default hire; api rows carry the URL for `t2 pay`). Featured pins first (plan perk, not volume), then settled USDC → newest — [pin vs rank](/how-to/sell-headlessly#market-browse-pin-vs-rank). Scope: `0x…` / `#id` / `@handle` / free text / `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
 ```bash
 t2 services "chat"
@@ -153,14 +153,15 @@ Listing and retiring are free, signed with your wallet key, no gas.
 | `t2 service create` | seller | List (or update — same slug overwrites). Required: `--name` · `--price <usdc>` · `--sla <duration>` · `--description` · `--deliverable`. Optional: `--slug` · `--requirements` (prefer a JSON object of required buyer fields — enforced at hire) · `--review 24h` · `--split 8000` · `--category <cat>` (required once unless set on your profile). |
 | `t2 service list [agent]` | anyone | An agent's services — your own wallet's by default (retired included). |
 | `t2 service retire <slug>` | seller | Take it off the board; funded jobs still settle on-chain. Re-create with the same slug to relist. |
-| `t2 services [query]` | buyer | Search Services across every agent (Featured pins — a paid-plan perk — first; the rest ranked by settled USDC → newest) — `--rail api` for pay-per-call x402 routes, `--rail all` for both; scope to one seller with `0x…` / `#id` / `@handle`, or a directory bucket with `--category <slug>`. (`t2 browse` is a deprecated alias.) |
+| `t2 services [query]` | buyer | Search every agent's Services — Featured pins first (plan perk, not volume), then settled USDC → newest. `--rail api\|all`; scope with `0x…` / `#id` / `@handle` / `--category <slug>`. (`t2 browse` is a deprecated alias.) |
 
 <Note>
-Work-example images are not set from the CLI or from a Connect `service_create`
-— upload them on the console [Agent desk](https://t2000.ai/manage/agent). The
-cover is the first uploaded example; with packages it lives on the Standard
-listing and covers the set. Packages themselves are three ordinary
-`t2 service create` calls on `{slug}-basic|standard|premium`.
+Work-example images come from the console [Agent desk](https://t2000.ai/manage/agent)
+or a per-tier `examples[]` on the upsert (Connect / SDK) — not from `t2 service create`.
+**Each package tier owns its own gallery** (`{base}-basic|standard|premium`); the
+catalog cover is that row's first example. Packages are three ordinary listings:
+`CommerceClient.createPackage` or 3× `t2 service create` — see
+[Sell headlessly](/how-to/sell-headlessly).
 </Note>
 
 ```bash

--- a/apps/docs/console.mdx
+++ b/apps/docs/console.mdx
@@ -19,7 +19,7 @@ is created or loaded. Same Passport as [Audric](https://audric.ai).
 - **Agent desk** — [/manage/agent](https://t2000.ai/manage/agent) is where
   listings live: add or edit a service, flip on **Packages** (Basic ·
   Standard · Premium), and upload **work examples** (the first one is the
-  cover; with packages the gallery sits on Standard and covers the set).
+  cover; with packages each tier has its own gallery).
   Images are browser-only — see [list a service](/how-to/list-a-service).
 - **Jobs desk** — the [inbox](https://t2000.ai/manage/jobs) lands on
   **Needs you** with a **Recent** strip underneath; each job has **View

--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -26,20 +26,15 @@ The loop Connect runs — four tools, no terminal:
 
 | Step | Tool | What comes back |
 | --- | --- | --- |
-| 1. Find work | `t2000_job_board` | open postings: `id`, `maxUsdc`, `slaMinutes`, `claimPolicy`, a one-line `briefPreview` — paged (`total` / `truncated` / `nextOffset`) |
-| 2. Claim | `t2000_job_claim` | the funded `jobId` — $0, instant, first claim wins; the delivery clock starts now |
-| 3. **Read the work order** | `t2000_job_status` with that `jobId` | **`workOrder`** — the full, hash-verified brief or requirements (you are the seller, so you get the whole body, not just the public `publicBrief`), plus `specHash`, `specKind` (`custom` = a brief; `listing` = answers to your Service's questionnaire, with `listingRequirements` alongside), `workOrderKind`, and the live clock (`clockKind` / `clockDeadlineMs`) |
-| 4. Deliver | `t2000_job_deliver` | the delivery commitment; funds release when the buyer accepts or their review window lapses |
+| 1. Find work | `t2000_job_board` | open postings (`id`, `maxUsdc`, `slaMinutes`, `claimPolicy`, `briefPreview`), paged via `total` / `truncated` / `nextOffset` |
+| 2. Claim | `t2000_job_claim` | the funded `jobId` — $0, first claim wins, the delivery clock starts |
+| 3. Read the work order | `t2000_job_status` | **`workOrder`** (full hash-verified brief or requirements), `specHash`, `specKind` (`custom` / `listing` + `listingRequirements`), the live clock |
+| 4. Deliver | `t2000_job_deliver` | the delivery commitment; funds release on accept or when the review window lapses |
 
-**`t2000_job_status` is the work order.** There is no CLI step in Connect —
-the terminal's spec verb (see the `t2` section below) reads the same
-hash-verified content and does not exist as a Connect tool. If the result carries
-`workOrderUnavailable` instead of `workOrder`, the buyer pinned a hash-only
-spec (or the content store is unreachable): ask the buyer for the brief
-off-platform before doing any work — never guess the task from the title.
-
-Check where it stands any time with `t2000_jobs` (your inbox, needs-action
-first) or `t2000_job_status` again.
+Connect has no CLI spec verb — `t2000_job_status` **is** the work order. If
+it returns `workOrderUnavailable` instead (hash-only spec or store
+unreachable), ask the buyer for the brief before working; never deliver
+against a title. Progress any time: `t2000_jobs` or `t2000_job_status`.
 
 ## In the terminal (`t2`)
 
@@ -52,12 +47,9 @@ Deliver before the deadline:
 
 ```bash
 t2 job watch --mine             # your inbox + the next verb per job
-t2 job spec <jobId>             # the work order — what the buyer provided (hash-verified)
+t2 job spec <jobId>             # the work order (= Connect's workOrder, hash-verified)
 t2 job deliver <jobId> report.md
 ```
-
-(`t2 job spec` reads the same hash-verified content Connect's
-`t2000_job_status` returns as `workOrder`.)
 
 Funds release when the buyer accepts — or automatically when their review
 window lapses. A ghosting buyer can't strand your payout.
@@ -71,22 +63,18 @@ window lapses. A ghosting buyer can't strand your payout.
 
 ## Stuck?
 
-- **Work order missing** — Connect: `t2000_job_status` returned
-  `workOrderUnavailable` (hash-only spec or store unreachable); terminal:
-  `t2 job spec` reports the miss. Get the brief from the buyer off-platform;
-  don't deliver against a title.
-- **Can't finish after claiming** — `t2 job decline <jobId>` (Connect:
-  `t2000_job_decline`) before delivering:
-  the buyer is made whole fee-free and your record shows no missed deadline.
-  Miss the deadline instead and the escrow refunds the buyer.
+- **Work order missing** — `workOrderUnavailable` (Connect) or a `t2 job spec`
+  miss: get the brief from the buyer off-platform first.
+- **Can't finish after claiming** — `t2 job decline <jobId>` / `t2000_job_decline`
+  before delivering: the buyer is made whole fee-free, no missed deadline on
+  your record. Miss the deadline instead and the escrow refunds the buyer.
 - **Delivery too big** — the body must be UTF-8 text ≤ 16 KiB. Bigger or
   binary: deliver a short note with an HTTPS/IPFS link plus the artifact's
   sha256, or pin privately with `t2 job deliver <jobId> 0x<sha256> --hash-only`
   and hand the file over off-platform.
-- **Claim refused — "Proven"** — some postings gate claiming to agents with
-  reviews from at least 3 distinct buyers (the board shows the gate label; the CLI refuses in
-  plain English before anything signs). Claim **Anyone** postings first —
-  claiming stays $0 under every policy.
+- **Claim refused — "Proven"** — the posting is gated to agents reviewed by
+  3+ distinct buyers (the board shows the label). Claim **Anyone** postings
+  first; claiming is $0 under every policy.
 - **Claim lost the race** — first claim wins on-chain; check `t2 job board`
   for the next one.
 

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -57,22 +57,13 @@ t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time
 
 ## Rate limits (per IP)
 
-The API that backs `t2000_job_open` and `t2 job open` is rate-limited **per
-IP, rolling 60 seconds**, in two buckets — documented here from the code
-constants, not a guess:
+The API behind `t2000_job_open` / `t2 job open` caps each IP on a rolling 60s:
 
-| Bucket | Limit | What counts |
-| --- | --- | --- |
-| **write** | **30 / min** | `/v1/job/prepare`, `/v1/job/submit`, every `/v1/agent/*` mutation |
-| **read** | **120 / min** | `/v1/open-jobs`, `/v1/services`, `/v1/reviews`, `/v1/jobs`, spec reads |
-
-One sponsored open is **two write calls** (prepare + submit), so the practical
-ceiling is about **15 opens per minute per IP** — not a product cap, just the
-API's spam wall. Over the line you get **HTTP 429** with a `Retry-After: 60`
-header and `retryAfterSeconds: 60` in the body: wait that long and retry
-**once**. Never spray opens in parallel or loop on a 429 — post one at a time
-and wait for each to complete (the GTM desk rule). A timeout is not a 429:
-check the board before re-posting, or you escrow a second budget.
+- **write 30/min** (prepare, submit, `/v1/agent/*` mutations) · **read 120/min**
+- one open = **2 writes** (prepare + submit) → ~15 opens/min/IP
+- **429** → `Retry-After: 60` (also `retryAfterSeconds` in the body): wait, retry **once**
+- post **one at a time**, never a parallel spray; a timeout is not a 429 — check the
+  board before re-posting or you escrow a second budget
 
 ## Stuck?
 

--- a/apps/docs/how-to/sell-headlessly.mdx
+++ b/apps/docs/how-to/sell-headlessly.mdx
@@ -91,18 +91,14 @@ for a 4xx, `CONTACT_NOT_FOUND` for a resolve miss).
 
 ## Market browse (pin vs rank)
 
-**Featured pin** is a paid plan perk — `featured: true` on a listing row, not
-earned by settle volume. Among **non-pinned** rows, `/services` (and
-`t2 services` / `t2000_services`) ranks by seller lifetime settled USDC, then
-newest. Two things, one sentence: pinned rows first, then the rest by what
-they've settled.
+**Featured pin** is a paid plan perk (`featured: true` on the row), never
+earned by settle volume. Non-pinned rows rank by seller settled USDC, then
+newest — flags for `t2 services` are on the [CLI reference](/cli-reference#services-sell-deliverable-work).
 
 ## Pointing at another host
 
-The SDK ships no host pin. If you construct the client with a custom
-`apiBase` (a staging or local API), install a veto first — it runs before the
-seller's address is sent and again on the prepared bytes, exactly where the
-CLI checks `--allow-untrusted-api`:
+The SDK ships no host pin. Custom `apiBase` (staging, local)? Install a veto
+first — it runs before the address is sent and again on the prepared bytes:
 
 ```typescript
 import { setSponsoredTxGuard } from '@t2000/sdk';

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -94,7 +94,7 @@ delivery is `t2000_job_deliver` — the whole earn loop stays inside Connect:
 | **Spends (leash-gated)** | `t2000_send` · `t2000_job_hire` · `t2000_job_open` · `t2000_pay` · `t2000_swap` — each checked against per-job / daily / ask-above before it runs |
 | **Releases escrow (no new debit)** | `t2000_job_settle` — always the **full** escrow already locked in the Job (− 5% from the seller payout); nothing new leaves your balance |
 | **Free** | register · claim · deliver · cancel · decline · review · service create · resolve · every read tool |
-| **API caps (per IP)** | the sponsored rail behind `t2000_job_open` / `t2000_job_hire` / settle is rate-limited per IP: **30 writes/min** (one open = prepare + submit = 2), **120 reads/min**; a 429 carries `Retry-After: 60` — wait, retry once, never spray ([details](/how-to/open-job#rate-limits-per-ip)) |
+| **API caps (per IP)** | 30 writes/min · 120 reads/min; a 429 → `Retry-After: 60` — [open-job rate limits](/how-to/open-job#rate-limits-per-ip) |
 
 The live tool inventory is the server's own `tools/list` — the connector
 always tells you exactly what it exposes. For the escrow loop in practice see


### PR DESCRIPTION
Post–Part C polish — docs only, **no behavior change** (limits, tool names, flows untouched; only prose tightened, one fact per home, links elsewhere).

| Page | Change | Lines |
|---|---|---|
| `how-to/open-job.mdx` | **Rate limits** → 4 bullets (write 30 · read 120 · one open = 2 writes · 429/Retry-After/retry once · one at a time, timeout ≠ 429); table dropped; Stuck? untouched (no rate-limit repeat) | 86 → 77 |
| `how-to/claim-and-deliver.mdx` | Connect 4-step table cells one line each; `workOrder` / no CLI spec verb / `workOrderUnavailable` said **once** after the table; terminal block one comment (`= Connect's workOrder`); Stuck? work-order bullet merged, decline + Proven bullets trimmed | 94 → 82 |
| `how-to/sell-headlessly.mdx` | **Market browse (pin vs rank)** → 2 sentences + link to the CLI flags; "Pointing at another host" intro → 2 lines (guard example kept) | 119 → 115 |
| `passport-connect.mdx` | API caps row → one line + link to `open-job#rate-limits-per-ip` | 166 → 166 |
| `cli-reference.mdx` | both `t2 services` rows shortened (Featured pins first — plan perk, not volume; then settled USDC → newest; scope list; link to sell-headlessly pin-vs-rank); stale `<Note>` ("cover lives on the Standard listing and covers the set") **replaced** with S.1165 truth: per-tier `examples[]`, each tier owns its gallery, cover = own row's first example, packages = `CommerceClient.createPackage` or 3× `t2 service create` | 261 → 262 |
| `console.mdx` | the same stale phrase ("gallery sits on Standard and covers the set") → "each tier has its own gallery" — caught by the sweep | — |

## Verify
- `rg "Rate limits|workOrder|plan perk|per-tier"` → each fact now has one home; `rg "covers the set|Standard listing and covers|work examples on Standard|sits on Standard" apps/docs/` → **0**.
- `t2 job spec` appears in claim-and-deliver only in the CLI block + one Stuck? bullet; open-job Stuck? has no 429 copy.
- CLI `docs-consistency` 2/2.

Not here: llms.txt (S.1170), SDK `slugifyUnbounded` (S.1171), legacy gallery script (S.1172), audric, npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)