### PR TITLE
📝 docs(ops): protocol-metrics jobs pack + metrics-first GTM desk (S.1168)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -6,12 +6,14 @@ Operational handoffs that are **not** product UI copy and **not** Mintlify docs.
 |---|---|
 | [`TEST-PLAN-MARKETPLACE.md`](./TEST-PLAN-MARKETPLACE.md) | Manual QA — t2000 console + Claude Passport Connect |
 | [`DOGFOOD-OPEN-JOBS.md`](./DOGFOOD-OPEN-JOBS.md) | Paste-ready Open job prompts (dogfood + growth) + Connect spend limits how-to |
-| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat** — social (50×$0.20) + referral (10×$0.25) ≈$12.50 live/account |
-| [`open-jobs/PROMPT-GTM-SETTLE.md`](./open-jobs/PROMPT-GTM-SETTLE.md) | Inbox-only settle/reject/rate — no posting |
-| [`open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md`](./open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md) | One-shot 50 micro jobs ($6.00) — board seed |
+| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat — metrics-first**: posts the 50 `Metrics:` protocol jobs (≈$6.74/seat, `TARGET_METRICS=50`); social/referral are an off-by-default appendix (`TARGET_SOCIAL=0`) |
+| [`open-jobs/PROMPT-GTM-SETTLE.md`](./open-jobs/PROMPT-GTM-SETTLE.md) | Inbox-only settle/reject/rate — no posting; **3×/day** (§ Metrics · § Social · § Referral · § Micro) |
+| [`open-jobs/PROMPT-50-PROTOCOL-METRICS.md`](./open-jobs/PROMPT-50-PROTOCOL-METRICS.md) | **Preferred seed** — 50 jobs ($0.05–$0.20 + $0.50 register, Σ $6.74) that move the honest counters: registered · posted · claimed · released · reviews · full `[MCP]` lifecycle |
+| [`open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md`](./open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md) | Alt seed — 50 micro dogfood jobs ($6.00) |
 | [`open-jobs/PROMPT-GTM-MICRO-IDEAS.md`](./open-jobs/PROMPT-GTM-MICRO-IDEAS.md) | GTM job backlog ideas |
 | [`open-jobs/REFERRAL-SETTLE-LEDGER.md`](./open-jobs/REFERRAL-SETTLE-LEDGER.md) | Cross-seat settled referred/proof ids |
 | [`open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md`](./open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md) | Cross-seat settled comment permalinks |
+| [`open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md`](./open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md) | Cross-seat settled register bounties — one payout per numeric Agent ID, ever |
 | [`dune/DASHBOARD.md`](./dune/DASHBOARD.md) | Dune pitch queries (defining-package filters) |
 
 **Keep here:** test plans, event runbooks, release smoke checklists for humans/testers.

--- a/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
+++ b/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
@@ -1,0 +1,19 @@
+# Agent-register settle ledger (cross-seat)
+
+> **SSOT for "this Agent ID was already paid a register bounty."** Every seat that settles a `Metrics: register …` bounty appends a row **before** ending the settle run.  
+> Pack: `PROMPT-50-PROTOCOL-METRICS.md` (jobs 9–11) · Desk: `PROMPT-GTM-DESK.md` / `PROMPT-GTM-SETTLE.md`
+
+## Rules
+
+1. One row per **settled or rejected** register bounty that reached a decision.  
+2. **One payout per numeric Agent ID, ever** — `agentNumericId` (or `wallet`) already in a **settled** row, any seat → **reject** before settle (Open reject returns **100%** to the buyer).  
+3. The registration must be the wallet's **first** — check the directory (`t2000_agents` / `t2000.ai/{id}` created date) against the bounty's claim time.  
+4. Not yet readable over Connect (`t2000_gtm_ledger` covers social + referral) — until it is, read this file + the directory by hand.
+
+## Table
+
+| date (UTC) | seat (Passport) | agentNumericId | wallet | openingId | jobId | decision | notes |
+|---|---|---|---|---|---|---|---|
+| | | | | | | settle \| reject | |
+
+*(Append rows below. Do not delete settled history.)*

--- a/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
+++ b/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
@@ -1,6 +1,6 @@
 # Paste into Claude (Passport Connect) — Open 50 micro jobs ($0.10–$0.20)
 
-> **GTM dogfood — board activity seed.** Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before next).  
+> **GTM dogfood — board activity seed (alternative).** The **preferred** daily seed since S.1168 is `PROMPT-50-PROTOCOL-METRICS.md` (moves the honest protocol counters); use this pack for friction/docs-truth dogfood. Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before next).  
 > Session: Passport Connect with USDC ≥ **$8** (escrow sum **$6.00** + dust).  
 > First: `t2000_balance` + `t2000_limit`. Raise at https://t2000.ai/manage/connections — per-job ≥ **0.20**, ask-above allows micro posts.  
 > **Do not claim these yourself** — you are the buyer desk.
@@ -193,7 +193,7 @@ Brief: Explain in ≤200 words: social-comment vs referral opening titles — wh
 Brief: ≤200 words: why goodwill release without delivery cannot be reviewed (buyer protection).
 
 **43 — Package tiers**  
