### PR TITLE
🐛 fix(sdk): createPackage base from the unbounded kebab, not a 48-capped slug (S.1171)

### DIFF
--- a/packages/sdk/src/commerce/index.ts
+++ b/packages/sdk/src/commerce/index.ts
@@ -10,12 +10,16 @@ export {
 export { endpointIssueLines, listEndpoint, removeEndpoint } from './endpoint.js';
 export { createPackage, planPackage } from './package.js';
 export {
+  MAX_SLUG_LENGTH,
   MAX_TIER_BASE_LENGTH,
+  packageBaseFromName,
   packageBaseSlug,
   packageTierSlugs,
   parseServiceTierSlug,
   SERVICE_SLUG_RE,
   slugify,
+  slugifyLoner,
+  slugifyUnbounded,
   trimDashes,
 } from './package-slug.js';
 export { ensureCategory, parseAgentCategory, updateProfile } from './profile.js';

--- a/packages/sdk/src/commerce/package-slug.test.ts
+++ b/packages/sdk/src/commerce/package-slug.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  MAX_SLUG_LENGTH,
   MAX_TIER_BASE_LENGTH,
+  packageBaseFromName,
   packageBaseSlug,
   packageTierSlugs,
   parseServiceTierSlug,
   SERVICE_SLUG_RE,
   slugify,
+  slugifyLoner,
+  slugifyUnbounded,
 } from './package-slug.js';
 
 // S.1158 — COPIED from audric `apps/console/lib/service-tiers.ts`; these
@@ -45,5 +49,43 @@ describe('package slug math (parity with console service-tiers)', () => {
       'brand-kit-standard',
       'brand-kit-premium',
     ]);
+  });
+});
+
+// S.1171 — parity with console `service-slug.ts` (S.1161): a long package
+// name must go UNBOUNDED kebab → tier-base budget. The old path (48-cap,
+// THEN budget) cut the name twice and shipped `…cryptocurrenc-basic`.
+describe('package base from a long name (S.1171 — console parity)', () => {
+  const LONG =
+    'Deep-dive research report on any cryptocurrency token, with on-chain data and sources';
+
+  it('slugify stays the 48-cap loner rule; slugifyUnbounded has no cap', () => {
+    expect(slugify('  Sui Market Report!! ')).toBe('sui-market-report');
+    expect(slugify(LONG)).toHaveLength(MAX_SLUG_LENGTH);
+    expect(slugifyLoner(LONG)).toBe(slugify(LONG));
+    expect(slugifyUnbounded(LONG).length).toBeGreaterThan(MAX_SLUG_LENGTH);
+    expect(slugifyUnbounded('---')).toBe('');
+  });
+
+  it('packageBaseFromName: base ≤ 39, every tier slug ≤ 48 with its suffix intact — the console\'s exact base', () => {
+    const base = packageBaseFromName(LONG);
+    // The console (apps/console/lib/service-slug.ts) yields this for the
+    // same name — pinned literally so the two cannot drift.
+    expect(base).toBe('deep-dive-research-report-on-any-crypto');
+    expect(base.length).toBeLessThanOrEqual(MAX_TIER_BASE_LENGTH);
+    for (const { tier, slug } of packageTierSlugs(base)) {
+      expect(slug.length).toBeLessThanOrEqual(MAX_SLUG_LENGTH);
+      expect(slug).toMatch(SERVICE_SLUG_RE);
+      expect(slug.endsWith(`-${tier}`)).toBe(true);
+    }
+  });
+
+  it('the old order (48-cap first) is never shorter-or-equal by accident — the budget runs once', () => {
+    const old = packageBaseSlug(slugify(LONG));
+    const fixed = packageBaseFromName(LONG);
+    // Both land within budget, but the fixed base is computed ONCE from the
+    // unbounded kebab; the old path could lose up to 9 extra chars.
+    expect(fixed.length).toBeGreaterThanOrEqual(old.length);
+    expect(packageBaseFromName('Market report')).toBe('market-report');
   });
 });

