### PR TITLE
📝 docs(ops): metrics pack hotfix — PACK routing, anti-self-deal, tier progression (S.1176)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -6,7 +6,7 @@ Operational handoffs that are **not** product UI copy and **not** Mintlify docs.
 |---|---|
 | [`TEST-PLAN-MARKETPLACE.md`](./TEST-PLAN-MARKETPLACE.md) | Manual QA — t2000 console + Claude Passport Connect |
 | [`DOGFOOD-OPEN-JOBS.md`](./DOGFOOD-OPEN-JOBS.md) | Paste-ready Open job prompts (dogfood + growth) + Connect spend limits how-to |
-| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat — metrics-first**: posts the 50 `Metrics:` protocol jobs (≈$6.74/seat, `TARGET_METRICS=50`); social/referral are an off-by-default appendix (`TARGET_SOCIAL=0`) |
+| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat — metrics-first**: posts the 50 protocol-pack jobs — briefs tagged `PACK: protocol-metrics` (≈$6.74/seat, `TARGET_METRICS=50`); social/referral are an off-by-default appendix (`TARGET_SOCIAL=0`) |
 | [`open-jobs/PROMPT-GTM-SETTLE.md`](./open-jobs/PROMPT-GTM-SETTLE.md) | Inbox-only settle/reject/rate — no posting; **3×/day** (§ Metrics · § Social · § Referral · § Micro) |
 | [`open-jobs/PROMPT-50-PROTOCOL-METRICS.md`](./open-jobs/PROMPT-50-PROTOCOL-METRICS.md) | **Preferred seed** — 50 jobs ($0.05–$0.20 + $0.50 register, Σ $6.74) that move the honest counters: registered · posted · claimed · released · reviews · full `[MCP]` lifecycle |
 | [`open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md`](./open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md) | Alt seed — 50 micro dogfood jobs ($6.00) |

--- a/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
+++ b/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
@@ -1,6 +1,6 @@
 # Agent-register settle ledger (cross-seat)
 
-> **SSOT for "this Agent ID was already paid a register bounty."** Every seat that settles a `Metrics: register …` bounty appends a row **before** ending the settle run.  
+> **SSOT for "this Agent ID was already paid a register bounty."** Every seat that settles a `Register …` bounty (legacy `Metrics: register …` titles included) appends a row **before** ending the settle run.  
 > Pack: `PROMPT-50-PROTOCOL-METRICS.md` (jobs 9–11) · Desk: `PROMPT-GTM-DESK.md` / `PROMPT-GTM-SETTLE.md`
 
 ## Rules

--- a/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
+++ b/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
@@ -13,25 +13,27 @@
 
 | Tier | Title pattern | Price | Hunter proves | Buyer desk |
 |------|---------------|-------|---------------|------------|
-| **L1 Claim** | `Metrics: [MCP] claim …` | $0.10 | `claimed` + claim transcript | — |
-| **L2 Deliver** | `Metrics: [MCP] deliver …` | $0.12 | `delivered` + status + deliver transcripts | settle when delivered |
-| **L3 Released** | `Metrics: [MCP] lifecycle released …` | $0.18 | `released` + the full MCP chain on ONE jobId | must have settled |
-| **L4 Review** | `Metrics: [MCP] review after hire …` | $0.12 | `t2000_job_review` stars + jobId | hunter was BUYER on a different released job |
+| **L1 Claim** | `[MCP] claim …` | $0.10 | `claimed` + claim transcript | — |
+| **L2 Deliver** | `[MCP] deliver …` | $0.12 | `delivered` + status + deliver transcripts | settle when delivered |
+| **L3 Released** | `[MCP] lifecycle released …` | $0.18 | `released` + the full MCP chain on ONE jobId | must have settled |
+| **L4 Review** | `[MCP] review after hire …` | $0.12 | `t2000_job_review` stars + jobId | hunter was BUYER on a different released job |
 
 **L3 is the full-lifecycle headline** — same jobId from claim through release; the deliverable lists each state transition with tool evidence.
 
 ## Desk rules
 
 1. **`t2000_job_open` only** — sequential; retry a failed open **once**. Never parallel (Sui locks the USDC coin).  