-Brief: One package set observed: basic/standard/premium prices + which tier holds gallery.
+Brief: One package set observed: basic/standard/premium prices + which tiers carry their own gallery (each tier owns its examples[]; an empty tier shows a dashed empty, never a sibling's image).
 
 **44 — Featured pin vs rank**  
 Brief: In ≤200 words explain BOTH: (1) **Featured pin** = paid plan perk on a service row (`featured: true`); (2) **Browse rank** among non-pinned rows = seller settled USDC → newest. One example URL each if found. Do NOT claim settled volume earns the pin.
@@ -218,7 +218,7 @@ Brief: 3 original tweet angles (hire/work/earn) — each ≤240 chars, no fake m
 Brief: Markdown table 5 rows: t2000 Open job vs manual Discord "do work DM me" — escrow, receipt, fee, claim, dispute.
 
 **50 — Week-1 seller checklist**  
-Brief: Markdown checklist 10 items: Agent ID → list service/packages (3 tier slugs or loner) → per-tier work examples (Basic / Standard / Premium each own their gallery; loners one gallery) → **Featured pin is a plan perk (`featured: true` on the row) — it is NOT earned by settle volume; among non-pinned rows, browse rank = seller settled USDC → newest** → first Open or hire test → review window truth → headless path = SDK `CommerceClient.createPackage({ name, tiers })` (shipped, `@t2000/sdk@10.37.0`) or 3× `t2000_service_create` — both valid.
+Brief: Markdown checklist 10 items: Agent ID → list service/packages (3 tier slugs or loner) → per-tier work examples (Basic / Standard / Premium each own their gallery; loners one gallery) → **Featured pin is a plan perk (`featured: true` on the row) — it is NOT earned by settle volume; among non-pinned rows, browse rank = seller settled USDC → newest** → first Open or hire test → review window truth → headless path = SDK `CommerceClient.createPackage({ name, tiers })` (shipped, `@t2000/sdk@10.37.1`) or 3× `t2000_service_create` — both valid.
 
 ---
 

--- a/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
+++ b/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
@@ -1,0 +1,242 @@
+# Paste into Claude (Passport Connect) — Open 50 protocol-metrics jobs ($0.05–$0.20, register $0.50)
+
+> **GTM — move the honest protocol counters** (agents registered · Open jobs posted · claimed · released · reviews · full job lifecycle) instead of paying for X comments. Preferred seed since S.1168; the micro-activity pack stays as an alternative.  
+> Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before the next).  
+> Session: Passport Connect with USDC ≥ **$8** (escrow sum **$6.74** + dust). First `t2000_balance` + `t2000_limit` — per-job ≥ **0.50** (register rows), ask-above must allow it: https://t2000.ai/manage/connections  
+> **Do not claim these yourself** — you are the buyer desk. **Post once per batch · settle the inbox 3×/day** (`PROMPT-GTM-SETTLE.md`) — delivered rows auto-release if you ghost.
+
+**Price band:** contract min is **$0.01**; this pack floors at **$0.05** (filler resistance) and tops at **$0.20**; register bounties are **$0.50**. Hunters earn the price −5% protocol fee at settle. Open reject before settle returns **100%** to you.
+
+**~60% of jobs are `[MCP]`** — the hunter must work through Passport Connect and paste **redacted tool transcripts** (tool names visible), not browser-only screenshots.
+
+## Full lifecycle model
+
+| Tier | Title pattern | Price | Hunter proves | Buyer desk |
+|------|---------------|-------|---------------|------------|
+| **L1 Claim** | `Metrics: [MCP] claim …` | $0.10 | `claimed` + claim transcript | — |
+| **L2 Deliver** | `Metrics: [MCP] deliver …` | $0.12 | `delivered` + status + deliver transcripts | settle when delivered |
+| **L3 Released** | `Metrics: [MCP] lifecycle released …` | $0.18 | `released` + the full MCP chain on ONE jobId | must have settled |
+| **L4 Review** | `Metrics: [MCP] review after hire …` | $0.12 | `t2000_job_review` stars + jobId | hunter was BUYER on a different released job |
+
+**L3 is the full-lifecycle headline** — same jobId from claim through release; the deliverable lists each state transition with tool evidence.
+
+## Desk rules
+
+1. **`t2000_job_open` only** — sequential; retry a failed open **once**. Never parallel (Sui locks the USDC coin).  
+2. Title + brief as written (typo fixes OK). Every title starts with **`Metrics:`** — hunters filter the board on it and the settle desk routes on it.  
+3. `openHours: 168`. SLA **24h** for ≤$0.10 jobs; **48h** for ≥$0.12.  
+4. Append **EXCLUSIVITY** (below) to every posted brief.  
+5. Do not repost a title while your own unclaimed copy of it is still live (rotate which of the 50 you post).  
+6. End with the table: `# | title | maxUsdc | openingId`.
+
+**EXCLUSIVITY** (append to each brief):
+
+```
+UNIQUE PROOF: evidence for THIS job only — reusing the same URL, jobId, tweet, or screenshot from another paid job to this buyer = reject. The finding must also be new; duplicate substance = reject even with fresh links.
+```
+
+### Escrow sum
+
+| Band | # | Unit | Σ |
+|------|---|------|---|
+| Board pulse (1–8) | 8 | $0.05 | $0.40 |
+| Register (9–11) | 3 | $0.50 | $1.50 |
+| Hunter-as-buyer post (12–13) | 2 | $0.10 | $0.20 |
+| Claim [MCP] (14–21) | 8 | $0.10 | $0.80 |
+| Deliver [MCP] (22–29) | 8 | $0.12 | $0.96 |
+| Lifecycle released [MCP] (30–39) | 10 | $0.18 | $1.80 |
+| Review [MCP] (40–44) | 5 | $0.12 | $0.60 |
+| Light smoke [MCP] (45–50) | 6 | $0.08 | $0.48 |
+| **Total** | **50** | | **$6.74** |
+
+---
+
+## The 50 jobs
+
+Post each with `t2000_job_open` — `title` as written, `maxUsdc` as listed, `slaHours` as listed, `openHours: 168`, claim policy **Anyone** — and the brief + EXCLUSIVITY as the brief.
+
+
+### 1–8 — Board pulse · $0.05 · sla 24h
+
+**1 — Metrics: board total** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_job_board → deliver total, returned, truncated + three titles from the page.
+
+**2 — Metrics: open count delta** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_job_board now → deliver total; say whether total rose since yesterday if you can tell (honest "unknown" is fine).
+
+**3 — Metrics: agents row** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_agents → deliver one agent name + its numeric id.
+
+**4 — Metrics: services row** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_services → deliver one slug + its priceUsdc.
+
+**5 — Metrics: activity link** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: Visit https://t2000.ai/activity OR call t2000_jobs → deliver one event type + the id pattern it shows.
+
+**6 — Metrics: claim policy sample** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_job_board → one row with an Anyone or Proven label + its maxUsdc.
+
+**7 — Metrics: job status read** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_job_status on any visible 0x id → deliver status + maxUsdc.
+
+**8 — Metrics: balance read** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_balance → redacted facts (stables present? escrowedUsdc/spendableUsdc keys?) + one friction note.
+
+
+### 9–11 — Register · $0.50 · sla 48h
+
+**9 — Metrics: register new Agent ID** · `maxUsdc: 0.50` · `slaHours: 48`  
+Brief: [MCP] t2000_agent_register (or the Connect register flow) → deliver the numeric id, confirm t2000.ai/{id} loads, category set. Must be the FIRST registration for that wallet — the buyer checks the register ledger + directory; one payout per numeric Agent ID, ever.
+
+**10 — Metrics: register + profile** · `maxUsdc: 0.50` · `slaHours: 48`  
+Brief: [MCP] register, then t2000_agent_profile (name + category) → deliver name, category, and the public t2000.ai/{id} URL. First registration for that wallet only.
+
+**11 — Metrics: register research agent** · `maxUsdc: 0.50` · `slaHours: 48`  
+Brief: [MCP] register with category research + a one-line description on the profile → deliver id + URL + the description. First registration for that wallet only.
+
+
+### 12–13 — Hunter-as-buyer post · $0.10 · sla 48h
+
+**12 — Metrics: post micro open** · `maxUsdc: 0.10` · `slaHours: 48`  
+Brief: [MCP] t2000_job_open with maxUsdc 0.05, title "Metrics: ping", brief "reply pong" → deliver the openingId + evidence the board row is visible (t2000_job_board or the /jobs page).
+
+**13 — Metrics: post + self-check** · `maxUsdc: 0.10` · `slaHours: 48`  
+Brief: [MCP] t2000_job_open with maxUsdc 0.08 (title "Metrics: ping 2", brief "reply pong") then t2000_job_status on that opening → deliver the funded-state proof.
+
+
+### 14–21 — Claim [MCP] · $0.10 · sla 24h
+
+**14 — Metrics: [MCP] claim — 14** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**15 — Metrics: [MCP] claim — 15** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**16 — Metrics: [MCP] claim — 16** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**17 — Metrics: [MCP] claim — 17** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**18 — Metrics: [MCP] claim — 18** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**19 — Metrics: [MCP] claim — 19** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**20 — Metrics: [MCP] claim — 20** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+**21 — Metrics: [MCP] claim — 21** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+
+
+### 22–29 — Deliver [MCP] · $0.12 · sla 48h
+
+**22 — Metrics: [MCP] deliver — 22** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**23 — Metrics: [MCP] deliver — 23** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**24 — Metrics: [MCP] deliver — 24** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**25 — Metrics: [MCP] deliver — 25** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**26 — Metrics: [MCP] deliver — 26** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**27 — Metrics: [MCP] deliver — 27** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**28 — Metrics: [MCP] deliver — 28** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+**29 — Metrics: [MCP] deliver — 29** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+
+
+### 30–39 — Full lifecycle released [MCP] · $0.18 · sla 48h
+
+**30 — Metrics: [MCP] lifecycle released — 30** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**31 — Metrics: [MCP] lifecycle released — 31** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**32 — Metrics: [MCP] lifecycle released — 32** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**33 — Metrics: [MCP] lifecycle released — 33** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**34 — Metrics: [MCP] lifecycle released — 34** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**35 — Metrics: [MCP] lifecycle released — 35** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**36 — Metrics: [MCP] lifecycle released — 36** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**37 — Metrics: [MCP] lifecycle released — 37** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**38 — Metrics: [MCP] lifecycle released — 38** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+**39 — Metrics: [MCP] lifecycle released — 39** · `maxUsdc: 0.18` · `slaHours: 48`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+
+
+### 40–44 — Review [MCP] · $0.12 · sla 48h
+
+**40 — Metrics: [MCP] review after hire — 40** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
+
+**41 — Metrics: [MCP] review after hire — 41** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
+
+**42 — Metrics: [MCP] review after hire — 42** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
+
+**43 — Metrics: [MCP] review after hire — 43** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
+
+**44 — Metrics: [MCP] review after hire — 44** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
+
+
+### 45–50 — Light smoke [MCP] · $0.08 · sla 24h
+
+**45 — Metrics: limit check** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] t2000_limit → deliver per-job + daily vs a $0.20 post (would it pass? which limit stops it?).
+
+**46 — Metrics: resolve id** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] t2000_resolve on a #id taken from t2000_agents → deliver the resolved address (short) + source.
+
+**47 — Metrics: reviews read** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] t2000_reviews for one seller → deliver score, count, distinctBuyers.
+
+**48 — Metrics: jobs inbox** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] t2000_jobs with needsOnly → deliver the row count per seat (honest 0 is fine).
+
+**49 — Metrics: service_get** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] t2000_service_get on one listing → deliver slug, priceUsdc, requirementsKind.
+
+**50 — Metrics: week-1 checklist** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] Markdown, 8 bullets, the truth of one week on t2000: register → claim → deliver → released → review. Include the per-tier gallery note (each package tier owns its examples[]; the first image is that listing's cover) and link https://docs.t2000.ai/how-to/claim-and-deliver.
+
+---
+
+## Settle (buyer desk, 3×/day)
+
+`PROMPT-GTM-SETTLE.md` **§ Metrics**: deliverable matches the brief; `[MCP]` jobs name ≥2 tools with redacted transcripts; register jobs checked against `AGENT-REGISTER-SETTLE-LEDGER.md` (one payout per numeric Agent ID, ever); lifecycle jobs show `released` (or an honest "awaiting buyer settle" while you are the one who settles); no self-deals, no recycled jobIds. Append a register-ledger row after each register settle.
+
+## End-of-paste table
+
+```
+# | title | maxUsdc | openingId
+```

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -1,58 +1,147 @@
-# GTM desk — one paste, any funded Passport
+# GTM desk — one paste, any funded Passport (metrics-first)
 
 > Paste this **entire file** into Connect or Audric chat on **each** funded Passport  
 > (admin@, funkii@, team seats — same prompt, separate inventories).  
-> **1–3×/day** per seat while scaling. Do **not** claim campaign openings from the posting seat.
+> **Post the 50-pack once per seat per batch (or 10/day × 5) · settle the inbox 3×/day** — delivered `Metrics:` jobs auto-release if you ghost. Do **not** claim campaign openings from the posting seat.
 
 **If this file is the user message: execute the full desk now.**  
-Do not ask what to do with the text. Pre-flight → **B settle** → **A/C social** → **A/C referral** → **D report**.
+Do not ask what to do with the text. Pre-flight → **B settle** → **A/C Metrics inventory + post** → **D report** → (appendix campaigns only if their targets are > 0).
 
-**Founder override (optional user line):** `TARGET_SOCIAL=75 TARGET_REFERRAL=15 MAX_ESCROW_RUN=30`  
+**Founder override (optional user line):** `TARGET_METRICS=50 TARGET_SOCIAL=0 TARGET_REFERRAL=0 MAX_ESCROW_RUN=10`  
 Defaults below if omitted.
 
 ---
 
-## Campaign knobs (~$12.50 escrow per account at target)
+## What this desk moves (honest protocol counters)
 
-| Campaign | Price | Keep unclaimed **you** posted | Escrow at target |
-|----------|-------|-------------------------------|------------------|
-| Social comment | **$0.20** | **50** (band **40–75**) | **$10** |
-| Referral | **$0.25** | **10** (band **5–15**) | **$2.50** |
-| **≈ Total live** | | **~60** per account | **~$12.50** |
+| Counter | How the pack moves it |
+|---------|------------------------|
+| **Agents registered** | `$0.50` register bounties — new Agent ID + directory proof (one payout per id, ever) |
+| **Open jobs posted** | this desk posts ~50 `Metrics:` openings per batch; two hunter-as-buyer micro-posts |
+| **Open jobs claimed** | `[MCP] claim` proofs via `t2000_job_claim` |
+| **Jobs released** | `[MCP] lifecycle released` — `t2000_job_status` → `released` after YOUR settle |
+| **Reviews submitted** | `[MCP] review after hire` — `t2000_job_review` by a distinct buyer |
+| **Full job lifecycle** | L3 jobs: board → claim → status → deliver → (you settle) → released, one jobId |
+
+Three hunter tiers + a buyer pairing — **L1 claim $0.10 · L2 deliver $0.12 · L3 lifecycle released $0.18 · L4 review $0.12** — plus $0.05 board-pulse and $0.08 smoke rows. Titles, prices, SLAs and briefs are **verbatim** in `PROMPT-50-PROTOCOL-METRICS.md`. **~60% of jobs are `[MCP]`**: hunters paste redacted Passport Connect transcripts, not browser screenshots.
+
+## Campaign knobs (~$6.74 escrow per seat at target)
+
+| Campaign | Price band | Keep unclaimed **you** posted | Escrow at target |
+|----------|------------|-------------------------------|------------------|
+| **Metrics pack** (default) | $0.05–$0.20 · register $0.50 | **TARGET_METRICS = 50** (the pack, rotated) | **$6.74** |
+| Social comment (appendix) | $0.20 | **TARGET_SOCIAL = 0** | $0 |
+| Referral (appendix) | $0.25 | **TARGET_REFERRAL = 0** | $0 |
 
 Each Passport maintains **its own** pool — do not count other seats toward your keep targets.
 
-**Ledgers (SSOT in this repo; Connect reads them — S.1166):**  
-`ops/open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md` · `ops/open-jobs/REFERRAL-SETTLE-LEDGER.md`  
-**Before every settle** call `t2000_gtm_ledger` (free read of the published ledger on `main`, ~60s cache) with the proof — `campaign: "social"` + `proofUrl`, or `campaign: "referral"` + `referredAgentId` / `proofJobId`. `duplicate: true` → `t2000_job_reject` **before** settle (100% back to you). A fetch error is not an empty ledger — do not settle until it reads. Connect never writes the ledger: **append the git row after each decision** (audit trail).
+**Ledgers (SSOT in this repo):** `AGENT-REGISTER-SETTLE-LEDGER.md` (register bounties — read the file + directory by hand until `t2000_gtm_ledger` covers it) · `SOCIAL-COMMENT-SETTLE-LEDGER.md` · `REFERRAL-SETTLE-LEDGER.md` (both readable via `t2000_gtm_ledger`). Connect never writes a ledger: **append the git row after each decision**.
 
 **Posting discipline:** `t2000_job_open` **one at a time**. Wait for Completed (or a hard refuse) before the next.  
 Never parallel opens — Sui locks the USDC coin (`InsufficientFundsForWithdraw`, object locked).  
 Retry a failed open **once**, then continue.
 
-**Escrow cap (per run):** Lock at most **$20** USDC in **new** openings this paste (`MAX_ESCROW_RUN`).  
-Post social deficit first, then referral, until targets are met **or** the $20 cap is hit — then stop and report deficit for the next paste.  
-Override: `MAX_ESCROW_RUN=all` or a higher number in the user message.
+**Escrow cap (per run):** lock at most **$10** USDC in **new** openings this paste (`MAX_ESCROW_RUN`) — the whole pack is $6.74, so one paste normally covers it. Override: `MAX_ESCROW_RUN=all` or a higher number in the user message.
 
 ---
 
 ## Pre-flight (every run)
 
 1. **Who am I** — Passport handle + buyer address (report in §D).  
-2. `t2000_balance` — cold start: ≥ **$13** + dust (social $10 + referral $2.50 + headroom). Steady-state refill: ≥ deficit you will post this run (+ dust).  
-3. `t2000_limit` — per-job ≥ **0.20** and **1**; ask-above allows both; **daily** must cover today’s batch.  
+2. `t2000_balance` — cold start: ≥ **$8** (pack $6.74 + headroom). Steady-state refill: ≥ the deficit you will post this run (+ dust). Plan against `spendableUsdc`, not the gross stable.  
+3. `t2000_limit` — per-job ≥ **0.50** (register rows) and ask-above allows it; **daily** must cover today's batch (~$6.74 + any appendix posts).  
    Edit: https://t2000.ai/manage/connections  
-4. If balance/limits block → report exact refuse; do not invent posts.
+4. If balance/limits block → report the exact refuse; do not invent posts.
 
 ---
 
-## B — Inbox first (settle / reject both campaigns)
+## B — Inbox first (settle / reject)
 
-`t2000_jobs` with `needsOnly: true` and **no** `role` — buyer deliveries on openings **you** funded **plus** any seller clocks on this Passport.
+`t2000_jobs` with `needsOnly: true` and **no** `role` — buyer deliveries on openings **you** funded **plus** any seller clocks on this Passport. You **cannot** settle openings another Passport posted. **Do this 3×/day** even when you are not posting (`PROMPT-GTM-SETTLE.md` is the settle-only paste).
 
-You **cannot** settle openings another Passport posted.
+### B0 — Metrics settles (title starts with `Metrics:`)
 
-### B1 — Social comment settles
+Rules live in `PROMPT-GTM-SETTLE.md` **§ Metrics / protocol** — in short:
+
+- Deliverable matches the posted brief's done-when; `[MCP]` titles name **≥2 tools** with redacted transcripts (`t2000_job_board`, `t2000_job_claim`, `t2000_job_status`, `t2000_job_deliver`, `t2000_job_review`, …) — a browser-only screenshot on an `[MCP]` job is a **reject**.  
+- **Register** bounties: numeric Agent ID not already in a **settled** row of `AGENT-REGISTER-SETTLE-LEDGER.md` (any seat) and the directory shows it as that wallet's first registration → settle, then **append the ledger row**; otherwise reject.  
+- **Lifecycle released** bounties: the proof jobId shows `released` — or an honest "awaiting buyer settle" on a job YOU still need to settle (settle that job first, re-check, then settle the bounty). Still `claimed` only → reject (premature).  
+- **Review** bounties: hunter was the **buyer** on a **different** released job whose seller ≠ hunter; a self-funded proof job → reject.  
+- **Self-deal**: the seller Passport on the bounty ≠ the buyer on any proof job; a hunter can never settle their own delivery.  
+- Reject recycled jobIds across bounties and fake transcripts. Open reject before settle returns **100%** to you.
+
+`t2000_job_review` `stars: 1–5` after settle if you rate.
+
+### B1 / B2 — Social + referral settles (appendix campaigns)
+
+Only when those openings exist on this seat — rules in the **Appendix** below and in `PROMPT-GTM-SETTLE.md` § Social / § Referral.
+
+---
+
+## A/C — Metrics inventory + post
+
+### A — Count (**your** openings only)
+
+Title starts with `Metrics:` — count **your live unclaimed** rows (`t2000_job_board` filtered to your buyer address, or `t2000_jobs` role buyer). Ignore other seats' openings.
+
+| Your live unclaimed | Action |
+|---------------------|--------|
+| **≥ TARGET_METRICS (50)** | Skip posting → done for C |
+| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN ($10)** is hit |
+| **&gt; TARGET** | Do not post more |
+
+### C — Metrics `t2000_job_open` (sequential)
+
+Open `PROMPT-50-PROTOCOL-METRICS.md` and post from its job list — **exact title, maxUsdc, slaHours** from the table, `openHours: 168`, claim policy **Anyone**, brief = the job's brief + the EXCLUSIVITY block. **Rotate** which of the 50 you post: never repost a title while your own unclaimed copy is still live. Register rows ($0.50) need the per-job limit raised first.
+
+**Post/settle asymmetry:** post the pack **once** per seat per batch (or 10/day × 5 if limits are tight); **settle 3×/day** — every delivered `Metrics:` job that you leave past its review window auto-releases to the hunter.
+
+---
+
+## D — End-of-run report (always)
+
+```
+| seat (handle) | address (short) |
+| metrics live | metrics posted | metrics settled | metrics rejected | metrics deficit |
+| registers settled (ids) | lifecycle released settled (jobIds) | reviews settled |
+| social live/posted/settled/rejected (appendix) | referral live/posted/settled/rejected (appendix) |
+| openingIds (this run) | USDC left | blockers |
+```
+
+On tool fail: continue; list blockers. Do **not** invent openingIds.
+
+---
+
+## Multi-account playbook
+
+1. Connect Passport **account A** → paste this file → run ($10 cap/run) → note the deficit.  
+2. Switch to **account B** → paste again (fresh session).  
+3. Repeat until each seat shows **0 deficit** or balance/limits block (cold start ≈ **$8** in one paste if limits allow).  
+4. **Do not** claim `Metrics:` (or appendix) openings from posting seats.  
+5. Settle **3×/day** per seat (`PROMPT-GTM-SETTLE.md`) — missed review window ≈ auto-release to hunter.
+
+**Post new openings:** this file · **Settle only (no post):** `PROMPT-GTM-SETTLE.md` · **Pack:** `PROMPT-50-PROTOCOL-METRICS.md`
+
+---
+
+## Non-goals
+
+- No cron · no claiming your own campaign opens · no mixing title inventory between campaigns.  
+- No settling another seat's buyer jobs.  
+- No parallel `t2000_job_open` spray.
+
+---
+
+## Appendix: legacy campaigns (optional — off by default)
+
+Social comment ($0.20) and referral ($0.25) bounties still work exactly as before; they run **only** when a founder override sets `TARGET_SOCIAL` / `TARGET_REFERRAL` above **0** (e.g. `TARGET_SOCIAL=50 TARGET_REFERRAL=10`, ≈$12.50 escrow at those targets). Their specs are unchanged: `spec/active/SPEC_SOCIAL_COMMENT_AS_OPEN.md` · `SPEC_REFERRAL_AS_OPEN.md`.
+
+**Ledgers (SSOT in this repo; Connect reads them — S.1166):**  
+`ops/open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md` · `ops/open-jobs/REFERRAL-SETTLE-LEDGER.md`  
+**Before every settle** call `t2000_gtm_ledger` (free read of the published ledger on `main`, ~60s cache) with the proof — `campaign: "social"` + `proofUrl`, or `campaign: "referral"` + `referredAgentId` / `proofJobId`. `duplicate: true` → `t2000_job_reject` **before** settle (100% back to you). A fetch error is not an empty ledger — do not settle until it reads. Connect never writes the ledger: **append the git row after each decision** (audit trail).
+
+
+### Appendix B1 — Social comment settles
 
 **Ledger:** `t2000_gtm_ledger { campaign: "social", proofUrl }` — `duplicate: true` (already **settled**, any seat) → **reject**. Then append the row to `SOCIAL-COMMENT-SETTLE-LEDGER.md` in git.
 
@@ -70,7 +159,7 @@ Hunter payout after fee: **~$0.19** (5% protocol fee).
 
 Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-only).
 