--- a/packages/sdk/src/commerce/package-slug.ts
+++ b/packages/sdk/src/commerce/package-slug.ts
@@ -2,9 +2,15 @@
 // three ordinary service rows `{base}-basic|standard|premium` on the same
 // agent — no schema field, every row a normal listing + Hire target.
 //
-// COPIED (not imported) from audric `apps/console/lib/service-tiers.ts` —
-// the SDK cannot depend on `@audric/*`; keep the two in step (the unit
-// tests here mirror the console's budget/parse cases).
+// COPIED (not imported) from audric `apps/console/lib/service-tiers.ts` +
+// `service-slug.ts` (S.1161) — the SDK cannot depend on `@audric/*`; keep
+// the two in step (the unit tests here mirror the console's cases).
+//
+// ORDER MATTERS (S.1171, the console's S.1161 lesson):
+//   loner    → slugifyUnbounded(name).slice(0, 48)        = slugify / slugifyLoner
+//   package  → packageBaseSlug(slugifyUnbounded(name))    = packageBaseFromName
+// Capping at 48 BEFORE the 39-char tier-base budget cut long names twice and
+// shipped mangled tier slugs (`…cryptocurrenc-basic`). Never do that.
 
 import { SERVICE_TIERS, type ServiceTier } from './types.js';
 
@@ -21,10 +27,25 @@ export function trimDashes(s: string): string {
   return s.slice(start, end);
 }
 
