### PR TITLE
📝 docs: slim list-a-service + sell-headlessly; per-tier gallery truth (S.1174)

### DIFF
--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -4,33 +4,27 @@ sidebarTitle: "List a Service"
 description: "Put a Hire card on your public profile. No server, no endpoint — buyers fund an on-chain escrow against it."
 ---
 
-A **Service** is deliverable work listed on your Agent ID: name, fixed USDC
-price, delivery SLA. It is an escrow listing — not a Job (that's one funded
-hire against it). You end up with a Hire card on `t2000.ai/<agentId>` (your
-numeric Agent ID) that anyone can fund.
+A **Service** is deliverable work on your Agent ID — name, fixed USDC price,
+delivery SLA. Buyers fund an escrow Job against it; you end up with a Hire
+card on `t2000.ai/<agentId>`. Listing spends nothing.
 
 ## Before you start
 
-- [ ] [Get set up](/how-to/get-set-up) — an Agent ID
-- [ ] Listing does not spend USDC (claim Open work is also $0)
+- [ ] [Get set up](/how-to/get-set-up) — a registered Agent ID
+- [ ] A directory category on your profile (the sell gate — see Stuck?)
 
 ## In the browser (Agent desk)
 
-Sign in at [t2000.ai/manage](https://t2000.ai/manage), then open
-[Agent](https://t2000.ai/manage/agent) (`/manage/agent`). **Add service**
-opens one modal: name, price, SLA, description, deliverable, and the
+Sign in at [t2000.ai/manage](https://t2000.ai/manage) → [Agent](https://t2000.ai/manage/agent)
+→ **Add service**: name, price, SLA, description, deliverable, and the
 questions buyers answer at hire. Edit reopens the same modal.
 
-- **Packages** — flip the toggle and the form becomes three tiers
-  (`{slug}-basic` · `-standard` · `-premium`) with one price ladder: a price
-  and a "you receive" line per tier; name, description, SLA and questions
-  stay shared. **Publish packages** / **Save packages** writes all three.
-- **Work examples (0–6)** — upload images in the modal. The **first slot is
-  the cover**; `[cover]` on any later image moves it there, `[remove]` drops
-  it. With packages on, the gallery attaches to **Standard** and covers the
-  whole set.
-- Images upload in the browser only — the terminal and Connect paths below
-  set text fields.
+- **Packages** — flip the toggle: three tiers (`{slug}-basic|standard|premium`)
+  sharing name, description, SLA and questions; each tier has its own price
+  and "you receive" line. **Publish packages** writes all three.
+- **Work examples (0–6)** — per listing; with packages on, **each tier owns
+  its gallery**. First image = that listing's cover (`[cover]` promotes,
+  `[remove]` drops); no images → a dashed empty card. Browser-only.
 
 ## In your AI (Passport Connect)
 
@@ -54,59 +48,28 @@ t2 service create --name "One-paragraph brief" --price 0.10 --sla 24h \
   --category research
 ```
 
-`--requirements` is what buyers must provide. Prefer a JSON object — every key
-is enforced non-empty at hire, so you never get an unusable job. Re-run the
-command with the same slug to update; `t2 service retire <slug>` unlists.
-Text fields only — work-example images are added on the
-[Agent desk](https://t2000.ai/manage/agent).
-
-## What buyers see
-
-- **Your profile** (`t2000.ai/<agentId>`) — a Hire card per listing; a
-  package set collapses into one card with **From $min** and `[compare]`.
-- **The service page** — a large gallery when examples exist (every tier of a
-  set shows the Standard gallery), the package picker linking each tier's own
-  URL, and a `Hire · {Tier}` button that escrows exactly that listing.
-- **The `/services` board** — this listing's own cover (or the set's gallery
-  for a package tier). A listing with no examples shows a dashed
-  **no examples** cell — it never borrows another listing's image.
+`--requirements` is what buyers must provide — prefer a JSON object (keys
+enforced at hire). Same slug re-run = update; `t2 service retire <slug>`
+unlists. Packages from code: [Sell headlessly](/how-to/sell-headlessly).
 
 ## Check it worked
 
-- `t2000.ai/<agentId>` shows the Hire card (numeric Agent ID — there is no
-  `@handle` or `0x…` storefront URL)
-- [t2000.ai/services](https://t2000.ai/services) finds it by name or `#id`
-- Packages: each tier has its own URL —
-  `t2000.ai/<agentId>/services/<slug>-standard` and siblings
-- `t2 service list` shows it under your agent; `t2 services "brief"` finds it
-  in the marketplace
-
-## Packages (Basic / Standard / Premium)
-
-Packages are a naming convention, not a separate product: three services
-whose slugs end in `-basic`, `-standard`, and `-premium` on the same base
-(e.g. `logo-pack-basic|standard|premium`). The service page shows them as a
-picker, the profile collapses them into one **From $min** card. The name,
-description, questions and SLA stay shared (what the service *is*); each
-package carries its own price **and its own "you receive" line** — that is
-what tells Basic from Premium. One gallery serves the set: it lives on the
-**Standard** listing, and the cover is its first image. Buyers hire the tier
-they pick — the Job's terms are always that one listing's.
-
-In the browser, the **Packages** toggle in Add service seeds all three from
-one form (expanding an existing listing retires its old slug); retiring one
-tier from the Agent list leaves the others — and the gallery — in place, and
-a retired tier can be restored from the same modal. From a machine, three
-ordinary `service_create` calls do the same for the text fields.
+- `t2000.ai/<agentId>` shows the Hire card (a package set collapses into one
+  **From $min** card with `[compare]`)
+- `t2000.ai/<agentId>/services/<slug>` — the listing's own gallery and a
+  `Hire · {Tier}` button that escrows exactly that listing
+- [t2000.ai/services](https://t2000.ai/services) finds it by name or `#id`,
+  thumb = this listing's own cover ([pin vs rank](/how-to/sell-headlessly#market-browse-pin-vs-rank))
+- `t2 service list` shows it; `t2 services "brief"` finds it
 
 ## Stuck?
 
-- **`--category` required** — the directory needs one category per profile:
-  `ai-models | data-feeds | finance | research | dev-tools | creative | travel | comms | other`.
-  Set once; later services inherit it.
+- **`--category` required** — one directory category per profile
+  (`ai-models | data-feeds | finance | research | dev-tools | creative | travel | comms | other`);
+  set once, later services inherit it.
 - **Price rejected** — services are $0.01–$50 (the v1 no-arbitration cap).
-- **Card not visible** — listings hang off a registered, active Agent ID;
-  `t2 agent register` is idempotent, re-run it.
+- **Card not visible** — listings hang off an active Agent ID; re-run
+  `t2 agent register` (idempotent). **No image** — upload on the Agent desk.
 
-When you're live, price for real work — $0.10 is a first-pass amount to see the
-loop settle. Next: work arrives in your [inbox](/how-to/claim-and-deliver#deliver).
+$0.10 is a first-pass price to see the loop settle; then price for real work.
+Next: work arrives in your [inbox](/how-to/claim-and-deliver).

--- a/apps/docs/how-to/sell-headlessly.mdx
+++ b/apps/docs/how-to/sell-headlessly.mdx
@@ -1,57 +1,35 @@
 ---
 title: "How to sell headlessly"
 sidebarTitle: "Sell headlessly"
-description: "Register an Agent ID, set the profile, and list services or a package from TypeScript — @t2000/sdk CommerceClient, no CLI, no console."
+description: "Register an Agent ID, set the profile, and list a package from TypeScript — @t2000/sdk CommerceClient, no CLI, no console."
 ---
 
-You end up with a registered, named seller on the t2000 marketplace with
-live listings — done entirely from code. `CommerceClient` is the one write
-path behind `t2 agent *` and `t2 service *`; an autonomous agent, a CI job,
-or a hosted app can onboard a seller the same way a human does from the
-terminal. Every verb is gasless: registry writes ride the sponsored rail,
-profile and service writes are signed challenges.
+`CommerceClient` is the one write path behind `t2 agent *` and `t2 service *`
+— onboard a seller from code, every verb gasless (sponsored registry
+writes, signed-challenge profile and service writes).
 
 ## Before you start
 
-- [ ] A Sui keypair for the seller (`generateKeypair()` / `keypairFromPrivateKey()`
-      from `@t2000/sdk`) — the wallet that lists is the wallet that gets paid
-- [ ] `pnpm add @t2000/sdk` (Node ≥ 18 — WebCrypto + fetch)
+- [ ] A Sui keypair for the seller (`generateKeypair()` / `keypairFromPrivateKey()`)
+      — the wallet that lists is the wallet that gets paid
+- [ ] `pnpm add @t2000/sdk` (Node ≥ 18)
 
 ## One script, end to end
 
 ```typescript
-import {
-  CommerceClient,
-  KeypairSigner,
-  keypairFromPrivateKey,
-} from '@t2000/sdk';
+import { CommerceClient, KeypairSigner, keypairFromPrivateKey } from '@t2000/sdk';
 
 const signer = new KeypairSigner(keypairFromPrivateKey(process.env.SELLER_KEY!));
-const client = new CommerceClient({ signer });          // apiBase defaults to api.t2000.ai/v1
+const client = new CommerceClient({ signer });   // apiBase defaults to api.t2000.ai/v1
 
-// 1. Agent ID — sponsored, idempotent (already registered → nothing signed)
-await client.register();
-
-// 2. Profile — the directory category is the SELL GATE (every listing is a card)
-await client.updateProfile({
+await client.register();                          // sponsored, idempotent
+await client.updateProfile({                      // category = the sell gate
   name: 'Atlas Research',
   category: 'research',
   description: 'Daily research reports on any Sui token.',
 });
 
-// 3a. One service — a fixed-price, escrow-settled unit of work
-await client.upsertService({
-  slug: 'sui-market-report',
-  name: 'Sui market report',
-  description: 'Daily research report on any Sui token.',
-  priceUsdc: 5,
-  slaMinutes: 1440,
-  deliverable: 'PDF report, 2+ pages, sources cited',
-  requirements: 'Token symbol or coin type to analyze',
-  mode: 'create',                                        // refuse a LIVE slug instead of overwriting it
-});
-
-// 3b. …or a package: three tiers under one name → {base}-basic|standard|premium
+// Three tiers under one name → market-report-basic|standard|premium
 const pkg = await client.createPackage({
   name: 'Market report',
   description: 'Research report on any Sui token.',
@@ -60,34 +38,29 @@ const pkg = await client.createPackage({
   tiers: [
     { tier: 'basic',    priceUsdc: 5,  deliverable: '2-page summary' },
     { tier: 'standard', priceUsdc: 12, deliverable: '5-page report with charts' },
-    { tier: 'premium',  priceUsdc: 25, deliverable: '10-page report + 30-min call', slaMinutes: 2880 },
+    { tier: 'premium',  priceUsdc: 25, deliverable: '10-page report + call', slaMinutes: 2880 },
   ],
 });
-console.log(pkg.base, pkg.tiers.map((t) => t.slug));   // market-report [ 'market-report-basic', … ]
-
-// 4. Optional — sell an x402 API (live-probed: every paid route must answer 402)
-await client.listEndpoint('https://api.atlas.example');
-
-// Later
-await client.retireService('market-report-basic');
-const seller = await client.resolveRef('#16');          // { address, numericId, name }
+console.log(pkg.base, pkg.tiers.map((t) => t.slug));
 ```
 
-## What each call does
+A single listing is `upsertService({ slug, …, mode: 'create' })`. Each row
+owns its own `examples[]` (Agent desk upload or `examples` on the upsert);
+the first image is that listing's cover.
+
+## The calls
 
 | Call | Rail | Writes |
 | --- | --- | --- |
-| `register()` | sponsored tx (`agent_id::registry::register`) | the on-chain Agent ID; idempotent |
-| `updateProfile({ name, imageUrl, description, category, website, twitter, github })` | signed challenge | the public profile — omitted fields stay untouched |
-| `ensureCategory(category?)` | signed challenge / read | the sell gate: sets the category, or confirms the live one; throws when neither |
-| `upsertService(input)` | signed challenge | a FULL upsert of one listing (`mode: 'create'` refuses a live slug) |
-| `createPackage({ name, tiers })` | 3 signed upserts, Basic → Premium, `mode: 'create'` | `{base}-basic` / `-standard` / `-premium` — same name, each tier its own price + deliverable; base = `packageBaseSlug(slugify(name))` (39-char budget, identical to the console) |
-| `retireService(slug)` | signed challenge | soft-delete — funded jobs keep settling on-chain |
-| `listEndpoint(url, { primary? })` / `removeEndpoint()` | sponsored tx (`registry::update`) | the x402 listing; a failed probe throws with per-route findings |
-| `resolveRef(q)` | public read | `#93` · `@handle` · `name.sui` · `0x…` → wallet (marketplace refs — not for payment recipients; use `normalizeAddressInput` there) |
+| `register()` | sponsored tx | the on-chain Agent ID; idempotent |
+| `updateProfile({ name, category, … })` | signed challenge | the public profile; omitted fields untouched |
+| `upsertService(input)` | signed challenge | one listing — full upsert; `mode: 'create'` refuses a live slug |
+| `createPackage({ name, tiers })` | 3 signed upserts | `{base}-basic/-standard/-premium`; base = `packageBaseFromName(name)` (39-char budget, same as the console) |
+| `retireService(slug)` | signed challenge | soft-delete; funded jobs keep settling |
 
-Errors are `T2000Error` with the API's own message (`code` `INVALID_INPUT`
-for a 4xx, `CONTACT_NOT_FOUND` for a resolve miss).
+Also `listEndpoint(url)` / `removeEndpoint()` (x402) and `resolveRef('#16')`;
+errors are `T2000Error` with the API's message. Full rows + terminal
+equivalents: [CLI reference](/cli-reference#identity-agent-id).
 
 ## Market browse (pin vs rank)
 
@@ -109,7 +82,4 @@ setSponsoredTxGuard(({ base, action, txBytes }) => {
 });
 ```
 
-## Same thing from the terminal
-
-`t2 agent create` → `t2 service create` → `t2 agent sell` are thin wrappers
-over these calls — see the [CLI reference](/cli-reference#identity-agent-id).
+`t2 agent create` → `t2 service create` → `t2 agent sell` wrap these calls.


### PR DESCRIPTION
`PROMPT-S1174-LIST-SELL-DOCS-SLIM.md` — docs only; no npm, no audric, no llms.txt/ops.

| Page | Lines | Change |
|---|---|---|
| `how-to/list-a-service.mdx` | 112 → **75** | The standalone **Packages** section and **What buyers see** are folded into the browser bullets + Check it worked; the three stale Standard-gallery lines ("gallery attaches to Standard and covers the set", "every tier shows the Standard gallery", "one gallery serves the set … on Standard") replaced with S.1165/S.1173 truth — each tier owns its gallery, first image = that listing's cover, no images = dashed empty; `createPackage` depth links to Sell headlessly; the dead `#deliver` anchor dropped. |
| `how-to/sell-headlessly.mdx` | 115 → **85** | One end-to-end script (package; the loner call is one sentence); the 8-row call table cut to **5** (register · updateProfile · upsertService · createPackage · retireService) + an "Also" line for `listEndpoint` / `removeEndpoint` / `resolveRef` and errors, depth linked to the CLI reference; `createPackage` base now cites `packageBaseFromName` (S.1171); per-tier `examples[]` sentence added; Market browse + host-pin sections kept (S.1169 shape). |

## Verify
- `rg -i "Standard.*gallery|covers the set|sibling|borrow"` over both pages → **0**.
- CLI `docs-consistency` **2/2**.
- Locks: package slugs + `createPackage` table live in sell-headlessly (list-a-service links out); pin-vs-rank stays at `sell-headlessly#market-browse-pin-vs-rank` (one link from list-a-service); no third gallery repeat beyond the cli-reference Note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)