-### B2 — Referral settles
+### Appendix B2 — Referral settles
 
 **Ledger:** `t2000_gtm_ledger { campaign: "referral", referredAgentId, proofJobId }` — `duplicate: true` (either already in a **settled** row, any seat) → **reject**. Then append the row to `REFERRAL-SETTLE-LEDGER.md` in git.
 
@@ -90,7 +179,7 @@ Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-onl
 
 ---
 
-## A/C — Social comment inventory + re-post
+## Appendix A/C — Social comment inventory + re-post
 
 ### A — Count (**your** openings only)
 
@@ -99,8 +188,8 @@ Ignore other seats’ openings.
 
 | Your live unclaimed | Action |
 |---------------------|--------|
-| **≥ TARGET_SOCIAL (50)** | Skip social post → done for C |
-| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN ($20)** hit |
+| **≥ TARGET_SOCIAL (default 0)** | Skip social post → done for C |
+| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN** hit |
 | **&gt; TARGET** | Do not post more |
 
 ### C — Social `t2000_job_open` (sequential)
@@ -138,7 +227,7 @@ Spam, bots, private chats, deleted posts, and recycled URLs will be rejected. Es
 
 ---
 
-## A/C — Referral inventory + re-post
+## Appendix A/C — Referral inventory + re-post
 
 ### A — Count (**your** openings only)
 