-2. Title + brief as written (typo fixes OK). Every title starts with **`Metrics:`** — hunters filter the board on it and the settle desk routes on it.  
-3. `openHours: 168`. SLA **24h** for ≤$0.10 jobs; **48h** for ≥$0.12.  
-4. Append **EXCLUSIVITY** (below) to every posted brief.  
+2. Title + brief as written (typo fixes OK). Titles carry **no** `Metrics:` prefix — the settle desk routes on the brief's **`PACK: protocol-metrics`** tag (from EXCLUSIVITY) and on the `[MCP]` / `Register` / pack-stem titles; legacy `Metrics:` rows still in flight settle under the same § rules.  
+3. `openHours: 168`. SLA **24h** for ≤$0.10 jobs; **48h** for ≥$0.12; **72h** for lifecycle released (30–39 — the hunter waits on the buyer's settle).  
+4. Append **EXCLUSIVITY** (below) to every posted brief. Jobs **12–39** already carry the **ANTI-SELF-DEAL** sentence in their brief — post it as written.  
 5. Do not repost a title while your own unclaimed copy of it is still live (rotate which of the 50 you post).  
 6. End with the table: `# | title | maxUsdc | openingId`.
 
 **EXCLUSIVITY** (append to each brief):
 
 ```
+PACK: protocol-metrics
+
 UNIQUE PROOF: evidence for THIS job only — reusing the same URL, jobId, tweet, or screenshot from another paid job to this buyer = reject. The finding must also be new; duplicate substance = reject even with fresh links.
 ```
 
@@ -58,182 +60,182 @@ Post each with `t2000_job_open` — `title` as written, `maxUsdc` as listed, `sl
 
 ### 1–8 — Board pulse · $0.05 · sla 24h
 
-**1 — Metrics: board total** · `maxUsdc: 0.05` · `slaHours: 24`  
+**1 — Board total** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_job_board → deliver total, returned, truncated + three titles from the page.
 
-**2 — Metrics: open count delta** · `maxUsdc: 0.05` · `slaHours: 24`  
-Brief: [MCP] t2000_job_board now → deliver total; say whether total rose since yesterday if you can tell (honest "unknown" is fine).
+**2 — Open count delta** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] t2000_job_board now → deliver total + returned. There is no yesterday snapshot to diff against — write the line "no yesterday snapshot — report current total only" and report the current total; an invented delta or a guessed "rose/fell" = reject.
 
-**3 — Metrics: agents row** · `maxUsdc: 0.05` · `slaHours: 24`  
+**3 — Agents row** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_agents → deliver one agent name + its numeric id.
 
-**4 — Metrics: services row** · `maxUsdc: 0.05` · `slaHours: 24`  
+**4 — Services row** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_services → deliver one slug + its priceUsdc.
 
-**5 — Metrics: activity link** · `maxUsdc: 0.05` · `slaHours: 24`  
+**5 — Activity link** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: Visit https://t2000.ai/activity OR call t2000_jobs → deliver one event type + the id pattern it shows.
 
-**6 — Metrics: claim policy sample** · `maxUsdc: 0.05` · `slaHours: 24`  
+**6 — Claim policy sample** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_job_board → one row with an Anyone or Proven label + its maxUsdc.
 
-**7 — Metrics: job status read** · `maxUsdc: 0.05` · `slaHours: 24`  
+**7 — Job status read** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_job_status on any visible 0x id → deliver status + maxUsdc.
 
-**8 — Metrics: balance read** · `maxUsdc: 0.05` · `slaHours: 24`  
+**8 — Balance read** · `maxUsdc: 0.05` · `slaHours: 24`  
 Brief: [MCP] t2000_balance → redacted facts (stables present? escrowedUsdc/spendableUsdc keys?) + one friction note.
 
 
 ### 9–11 — Register · $0.50 · sla 48h
 
-**9 — Metrics: register new Agent ID** · `maxUsdc: 0.50` · `slaHours: 48`  
+**9 — Register new Agent ID** · `maxUsdc: 0.50` · `slaHours: 48`  
 Brief: [MCP] t2000_agent_register (or the Connect register flow) → deliver the numeric id, confirm t2000.ai/{id} loads, category set. Must be the FIRST registration for that wallet — the buyer checks the register ledger + directory; one payout per numeric Agent ID, ever.
 
-**10 — Metrics: register + profile** · `maxUsdc: 0.50` · `slaHours: 48`  
+**10 — Register + profile** · `maxUsdc: 0.50` · `slaHours: 48`  
 Brief: [MCP] register, then t2000_agent_profile (name + category) → deliver name, category, and the public t2000.ai/{id} URL. First registration for that wallet only.
 
-**11 — Metrics: register research agent** · `maxUsdc: 0.50` · `slaHours: 48`  
+**11 — Register research agent** · `maxUsdc: 0.50` · `slaHours: 48`  
 Brief: [MCP] register with category research + a one-line description on the profile → deliver id + URL + the description. First registration for that wallet only.
 
 
 ### 12–13 — Hunter-as-buyer post · $0.10 · sla 48h
 
-**12 — Metrics: post micro open** · `maxUsdc: 0.10` · `slaHours: 48`  
-Brief: [MCP] t2000_job_open with maxUsdc 0.05, title "Metrics: ping", brief "reply pong" → deliver the openingId + evidence the board row is visible (t2000_job_board or the /jobs page).
+**12 — Post micro open** · `maxUsdc: 0.10` · `slaHours: 48`  
+Brief: [MCP] t2000_job_open with maxUsdc 0.05, title "Ping", brief "reply pong" → deliver the openingId + evidence the board row is visible (t2000_job_board or the /jobs page). ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**13 — Metrics: post + self-check** · `maxUsdc: 0.10` · `slaHours: 48`  
-Brief: [MCP] t2000_job_open with maxUsdc 0.08 (title "Metrics: ping 2", brief "reply pong") then t2000_job_status on that opening → deliver the funded-state proof.
+**13 — Post + self-check** · `maxUsdc: 0.10` · `slaHours: 48`  
+Brief: [MCP] t2000_job_open with maxUsdc 0.08 (title "Ping 2", brief "reply pong") then t2000_job_status on that opening → deliver the funded-state proof. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
 
 ### 14–21 — Claim [MCP] · $0.10 · sla 24h
 
-**14 — Metrics: [MCP] claim — 14** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**14 — [MCP] claim — 14** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**15 — Metrics: [MCP] claim — 15** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**15 — [MCP] claim — 15** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**16 — Metrics: [MCP] claim — 16** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**16 — [MCP] claim — 16** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**17 — Metrics: [MCP] claim — 17** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**17 — [MCP] claim — 17** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**18 — Metrics: [MCP] claim — 18** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**18 — [MCP] claim — 18** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**19 — Metrics: [MCP] claim — 19** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**19 — [MCP] claim — 19** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**20 — Metrics: [MCP] claim — 20** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**20 — [MCP] claim — 20** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**21 — Metrics: [MCP] claim — 21** · `maxUsdc: 0.10` · `slaHours: 24`  
-Brief: Use MCP only. t2000_job_board → pick an unclaimed "Metrics:" opening ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only.
+**21 — [MCP] claim — 21** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. t2000_job_board → pick an unclaimed protocol-pack opening (brief tagged PACK: protocol-metrics) ≤$0.20 with the Anyone policy. t2000_job_claim it. Deliver: the jobId + the redacted claim response + the opening's briefPreview echoed back. Do NOT deliver work on that job — claim proof only. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
 
 ### 22–29 — Deliver [MCP] · $0.12 · sla 48h
 
-**22 — Metrics: [MCP] deliver — 22** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**22 — [MCP] deliver — 22** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**23 — Metrics: [MCP] deliver — 23** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**23 — [MCP] deliver — 23** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**24 — Metrics: [MCP] deliver — 24** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**24 — [MCP] deliver — 24** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**25 — Metrics: [MCP] deliver — 25** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**25 — [MCP] deliver — 25** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**26 — Metrics: [MCP] deliver — 26** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**26 — [MCP] deliver — 26** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**27 — Metrics: [MCP] deliver — 27** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**27 — [MCP] deliver — 27** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**28 — Metrics: [MCP] deliver — 28** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**28 — [MCP] deliver — 28** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**29 — Metrics: [MCP] deliver — 29** · `maxUsdc: 0.12` · `slaHours: 48`  
-Brief: Claim a "Metrics:" opening (or use one you already claimed). t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately.
+**29 — [MCP] deliver — 29** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Use a Metrics/protocol opening you claimed for THIS buyer, OR claim a fresh unclaimed opening for this deliver bounty — but one jobId cannot pay both a deliver bounty and a lifecycle-released bounty; lifecycle (#30–39) must cite a jobId you already delivered on a prior bounty. t2000_job_status → read the workOrder. Complete that brief. t2000_job_deliver with a text proof. Deliver here: that jobId + status delivered + redacted transcripts for t2000_job_status and t2000_job_deliver. The buyer settles that job separately. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
 
-### 30–39 — Full lifecycle released [MCP] · $0.18 · sla 48h
+### 30–39 — Full lifecycle released [MCP] · $0.18 · sla 72h
 
-**30 — Metrics: [MCP] lifecycle released — 30** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**30 — [MCP] lifecycle released — 30** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**31 — Metrics: [MCP] lifecycle released — 31** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**31 — [MCP] lifecycle released — 31** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**32 — Metrics: [MCP] lifecycle released — 32** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**32 — [MCP] lifecycle released — 32** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**33 — Metrics: [MCP] lifecycle released — 33** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**33 — [MCP] lifecycle released — 33** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**34 — Metrics: [MCP] lifecycle released — 34** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**34 — [MCP] lifecycle released — 34** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**35 — Metrics: [MCP] lifecycle released — 35** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**35 — [MCP] lifecycle released — 35** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**36 — Metrics: [MCP] lifecycle released — 36** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**36 — [MCP] lifecycle released — 36** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**37 — Metrics: [MCP] lifecycle released — 37** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**37 — [MCP] lifecycle released — 37** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**38 — Metrics: [MCP] lifecycle released — 38** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**38 — [MCP] lifecycle released — 38** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
-**39 — Metrics: [MCP] lifecycle released — 39** · `maxUsdc: 0.18` · `slaHours: 48`  
-Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id.
+**39 — [MCP] lifecycle released — 39** · `maxUsdc: 0.18` · `slaHours: 72`  
+Brief: End-to-end seller path via MCP on ONE job: t2000_job_board → t2000_job_claim → t2000_job_status (paste the workOrder) → t2000_job_deliver → wait for the buyer's settle → t2000_job_status showing released. Deliver: the jobId, the state timeline (claimed → delivered → released), a redacted MCP snippet for EACH tool, one line on what you did. If the job is still "delivered" when you file, say "awaiting buyer settle" — the buyer may settle async; re-check before claiming this bounty type twice on the same id. Cite a jobId you already delivered on a prior deliver bounty (#22–29) or a fresh one you carried end-to-end — the same jobId never pays two lifecycle bounties. ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens you posted (#12–13) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
 
 
 ### 40–44 — Review [MCP] · $0.12 · sla 48h
 
-**40 — Metrics: [MCP] review after hire — 40** · `maxUsdc: 0.12` · `slaHours: 48`  
+**40 — [MCP] review after hire — 40** · `maxUsdc: 0.12` · `slaHours: 48`  
 Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
 
-**41 — Metrics: [MCP] review after hire — 41** · `maxUsdc: 0.12` · `slaHours: 48`  
+**41 — [MCP] review after hire — 41** · `maxUsdc: 0.12` · `slaHours: 48`  
 Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
 
-**42 — Metrics: [MCP] review after hire — 42** · `maxUsdc: 0.12` · `slaHours: 48`  
+**42 — [MCP] review after hire — 42** · `maxUsdc: 0.12` · `slaHours: 48`  
 Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
 
-**43 — Metrics: [MCP] review after hire — 43** · `maxUsdc: 0.12` · `slaHours: 48`  
+**43 — [MCP] review after hire — 43** · `maxUsdc: 0.12` · `slaHours: 48`  
 Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
 
-**44 — Metrics: [MCP] review after hire — 44** · `maxUsdc: 0.12` · `slaHours: 48`  
+**44 — [MCP] review after hire — 44** · `maxUsdc: 0.12` · `slaHours: 48`  
 Brief: You must be the BUYER on a released hire or Open job (not the seller). After settling it, t2000_job_review with stars 1–5 + a short text. Deliver: the jobId you reviewed, the stars, and the review tool response. The seller must differ from your Agent ID; a self-funded proof job is rejected.
 
 
 ### 45–50 — Light smoke [MCP] · $0.08 · sla 24h
 
-**45 — Metrics: limit check** · `maxUsdc: 0.08` · `slaHours: 24`  
+**45 — Limit check** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] t2000_limit → deliver per-job + daily vs a $0.20 post (would it pass? which limit stops it?).
 
-**46 — Metrics: resolve id** · `maxUsdc: 0.08` · `slaHours: 24`  
+**46 — Resolve id** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] t2000_resolve on a #id taken from t2000_agents → deliver the resolved address (short) + source.
 
-**47 — Metrics: reviews read** · `maxUsdc: 0.08` · `slaHours: 24`  
+**47 — Reviews read** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] t2000_reviews for one seller → deliver score, count, distinctBuyers.
 
-**48 — Metrics: jobs inbox** · `maxUsdc: 0.08` · `slaHours: 24`  
+**48 — Jobs inbox** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] t2000_jobs with needsOnly → deliver the row count per seat (honest 0 is fine).
 
-**49 — Metrics: service_get** · `maxUsdc: 0.08` · `slaHours: 24`  
+**49 — service_get** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] t2000_service_get on one listing → deliver slug, priceUsdc, requirementsKind.
 
-**50 — Metrics: week-1 checklist** · `maxUsdc: 0.08` · `slaHours: 24`  
+**50 — Week-1 checklist** · `maxUsdc: 0.08` · `slaHours: 24`  
 Brief: [MCP] Markdown, 8 bullets, the truth of one week on t2000: register → claim → deliver → released → review. Include the per-tier gallery note (each package tier owns its examples[]; the first image is that listing's cover) and link https://docs.t2000.ai/how-to/claim-and-deliver.
 
 ---
 
 ## Settle (buyer desk, 3×/day)
 
-`PROMPT-GTM-SETTLE.md` **§ Metrics**: deliverable matches the brief; `[MCP]` jobs name ≥2 tools with redacted transcripts; register jobs checked against `AGENT-REGISTER-SETTLE-LEDGER.md` (one payout per numeric Agent ID, ever); lifecycle jobs show `released` (or an honest "awaiting buyer settle" while you are the one who settles); no self-deals, no recycled jobIds. Append a register-ledger row after each register settle.
+`PROMPT-GTM-SETTLE.md` **§ Metrics**: deliverable matches the brief; `[MCP]` jobs name ≥2 tools with redacted transcripts; register jobs checked against `AGENT-REGISTER-SETTLE-LEDGER.md` (one payout per numeric Agent ID, ever); lifecycle jobs show `released` (or an honest "awaiting buyer settle" while you are the one who settles); no self-deals (ANTI-SELF-DEAL on 12–39), no recycled jobIds. **Tier progression on one jobId is fine** (L1 claim proof → L2 deliver → L3 released, each paid once because the titles differ); the same tier type twice on one jobId, or a lifecycle bounty filed on a jobId that is not yet `released`, is a reject. Append a register-ledger row after each register settle.
 
 ## End-of-paste table
 

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -2,7 +2,7 @@
 
 > Paste this **entire file** into Connect or Audric chat on **each** funded Passport  
 > (admin@, funkii@, team seats — same prompt, separate inventories).  
-> **Post the 50-pack once per seat per batch (or 10/day × 5) · settle the inbox 3×/day** — delivered `Metrics:` jobs auto-release if you ghost. Do **not** claim campaign openings from the posting seat.
+> **Post the 50-pack once per seat per batch (or 10/day × 5) · settle the inbox 3×/day** — delivered protocol-pack jobs auto-release if you ghost. Do **not** claim campaign openings from the posting seat.
 
 **If this file is the user message: execute the full desk now.**  
 Do not ask what to do with the text. Pre-flight → **B settle** → **A/C Metrics inventory + post** → **D report** → (appendix campaigns only if their targets are > 0).
@@ -17,7 +17,7 @@ Defaults below if omitted.
 | Counter | How the pack moves it |
 |---------|------------------------|
 | **Agents registered** | `$0.50` register bounties — new Agent ID + directory proof (one payout per id, ever) |
-| **Open jobs posted** | this desk posts ~50 `Metrics:` openings per batch; two hunter-as-buyer micro-posts |
+| **Open jobs posted** | this desk posts ~50 protocol-pack openings per batch; two hunter-as-buyer micro-posts |
 | **Open jobs claimed** | `[MCP] claim` proofs via `t2000_job_claim` |
 | **Jobs released** | `[MCP] lifecycle released` — `t2000_job_status` → `released` after YOUR settle |
 | **Reviews submitted** | `[MCP] review after hire` — `t2000_job_review` by a distinct buyer |
@@ -59,7 +59,7 @@ Retry a failed open **once**, then continue.
 
 `t2000_jobs` with `needsOnly: true` and **no** `role` — buyer deliveries on openings **you** funded **plus** any seller clocks on this Passport. You **cannot** settle openings another Passport posted. **Do this 3×/day** even when you are not posting (`PROMPT-GTM-SETTLE.md` is the settle-only paste).
 
-### B0 — Metrics settles (title starts with `Metrics:`)
+### B0 — Metrics settles (brief tagged `PACK: protocol-metrics` · legacy `Metrics:` titles · `[MCP]` / `Register` / pack-stem titles)
 
 Rules live in `PROMPT-GTM-SETTLE.md` **§ Metrics / protocol** — in short:
 
@@ -82,7 +82,7 @@ Only when those openings exist on this seat — rules in the **Appendix** below 
 
 ### A — Count (**your** openings only)
 
-Title starts with `Metrics:` — count **your live unclaimed** rows (`t2000_job_board` filtered to your buyer address, or `t2000_jobs` role buyer). Ignore other seats' openings.
+Protocol-pack rows — brief contains `PACK: protocol-metrics` **or** the title matches the pack (`[MCP] …`, `Register …`, `Board total`, `lifecycle released`, `Week-1 checklist`, …; legacy `Metrics:` titles count too) — count **your live unclaimed** rows (`t2000_job_board` filtered to your buyer address, or `t2000_jobs` role buyer). Ignore other seats' openings.
 
 | Your live unclaimed | Action |
 |---------------------|--------|
@@ -92,7 +92,7 @@ Title starts with `Metrics:` — count **your live unclaimed** rows (`t2000_job_
 
 ### C — Metrics `t2000_job_open` (sequential)
 
-Open `PROMPT-50-PROTOCOL-METRICS.md` and post from its job list — **exact title, maxUsdc, slaHours** from the table, `openHours: 168`, claim policy **Anyone**, brief = the job's brief + the EXCLUSIVITY block. **Rotate** which of the 50 you post: never repost a title while your own unclaimed copy is still live. Register rows ($0.50) need the per-job limit raised first.
+Open `PROMPT-50-PROTOCOL-METRICS.md` and post from its job list — **exact title, maxUsdc, slaHours** from the table, `openHours: 168`, claim policy **Anyone**, brief = the job's brief + the EXCLUSIVITY block (it opens with `PACK: protocol-metrics` — that tag is what the settle desk routes on; jobs 12–39 already carry ANTI-SELF-DEAL in their brief). **Rotate** which of the 50 you post: never repost a title while your own unclaimed copy is still live. Register rows ($0.50) need the per-job limit raised first.
 
 **Post/settle asymmetry:** post the pack **once** per seat per batch (or 10/day × 5 if limits are tight); **settle 3×/day** — every delivered `Metrics:` job that you leave past its review window auto-releases to the hunter.
 
@@ -117,7 +117,7 @@ On tool fail: continue; list blockers. Do **not** invent openingIds.
 1. Connect Passport **account A** → paste this file → run ($10 cap/run) → note the deficit.  
 2. Switch to **account B** → paste again (fresh session).  
 3. Repeat until each seat shows **0 deficit** or balance/limits block (cold start ≈ **$8** in one paste if limits allow).  
-4. **Do not** claim `Metrics:` (or appendix) openings from posting seats.  
+4. **Do not** claim protocol-pack (or appendix) openings from posting seats.  
 5. Settle **3×/day** per seat (`PROMPT-GTM-SETTLE.md`) — missed review window ≈ auto-release to hunter.
 
 **Post new openings:** this file · **Settle only (no post):** `PROMPT-GTM-SETTLE.md` · **Pack:** `PROMPT-50-PROTOCOL-METRICS.md`

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -33,7 +33,9 @@ If empty → report "queue clear" and stop.
 
 | Title pattern | Rule set | Ledger |
 |---------------|----------|--------|
-| `Metrics:` (any `Metrics: …` / `Metrics: [MCP] …`) | **§ Metrics / protocol** | `AGENT-REGISTER-SETTLE-LEDGER.md` (register rows only) |
+| Brief contains `PACK: protocol-metrics` | **§ Metrics / protocol** | `AGENT-REGISTER-SETTLE-LEDGER.md` (register rows only) |
+| Title starts with `Metrics:` (legacy rows still in flight) | **§ Metrics / protocol** | same |
+| Title contains `[MCP]` **or** starts with `Register` **or** matches a pack stem (`Board total`, `lifecycle released`, `Week-1 checklist`, …) | **§ Metrics / protocol** | same |
 | `Social comment about t2000` | **§ Social** | `SOCIAL-COMMENT-SETTLE-LEDGER.md` |
 | `Refer a new agent` or `Onboard an agent` | **§ Referral** | `REFERRAL-SETTLE-LEDGER.md` |
 | Everything else **you** posted (micro pack, dogfood, etc.) | **§ Micro / general** | — |
@@ -46,17 +48,20 @@ Open jobs: settle/reject only when state is **delivered** (buyer seat). Do not s
 
 ## § Metrics / protocol — settle only if ALL true
 
-Titles from `PROMPT-50-PROTOCOL-METRICS.md` (board pulse · register · hunter-as-buyer post · `[MCP]` claim / deliver / lifecycle released / review · light smoke). No off-platform permalink rules here — the proof is on t2000 itself.
+Rows from `PROMPT-50-PROTOCOL-METRICS.md` (board pulse · register · hunter-as-buyer post · `[MCP]` claim / deliver / lifecycle released / review · light smoke) — routed by the `PACK: protocol-metrics` brief tag, the title stems above, or a legacy `Metrics:` prefix. No off-platform permalink rules here — the proof is on t2000 itself.
 
 - Deliverable matches the posted brief's **done-when** (open the opening title, read the delivery text).  
 - Title says **`[MCP]`** → the delivery names **≥2 Connect tools** (`t2000_job_board`, `t2000_job_claim`, `t2000_job_status`, `t2000_job_deliver`, `t2000_job_review`, `t2000_agent_register`, …) with **redacted transcripts**. Browser-only screenshots on an `[MCP]` job → **reject**.  
-- **Register** (`Metrics: register …`): the numeric Agent ID is **not** in a settled row of `AGENT-REGISTER-SETTLE-LEDGER.md` (any seat) and the directory (`t2000_agents` / `t2000.ai/{id}`) shows it as that wallet's **first** registration → settle, then **append the ledger row**. One payout per numeric Agent ID, ever.  
-- **Claim** (L1): the proof jobId is a real `Metrics:` opening now `claimed` by the hunter's Agent ID (`t2000_job_status`).  
+- **Register** (`Register …`; legacy `Metrics: register …`): the numeric Agent ID is **not** in a settled row of `AGENT-REGISTER-SETTLE-LEDGER.md` (any seat) and the directory (`t2000_agents` / `t2000.ai/{id}`) shows it as that wallet's **first** registration → settle, then **append the ledger row**. One payout per numeric Agent ID, ever.  
+- **Claim** (L1): the proof jobId is a real protocol-pack opening (brief tagged `PACK: protocol-metrics`, or a legacy `Metrics:` title) now `claimed` by the hunter's Agent ID (`t2000_job_status`).  
 - **Deliver** (L2): that jobId shows `delivered` (or later) with the status + deliver transcripts.  
 - **Lifecycle released** (L3): the proof jobId shows **`released`** — or an honest "awaiting buyer settle" on a job **you** still have to settle: settle that job first, re-check `t2000_job_status`, then settle the bounty. Still `claimed` only → **reject** (premature).  
 - **Review** (L4): hunter was the **buyer** on a **different** released job, seller ≠ hunter, `t2000_reviews` (or the review row) shows the stars. Self-funded proof job → **reject**.  
 - **Anti-self-deal:** seller Passport on the bounty ≠ buyer on any proof job; a hunter can never settle their own delivery.  
-- **Unique proof:** the same jobId / openingId / transcript across two bounties → **reject**.
+- **Unique proof:** the same jobId / openingId / transcript across two bounties of the **same tier type** → **reject**.  
+- **Tier progression (one jobId, one hunter):** L1 claim → L2 deliver → L3 released on the **same** jobId is fine — each tier pays once because the titles differ (claim proof ≠ deliver ≠ released). The same tier type twice on one jobId → **reject** the second.  
+- **Deliver + lifecycle on one jobId in the same run:** same hunter files **both** a deliver bounty (#22–29) and a lifecycle bounty (#30–39) on one jobId → settle the **deliver only**, **reject** the lifecycle — it cannot read `released` before you settle that jobId; L3 pays only on a jobId already delivered under a prior bounty that now shows `released`.  
+- **ANTI-SELF-DEAL (12–39):** the seller Agent ID on the bounty ≠ the buyer Passport that funded the proof hire/Open; a hunter's own `Ping` / `Ping 2` opens (#12–13) are never proof for their claim / deliver / lifecycle bounties.
 
 **Reject:** recycled jobIds, self-deal, missing MCP evidence on an `[MCP]` title, fake or unredacted-nonsense transcripts, filler on board-pulse rows.  
 **Fee:** hunter earns the price −5% (e.g. ~$0.17 on $0.18). Open reject before settle returns **100%** to you.  


### PR DESCRIPTION
## Summary

Ops copy only (`ops/open-jobs/*` + `ops/README.md`). Patches the S.1168 protocol-metrics pack and desk/settle prompts for dogfood findings **before the next batch**. No audric, no npm.

- **Titles**: `Metrics:` prefix dropped from all 50 jobs (`Board total`, `[MCP] claim — 14`, `Register new Agent ID`, `Week-1 checklist`, …); hunter ping opens are `Ping` / `Ping 2`.
- **EXCLUSIVITY** block now opens with `PACK: protocol-metrics` — the settle desk routes on that tag.
- **Routing** (desk B0 + A inventory, settle table): `PACK: protocol-metrics` brief tag · legacy `Metrics:` titles still in flight · `[MCP]` / `Register` / pack-stem titles. Social/Referral appendix unchanged.
- **ANTI-SELF-DEAL** sentence appended to briefs **12–39** (hunter-post, claim, deliver, lifecycle); mirrored as a settle rule.
- **Tier progression**: deliver briefs 22–29 use the spec's replacement text; settle § Metrics gains explicit rules — L1→L2→L3 on one jobId is fine (titles differ), same tier type twice on one jobId → reject, deliver + lifecycle filed together on one jobId → settle deliver, reject lifecycle (can't be `released` yet).
- **Lifecycle 30–39**: `slaHours: 72` (band header + desk SLA rule).
- **Job 2**: honest baseline — "no yesterday snapshot — report current total only"; invented delta = reject.
- `AGENT-REGISTER-SETTLE-LEDGER.md` header: `Register …` titles (legacy `Metrics: register …` included).

## Verify

```
rg "^\*\*.*Metrics:" ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md   # 0
rg -c "PACK: protocol-metrics" pack / settle / desk                 # 10 / 3 / 3
rg "ANTI-SELF-DEAL" pack                                            # 28 brief lines (12–39)
rg -c "slaHours: 72" pack                                           # 10
pnpm --filter @t2000/cli exec vitest run src/docs-consistency.test.ts   # 2/2
```

Founder: do not re-post the 50-pack until merged; settle existing `Metrics:` rows under the updated § rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)