-/** The CLI's name → slug rule (lowercase, runs of non-alphanumerics → `-`,
- *  trimmed, 48-char cap). */
+/** The API's slug cap (SERVICE_SLUG_RE: 2–48 chars). */
+export const MAX_SLUG_LENGTH = 48;
+
+/** Lowercase kebab, edge dashes trimmed, NO length cap — the input to BOTH
+ *  budgets below. */
+export function slugifyUnbounded(name: string): string {
+  return trimDashes(name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-'));
+}
+
+/** Single-listing (loner) slug — the full 48-char budget. */
+export function slugifyLoner(name: string): string {
+  return slugifyUnbounded(name).slice(0, MAX_SLUG_LENGTH);
+}
+
+/** The CLI's name → slug rule for LONERS (`t2 service create`): lowercase,
+ *  runs of non-alphanumerics → `-`, trimmed, 48-char cap. Loner-only — a
+ *  package base must come from `packageBaseFromName`, never from this. */
 export function slugify(name: string): string {
-  return trimDashes(name.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-')).slice(0, 48);
+  return slugifyLoner(name);
 }
 
 // Suffix must be the FINAL segment: `logo-pack-basic` parses,
@@ -53,6 +74,13 @@ export function packageBaseSlug(slugified: string): string {
   let end = cut.length;
   while (end > 0 && cut.charCodeAt(end - 1) === 45) end -= 1;
   return cut.slice(0, end);
+}
+
+/** Package base from a display name — unbounded kebab, THEN the tier-base
+ *  budget (trailing dashes shed), so every `{base}-{tier}` is a valid slug
+ *  with its suffix intact. Mirrors console `packageBaseFromName`. */
+export function packageBaseFromName(name: string): string {
+  return packageBaseSlug(slugifyUnbounded(name));
 }
 
 /** The three tier slugs for a base, Basic → Standard → Premium. */

--- a/packages/sdk/src/commerce/package.ts
+++ b/packages/sdk/src/commerce/package.ts
@@ -7,10 +7,10 @@
 import type { TransactionSigner } from '../signer.js';
 import { invalidInput } from './http.js';
 import {
+  packageBaseFromName,
   packageBaseSlug,
   packageTierSlugs,
   SERVICE_SLUG_RE,
-  slugify,
 } from './package-slug.js';
 import { upsertService } from './service.js';
 import {
@@ -31,7 +31,13 @@ export function planPackage(input: CreatePackageInput): {
   if (!name) {
     throw invalidInput('name is required.');
   }
-  const base = packageBaseSlug((input.baseSlug ?? slugify(name)).trim().toLowerCase());
+  // S.1171: the base is the UNBOUNDED kebab run through the 39-char tier
+  // budget — never a 48-capped slug first (that shipped `…cryptocurrenc-basic`
+  // from the console until S.1161). A caller-supplied baseSlug is trusted as
+  // given (trimmed + budgeted, not re-kebabed).
+  const base = input.baseSlug
+    ? packageBaseSlug(input.baseSlug.trim().toLowerCase())
+    : packageBaseFromName(name);
   if (!base || !SERVICE_SLUG_RE.test(`${base}-basic`)) {
     throw invalidInput(
       'Could not derive a package slug from the name — pass baseSlug (a-z, 0-9, dashes).',

--- a/packages/sdk/src/commerce/types.ts
+++ b/packages/sdk/src/commerce/types.ts
@@ -63,7 +63,7 @@ export interface AgentProfile {
 /** POST /v1/agent/service action "upsert" — a FULL upsert (omitted
  *  optionals take the server defaults: review 1440 min, split 8000 bps). */
 export interface ServiceUpsertInput {
-  /** 2–48 chars of [a-z0-9-]; derive one with `slugify`. */
+  /** 2–48 chars of [a-z0-9-]; derive one with `slugify` (loner, 48-cap). */
   slug: string;
   /** ≤80 chars. */
   name: string;
@@ -118,7 +118,8 @@ export interface CreatePackageInput {
   slaMinutes: number;
   /** All three tiers, in any order; each tier at most once. */
   tiers: PackageTierInput[];
-  /** Override the derived base slug (`packageBaseSlug(slugify(name))`). */
+  /** Override the derived base slug (default: `packageBaseFromName(name)` =
+   *  `packageBaseSlug(slugifyUnbounded(name))` — never a 48-capped slug first). */
   baseSlug?: string;
   reviewWindowMinutes?: number;
   rejectSplitBps?: number;


### PR DESCRIPTION
Post–Part C follow-up (`PROMPT-S1171-SDK-PACKAGE-SLUG-ALIGN.md`): align SDK package-slug derivation with the console's S.1161 fix. No audric change, no publish here (founder runs `release.yml` **patch** after merge).

## Root cause
`planPackage` did `packageBaseSlug(slugify(name))` — `slugify` caps at 48 *before* the 39-char tier-base budget, so a long name was cut twice and tier slugs shipped mangled (`…cryptocurrenc-basic`). Same bug class the console fixed in S.1161.

## Changes — `packages/sdk/src/commerce/`
- **`package-slug.ts`** (still a copy-in of console `service-tiers.ts` + `service-slug.ts`, no `@audric/*`): `MAX_SLUG_LENGTH` (48) · `slugifyUnbounded` (kebab, linear `trimDashes`, **no cap**) · `slugifyLoner` (`.slice(0, 48)`) · `packageBaseFromName` = `packageBaseSlug(slugifyUnbounded(name))`. **`slugify` keeps the 48-cap loner rule** (now delegates to `slugifyLoner`, documented loner-only) — CLI `t2 service create` unchanged. `MAX_TIER_BASE_LENGTH` still `48 - '-standard'.length` (39). Header comment spells out the order.
- **`package.ts`**: base = `packageBaseFromName(name)` when `baseSlug` is omitted; a caller-supplied `baseSlug` is trimmed + budgeted as before. `rg 'slugify\(name\)' package.ts` → 0.
- **`index.ts`**: exports the four new names. **`types.ts`**: `slug` / `baseSlug` comments updated.
- **`package-slug.test.ts`** (+3): `slugify` unchanged for loners; `packageBaseFromName` on the long crypto name pins the console's **exact** base `deep-dive-research-report-on-any-crypto` (39) with tier slugs 45/48/47, all matching `SERVICE_SLUG_RE` with suffixes intact; the budget runs once (fixed ≥ old).

## Verify
- `pnpm --filter @t2000/sdk test` **601/601** · `pnpm --filter @t2000/cli test` **306/306** · lint 0 errors (pre-existing warnings only) · typecheck + build clean.
- `planPackage` on the long name → `deep-dive-research-report-on-any-crypto-{basic,standard,premium}` (45/48/47).

Not here: audric, S.1172 gallery script, `PackageTierInput.examples`, npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)