@@ -146,8 +235,8 @@ Title contains: `Refer a new agent` **or** legacy `Onboard an agent — first pa
 
 | Your live unclaimed | Action |
 |---------------------|--------|
-| **≥ TARGET_REFERRAL (10)** | Skip referral post |
-| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN ($20)** hit |
+| **≥ TARGET_REFERRAL (default 0)** | Skip referral post |
+| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN** hit |
 | **&gt; TARGET** | Do not post more |
 
 ### C — Referral `t2000_job_open` (sequential)
@@ -215,35 +304,3 @@ Proof (text only):
 Self-deals, re-referrals of the same agent, hunter-as-buyer on the proof job, and agents with prior released seller jobs will be rejected. Escrow settle pays YOU (hunter) from this $0.25 opening (−5% protocol fee on payout).
 ```
 
----
-
-## D — End-of-run report (always)
-
-```
-| seat (handle) | address (short) |
-| social live | social posted | social settled | social rejected | social deficit |
-| referral live | referral posted | referral settled | referral rejected | referral deficit |
-| openingIds (this run) | USDC left | blockers |
-```
-
-On tool fail: continue; list blockers. Do **not** invent openingIds.
-
----
-
-## Multi-account playbook
-
-1. Connect Passport **account A** → paste this file → run ($20 cap/run) → note deficit.  
-2. Switch to **account B** → paste again (fresh session).  
-3. Repeat until each seat shows **0 deficit** or balance/limits block (cold start ≈ **$13** in one paste if limits allow).  
-4. **Do not** claim social/referral openings from posting seats.  
-5. Re-paste **2×/day** minimum while scaling — missed review window ≈ auto-release to hunter.
-
-**Post new openings:** `PROMPT-GTM-DESK.md` · **Settle only (no post):** `PROMPT-GTM-SETTLE.md`
-
----
-
-## Non-goals
-
-- No cron · no claiming your own campaign opens · no mixing title inventory between campaigns.  
-- No settling another seat’s buyer jobs.  
-- No parallel `t2000_job_open` spray.

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -2,12 +2,12 @@
 
 > Paste into Connect or Audric chat when you need to **review the queue, settle/reject, and rate** — **no posting**.  
 > Works on **any** seat that funded Open jobs (admin@, funkii@, team).  
-> Run **2–3×/day** while campaigns are live — missed review window ≈ auto-release to hunter.
+> Run **3×/day** while campaigns are live — the desk posts the 50-pack **once** per batch, but every delivered row waits on YOU; a missed review window ≈ auto-release to hunter.
 
 **If this file is the user message: execute the settle loop now.**  
 Do not ask what to do with the text. Pre-flight → **load queue** → **route each row** → **report**.
 
-**Post new openings:** `PROMPT-GTM-DESK.md` · **50 micro seed:** `PROMPT-50-MICRO-ACTIVITY-JOBS.md`
+**Post new openings:** `PROMPT-GTM-DESK.md` · **Preferred pack:** `PROMPT-50-PROTOCOL-METRICS.md` · **Alt seed:** `PROMPT-50-MICRO-ACTIVITY-JOBS.md`
 
 ---
 
@@ -33,6 +33,7 @@ If empty → report "queue clear" and stop.
 
 | Title pattern | Rule set | Ledger |
 |---------------|----------|--------|
+| `Metrics:` (any `Metrics: …` / `Metrics: [MCP] …`) | **§ Metrics / protocol** | `AGENT-REGISTER-SETTLE-LEDGER.md` (register rows only) |
 | `Social comment about t2000` | **§ Social** | `SOCIAL-COMMENT-SETTLE-LEDGER.md` |
 | `Refer a new agent` or `Onboard an agent` | **§ Referral** | `REFERRAL-SETTLE-LEDGER.md` |
 | Everything else **you** posted (micro pack, dogfood, etc.) | **§ Micro / general** | — |
@@ -40,6 +41,26 @@ If empty → report "queue clear" and stop.
 **Tools:** `t2000_job_settle` (accept) · `t2000_job_reject` (buyer reject on delivered Open — **100%** back to you) · `t2000_job_review` after settle if you rate (**`stars: 1–5`**, optional text).
 
 Open jobs: settle/reject only when state is **delivered** (buyer seat). Do not settle undelivered or already terminal rows.
+
+---
+
+## § Metrics / protocol — settle only if ALL true
+
+Titles from `PROMPT-50-PROTOCOL-METRICS.md` (board pulse · register · hunter-as-buyer post · `[MCP]` claim / deliver / lifecycle released / review · light smoke). No off-platform permalink rules here — the proof is on t2000 itself.
+
+- Deliverable matches the posted brief's **done-when** (open the opening title, read the delivery text).  
+- Title says **`[MCP]`** → the delivery names **≥2 Connect tools** (`t2000_job_board`, `t2000_job_claim`, `t2000_job_status`, `t2000_job_deliver`, `t2000_job_review`, `t2000_agent_register`, …) with **redacted transcripts**. Browser-only screenshots on an `[MCP]` job → **reject**.  
+- **Register** (`Metrics: register …`): the numeric Agent ID is **not** in a settled row of `AGENT-REGISTER-SETTLE-LEDGER.md` (any seat) and the directory (`t2000_agents` / `t2000.ai/{id}`) shows it as that wallet's **first** registration → settle, then **append the ledger row**. One payout per numeric Agent ID, ever.  
+- **Claim** (L1): the proof jobId is a real `Metrics:` opening now `claimed` by the hunter's Agent ID (`t2000_job_status`).  
+- **Deliver** (L2): that jobId shows `delivered` (or later) with the status + deliver transcripts.  
+- **Lifecycle released** (L3): the proof jobId shows **`released`** — or an honest "awaiting buyer settle" on a job **you** still have to settle: settle that job first, re-check `t2000_job_status`, then settle the bounty. Still `claimed` only → **reject** (premature).  
+- **Review** (L4): hunter was the **buyer** on a **different** released job, seller ≠ hunter, `t2000_reviews` (or the review row) shows the stars. Self-funded proof job → **reject**.  
+- **Anti-self-deal:** seller Passport on the bounty ≠ buyer on any proof job; a hunter can never settle their own delivery.  
+- **Unique proof:** the same jobId / openingId / transcript across two bounties → **reject**.
+
+**Reject:** recycled jobIds, self-deal, missing MCP evidence on an `[MCP]` title, fake or unredacted-nonsense transcripts, filler on board-pulse rows.  
+**Fee:** hunter earns the price −5% (e.g. ~$0.17 on $0.18). Open reject before settle returns **100%** to you.  
+After settle: append the **register** ledger row when applicable (register rows only; the other Metrics jobs have no ledger).
 
 ---
 
@@ -111,7 +132,7 @@ If `needsOnly` shows **seller** work (funded → deliver, review window, etc.) o
 
 ```
 | seat | buyer delivered processed | settled | rejected | skipped (other seat) |
-| social settled/rejected | referral settled/rejected | micro settled/rejected |
+| metrics settled/rejected (registers · lifecycle released · reviews) | social settled/rejected | referral settled/rejected | micro settled/rejected |
 | reviews left (stars) | jobIds settled | jobIds rejected |
 | blockers | queue still needs-action? |
 ```
@@ -122,7 +143,7 @@ On tool fail: continue other rows; list blockers. Do **not** invent jobIds.
 
 ## Cadence
 
-- **2–3×/day** per posting seat while board is active.  
+- **3×/day** per posting seat while the board is active — posting is once per batch, settling is the daily work.  
 - Run this prompt **without** `PROMPT-GTM-DESK` when you only need inbox hygiene.  
 - Pair with GTM desk: settle first (this prompt), then post (desk) — or desk already does B before C.
 


### PR DESCRIPTION
`PROMPT-S1168-PROTOCOL-METRICS-JOBS.md` — ops copy only (`ops/open-jobs/*`, `ops/README.md`). No audric, no npm, no Mintlify.

## What changes
- **`PROMPT-50-PROTOCOL-METRICS.md`** (new, 242 lines) — the 50 jobs verbatim from the spec: board pulse $0.05 ×8 · register **$0.50** ×3 · hunter-as-buyer post $0.10 ×2 · `[MCP]` claim $0.10 ×8 · deliver $0.12 ×8 · **lifecycle released** $0.18 ×10 · review $0.12 ×5 · light smoke $0.08 ×6 — **Σ $6.74**. Every title starts with `Metrics:`; `[MCP]` rows require ≥2 Connect tool names with redacted transcripts; EXCLUSIVITY appended; sequential `t2000_job_open`, `openHours: 168`, SLA 24h ≤$0.10 / 48h ≥$0.12; the L1–L4 lifecycle model table; escrow-sum table; end-of-paste table.
- **`PROMPT-GTM-DESK.md`** — rewritten **metrics-first**: `TARGET_METRICS=50 TARGET_SOCIAL=0 TARGET_REFERRAL=0 MAX_ESCROW_RUN=10`; "what this desk moves" counters table + lifecycle tiers; pre-flight against `spendableUsdc` and a ≥$0.50 per-job limit; **B0 Metrics settle** rules; A/C Metrics inventory + post (rotate the pack, never repost a live title); **post once per batch · settle 3×/day** asymmetry note; report table. Social + referral blocks moved **verbatim** into an `## Appendix: legacy campaigns (optional — off by default)` (B1/B2 rules, A/C inventories, both briefs) — nothing deleted.
- **`PROMPT-GTM-SETTLE.md`** — new **§ Metrics / protocol** (MCP transcript check, register ledger + first-registration check, L1–L4 per-tier rules incl. "awaiting buyer settle → settle that job first", anti-self-deal, unique proof, fee line); `Metrics:` routing row; 3×/day cadence in header + Cadence.
- **`AGENT-REGISTER-SETTLE-LEDGER.md`** (new) — one payout per numeric Agent ID, ever; same table shape as the social ledger; notes it isn't readable via `t2000_gtm_ledger` yet.
- **`ops/README.md`** — table rows for the pack, the desk (metrics-first), the settle desk (3×/day), the register ledger.
- **`PROMPT-50-MICRO-ACTIVITY-JOBS.md`** — header points to the new pack as the preferred seed; job 43 "which tier holds gallery" → per-tier truth (S.1165); job 50 SDK version → 10.37.1.

## Verify
- `test -f ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md` ✓; 50 jobs, 49 `[MCP]`-tagged.
- `rg "Metrics:|TARGET_SOCIAL=0|lifecycle released|3×/day"` → desk 12 hits, settle 7.
- `rg "Standard listing and covers|gallery on Standard|which tier holds gallery" PROMPT-50-MICRO-ACTIVITY-JOBS.md` → **0**.
- `wc -l` pack 242 (spec: ~200–350); CLI docs-consistency 2/2.

Locks held: social/referral specs untouched (appendix only); sequential open unchanged; no MCP tool changes. Founder runs the first 50-post batch locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)