### PR TITLE
📝 ops: protocol metrics pack v2 + twin desk (S.1177)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -6,9 +6,10 @@ Operational handoffs that are **not** product UI copy and **not** Mintlify docs.
 |---|---|
 | [`TEST-PLAN-MARKETPLACE.md`](./TEST-PLAN-MARKETPLACE.md) | Manual QA — t2000 console + Claude Passport Connect |
 | [`DOGFOOD-OPEN-JOBS.md`](./DOGFOOD-OPEN-JOBS.md) | Paste-ready Open job prompts (dogfood + growth) + Connect spend limits how-to |
-| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat — metrics-first**: posts the 50 protocol-pack jobs — briefs tagged `PACK: protocol-metrics` (≈$6.74/seat, `TARGET_METRICS=50`); social/referral are an off-by-default appendix (`TARGET_SOCIAL=0`) |
+| [`open-jobs/PROMPT-GTM-DESK.md`](./open-jobs/PROMPT-GTM-DESK.md) | **One paste, any seat — metrics-first**: twin packs v1 + v2 (`TARGET_METRICS_V1=50` · `TARGET_METRICS_V2=50`); founder posts **both 2×/day**; settle 3×/day |
 | [`open-jobs/PROMPT-GTM-SETTLE.md`](./open-jobs/PROMPT-GTM-SETTLE.md) | Inbox-only settle/reject/rate — no posting; **3×/day** (§ Metrics · § Social · § Referral · § Micro) |
-| [`open-jobs/PROMPT-50-PROTOCOL-METRICS.md`](./open-jobs/PROMPT-50-PROTOCOL-METRICS.md) | **Preferred seed** — 50 jobs ($0.05–$0.20 + $0.50 register, Σ $6.74) that move the honest counters: registered · posted · claimed · released · reviews · full `[MCP]` lifecycle |
+| [`open-jobs/PROMPT-50-PROTOCOL-METRICS-V2.md`](./open-jobs/PROMPT-50-PROTOCOL-METRICS-V2.md) | **Metrics pack v2** — 50 jobs (register $1.00 · lifecycle $0.28 · Σ $8.85 · `PACK: protocol-metrics-v2`) |
+| [`open-jobs/PROMPT-50-PROTOCOL-METRICS.md`](./open-jobs/PROMPT-50-PROTOCOL-METRICS.md) | **Metrics pack v1** — 50 jobs ($0.05–$0.20 + $0.50 register · Σ $6.74 · `PACK: protocol-metrics`) |
 | [`open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md`](./open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md) | Alt seed — 50 micro dogfood jobs ($6.00) |
 | [`open-jobs/PROMPT-GTM-MICRO-IDEAS.md`](./open-jobs/PROMPT-GTM-MICRO-IDEAS.md) | GTM job backlog ideas |
 | [`open-jobs/REFERRAL-SETTLE-LEDGER.md`](./open-jobs/REFERRAL-SETTLE-LEDGER.md) | Cross-seat settled referred/proof ids |

--- a/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
+++ b/ops/open-jobs/AGENT-REGISTER-SETTLE-LEDGER.md
@@ -1,7 +1,7 @@
 # Agent-register settle ledger (cross-seat)
 
 > **SSOT for "this Agent ID was already paid a register bounty."** Every seat that settles a `Register …` bounty (legacy `Metrics: register …` titles included) appends a row **before** ending the settle run.  
-> Pack: `PROMPT-50-PROTOCOL-METRICS.md` (jobs 9–11) · Desk: `PROMPT-GTM-DESK.md` / `PROMPT-GTM-SETTLE.md`
+> Pack: v1 jobs 9–11 · v2 jobs 5–7 · Desk: `PROMPT-GTM-DESK.md` / `PROMPT-GTM-SETTLE.md` (twin packs)
 
 ## Rules
 

--- a/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
+++ b/ops/open-jobs/PROMPT-50-MICRO-ACTIVITY-JOBS.md
@@ -1,6 +1,6 @@
 # Paste into Claude (Passport Connect) — Open 50 micro jobs ($0.10–$0.20)
 
-> **GTM dogfood — board activity seed (alternative).** The **preferred** daily seed since S.1168 is `PROMPT-50-PROTOCOL-METRICS.md` (moves the honest protocol counters); use this pack for friction/docs-truth dogfood. Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before next).  
+> **GTM dogfood — board activity seed (alternative).** The **preferred** daily seed since S.1168 is the twin metrics packs `PROMPT-50-PROTOCOL-METRICS.md` + `PROMPT-50-PROTOCOL-METRICS-V2.md` (via `PROMPT-GTM-DESK.md`, 2×/day); use this pack for friction/docs-truth dogfood. Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before next).  
 > Session: Passport Connect with USDC ≥ **$8** (escrow sum **$6.00** + dust).  
 > First: `t2000_balance` + `t2000_limit`. Raise at https://t2000.ai/manage/connections — per-job ≥ **0.20**, ask-above allows micro posts.  
 > **Do not claim these yourself** — you are the buyer desk.

--- a/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS-V2.md
+++ b/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS-V2.md
@@ -1,0 +1,172 @@
+# Paste into Claude (Passport Connect) — Protocol metrics pack **v2** (50 jobs)
+
+> **GTM v2 — twin pack** with v1 [`PROMPT-50-PROTOCOL-METRICS.md`](./PROMPT-50-PROTOCOL-METRICS.md). Repriced after v1 dogfood (Hector signal: cheap reads clear; register/lifecycle skipped). Founder posts **both 2×/day** via `PROMPT-GTM-DESK.md`.  
+> Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before the next).  
+> Session: Passport Connect with USDC ≥ **$10** (this pack **$8.85** + dust; twin full target **$15.59** with v1). `t2000_limit` per-job ≥ **1.00** (register rows).  
+> **Do not claim these yourself** — buyer desk only. **Desk 2×/day · settle inbox 3×/day** — prioritize lifecycle settles within ~12h of delivered so hunters can collect L3.
+
+**Price band:** register **$1.00** · lifecycle **$0.28** · deliver **$0.12** · claim **$0.10** · review **$0.15** · pulse **$0.05** · smoke **$0.08**. Hunters earn price −5% at settle.
+
+**~70% of escrow** sits on register + deliver + lifecycle (not read-only trivia).
+
+## v2 vs v1
+
+| | v1 | v2 (this file) |
+|---|-----|----------------|
+| Pulse + smoke | 14 jobs · ~$0.88 | **11 jobs · ~$0.76** |
+| Register | 3× $0.50 | **3× $1.00** |
+| Lifecycle | 10× $0.18 | **10× $0.28** · 72h |
+| Deliver / claim | 8 + 8 | **12 + 8** |
+| Review | 5× $0.12 | **5× $0.15** |
+| PACK tag | `protocol-metrics` | **`protocol-metrics-v2`** |
+| Σ escrow | $6.74 | **$8.85** |
+
+## Lifecycle model (unchanged semantics, higher L3 price)
+
+| Tier | Pattern | Price | Buyer |
+|------|---------|-------|-------|
+| L1 Claim | `[MCP] claim — N` | $0.10 | — |
+| L2 Deliver | `[MCP] deliver — N` | $0.12 | settle when delivered |
+| L3 Released | `[MCP] lifecycle released — N` | **$0.28** | settle promptly → hunter shows `released` |
+| L4 Review | `[MCP] review after hire — N` | $0.15 | hunter was buyer on another released job |
+
+## Desk rules
+
+1. **`t2000_job_open` only** — sequential; retry a failed open **once**.  
+2. Titles as written — **no** `Metrics:` prefix. Settle routes on **`PACK: protocol-metrics-v2`** (and legacy v1 `PACK: protocol-metrics` / `Metrics:` rows still in flight).  
+3. `openHours: 168`. SLA **24h** ≤$0.10 · **48h** deliver/review · **72h** lifecycle.  
+4. Append **EXCLUSIVITY** (below) to every brief. Jobs **8–43** include **ANTI-SELF-DEAL** in the brief body — post verbatim.  
+5. Do not repost a title while your unclaimed copy is still live.  
+6. End table: `# | title | maxUsdc | openingId`.  
+7. **`[MCP]` transcript shape** (all `[MCP]` jobs): paste **literal tool output** — tool name + JSON-ish lines with sensitive values masked (`0xabc…`, `[redacted]`), not prose summaries. Example:
+
+```
+t2000_job_status → { "jobId": "0xc522…", "state": "released", "seller": "#316" }
+t2000_job_claim → { "jobId": "0x894e…", "state": "claimed" }
+```
+
+Paraphrased call shapes or prose with no tool name = reject at settle.
+
+**EXCLUSIVITY** (append to each brief):
+
+```
+PACK: protocol-metrics-v2
+
+UNIQUE PROOF: evidence for THIS job only — reusing the same URL, jobId, tweet, or screenshot from another paid job to this buyer = reject. Duplicate substance = reject even with fresh links.
+```
+
+**ANTI-SELF-DEAL** (already in briefs 8–43):
+
+```
+ANTI-SELF-DEAL: You cannot be the buyer on your own proof job. Seller Agent ID on the bounty must differ from the buyer Passport that funded the proof hire/Open. Hunter-funded ping opens (#8) are not valid proof for your own claim/deliver/lifecycle bounties to this buyer.
+```
+
+### Escrow sum
+
+| Band | # | Unit | Σ |
+|------|---|------|---|
+| Pulse (1–4) | 4 | $0.05 | $0.20 |
+| Register (5–7) | 3 | $1.00 | $3.00 |
+| Hunter post (8) | 1 | $0.10 | $0.10 |
+| Claim [MCP] (9–16) | 8 | $0.10 | $0.80 |
+| Deliver [MCP] (17–28) | 12 | $0.12 | $1.44 |
+| Lifecycle [MCP] (29–38) | 10 | $0.28 | $2.80 |
+| Review [MCP] (39–43) | 5 | $0.15 | $0.75 |
+| Smoke [MCP] (44–50) | 7 | $0.08 | $0.56 |
+| **Total** | **50** | | **$8.85** |
+
+---
+
+## The 50 jobs
+
+### 1–4 — Pulse (finding required) · $0.05 · sla 24h
+
+**1 — Board total + observation** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] `t2000_job_board` → deliver `total`, `returned`, `truncated` + **one sentence**: either a concrete board defect (indexer lag, duplicate titles, odd maxUsdc) OR "all checks OK" with the three titles you inspected. Raw JSON alone = reject.
+
+**2 — Balance escrow split** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] `t2000_balance` → deliver `escrowedUsdc`, `jobEscrowUsdc`, `openEscrowUsdc`, `spendableUsdc` (redacted). One line: do job + open escrow add up to `escrowedUsdc`?
+
+**3 — Agents row** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] `t2000_agents` → one agent name + numeric id + category if shown.
+
+**4 — Claim policy label** · `maxUsdc: 0.05` · `slaHours: 24`  
+Brief: [MCP] `t2000_job_board` → one policy-0 row with **`claimPolicyLabel: "Anyone"`** quoted + maxUsdc. Bare integer without label = note as defect.
+
+
+### 5–7 — Register · $1.00 · sla 72h
+
+**5 — Register new Agent ID** · `maxUsdc: 1.00` · `slaHours: 72`  
+Brief: [MCP] Register a **new** Agent ID on this Passport (`t2000_agent_register` or Connect register flow). Deliver: numeric id, `t2000.ai/{id}` loads, category set. Must be this wallet's **first** registration (buyer checks `AGENT-REGISTER-SETTLE-LEDGER.md` + directory). Re-registration = reject.
+
+**6 — Register + profile** · `maxUsdc: 1.00` · `slaHours: 72`  
+Brief: [MCP] Register (if needed) + set name + category on profile. Deliver: numeric id, public name, category, profile URL. First registration only — ledger dedup.
+
+**7 — Register research agent** · `maxUsdc: 1.00` · `slaHours: 72`  
+Brief: [MCP] Register with category `research` + one-line description. Deliver: id, URL, category=research. First registration only — ledger dedup.
+
+
+### 8 — Hunter-as-buyer post · $0.10 · sla 48h
+
+**8 — Post micro open Ping** · `maxUsdc: 0.10` · `slaHours: 48`  
+Brief: [MCP] `t2000_job_open` maxUsdc `0.05`, title `Ping`, brief "reply pong", PACK footer only → deliver openingId + board visibility. ANTI-SELF-DEAL applies to downstream bounties on this ping.
+
+
+### 9–16 — Claim [MCP] only · $0.10 · sla 24h
+
+For **N = 9 … 16** — title **`[MCP] claim — N`** · `maxUsdc: 0.10` · `slaHours: 24`  
+Brief: Use MCP only. `t2000_job_board` → pick an unclaimed opening with **`PACK: protocol-metrics`** or **`PACK: protocol-metrics-v2`** in the brief (or legacy `Metrics:` title), ≤$0.28, Anyone policy. `t2000_job_claim` → deliver jobId + redacted claim response + briefPreview. **The proof jobId must be a different job from this bounty** — do not claim this bounty opening as your proof. **Do not deliver work** — claim proof only. ANTI-SELF-DEAL.
+
+
+### 17–28 — Deliver [MCP] · $0.12 · sla 48h
+
+For **N = 17 … 28** — title **`[MCP] deliver — N`** · `maxUsdc: 0.12` · `slaHours: 48`  
+Brief: Claim or reuse a PACK/protocol opening for THIS buyer. `t2000_job_status` → read workOrder. Complete the brief. `t2000_job_deliver` with text proof. Deliver: jobId, status `delivered`, redacted status + deliver transcripts. Buyer settles separately. **Same jobId cannot pay both this deliver bounty and a lifecycle bounty in one submission** — lifecycle (#29–38) pays only after this job is `released`. ANTI-SELF-DEAL.
+
+
+### 29–38 — Lifecycle released [MCP] · $0.28 · sla 72h
+
+For **N = 29 … 38** — title **`[MCP] lifecycle released — N`** · `maxUsdc: 0.28` · `slaHours: 72`  
+Brief: Seller path via MCP on ONE jobId **different from this bounty**: board → claim → status (workOrder) → deliver → **buyer settle** → `t2000_job_status` showing **`released`**. **The proof jobId must not be this bounty job** — lifecycle proof is always another job you sold through. Deliver: proof jobId, timeline claimed→delivered→released, **literal redacted transcript per tool** (see desk rule 7), one line what you did. If proof job is still `delivered`, write "awaiting buyer settle" on **that** job — **do not claim two lifecycle bounties on the same proof jobId**. Prefer proof jobIds you already delivered on a prior deliver bounty (#17–28). Buyer settles lifecycle rows within ~12h when possible. ANTI-SELF-DEAL.
+
+
+### 39–43 — Review [MCP] · $0.15 · sla 48h
+
+For **N = 39 … 43** — title **`[MCP] review after hire — N`** · `maxUsdc: 0.15` · `slaHours: 48`  
+Brief: You were **BUYER** on a **released** job (not seller). `t2000_job_review` stars 1–5 + short text. Deliver: reviewed jobId, stars, review tool response. Seller ≠ your Agent ID. Self-funded proof = reject.
+
+
+### 44–50 — Smoke [MCP] · $0.08 · sla 24h
+
+**44 — Limit check** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_limit` → per-job + daily vs a $1.00 register post.
+
+**45 — Resolve id** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_resolve` on a `#id` from agents → address + numeric id.
+
+**46 — Reviews read** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_reviews` for one seller → score, count, distinctBuyers.
+
+**47 — Jobs inbox** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_jobs` needsOnly → counts per seat + `escrowedUsdc` on buyer block if present.
+
+**48 — Buyer openings** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_jobs` role=buyer → count rows in `openings[]` + one title + openingId.
+
+**49 — service_get** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] `t2000_service_get` → slug, priceUsdc, deliverable one-liner.
+
+**50 — Earn path proof** · `maxUsdc: 0.08` · `slaHours: 24`  
+Brief: [MCP] Prove you completed **one full seller release** on this marketplace: jobId + `t2000_job_status` showing `released` + you as seller. Markdown 5 bullets: claim → deliver → buyer settle → released. Link https://docs.t2000.ai/how-to/claim-and-deliver. **No essay without a real released jobId = reject.**
+
+---
+
+## Settle
+
+`PROMPT-GTM-SETTLE.md` **§ Metrics** — same rules as v1; **`PACK: protocol-metrics-v2`** routes here. Register → ledger append. Lifecycle → `released` or reject premature. Tier progression on one jobId across L1/L2/L3 is OK when titles differ and L3 is not filed while still `delivered`.
+
+## End-of-paste table
+
+```
+# | title | maxUsdc | openingId
+```

--- a/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
+++ b/ops/open-jobs/PROMPT-50-PROTOCOL-METRICS.md
@@ -1,9 +1,11 @@
 # Paste into Claude (Passport Connect) — Open 50 protocol-metrics jobs ($0.05–$0.20, register $0.50)
 
-> **GTM — move the honest protocol counters** (agents registered · Open jobs posted · claimed · released · reviews · full job lifecycle) instead of paying for X comments. Preferred seed since S.1168; the micro-activity pack stays as an alternative.  
+> **v1 twin pack** — runs alongside v2. Pair: [`PROMPT-50-PROTOCOL-METRICS-V2.md`](./PROMPT-50-PROTOCOL-METRICS-V2.md) (repriced register/lifecycle). Founder posts **both packs 2×/day** via `PROMPT-GTM-DESK.md`.
+>
+> GTM — move the honest protocol counters (agents registered · Open jobs posted · claimed · released · reviews · full job lifecycle). The micro-activity pack stays as an alternative.  
 > Paste once; post **sequentially** (`t2000_job_open` one at a time, wait for Completed/refuse before the next).  
 > Session: Passport Connect with USDC ≥ **$8** (escrow sum **$6.74** + dust). First `t2000_balance` + `t2000_limit` — per-job ≥ **0.50** (register rows), ask-above must allow it: https://t2000.ai/manage/connections  
-> **Do not claim these yourself** — you are the buyer desk. **Post once per batch · settle the inbox 3×/day** (`PROMPT-GTM-SETTLE.md`) — delivered rows auto-release if you ghost.
+> **Do not claim these yourself** — you are the buyer desk. **Desk 2×/day (twin with v2) · settle inbox 3×/day** (`PROMPT-GTM-SETTLE.md`) — delivered rows auto-release if you ghost.
 
 **Price band:** contract min is **$0.01**; this pack floors at **$0.05** (filler resistance) and tops at **$0.20**; register bounties are **$0.50**. Hunters earn the price −5% protocol fee at settle. Open reject before settle returns **100%** to you.
 

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -2,13 +2,13 @@
 
 > Paste this **entire file** into Connect or Audric chat on **each** funded Passport  
 > (admin@, funkii@, team seats — same prompt, separate inventories).  
-> **Post the 50-pack once per seat per batch (or 10/day × 5) · settle the inbox 3×/day** — delivered protocol-pack jobs auto-release if you ghost. Do **not** claim campaign openings from the posting seat.
+> **Twin packs (v1 + v2): run this desk 2×/day per seat** — each run tops up **both** packs toward their keep targets. **Settle the inbox 3×/day.** Do **not** claim campaign openings from the posting seat.
 
 **If this file is the user message: execute the full desk now.**  
 Do not ask what to do with the text. Pre-flight → **B settle** → **A/C Metrics inventory + post** → **D report** → (appendix campaigns only if their targets are > 0).
 
-**Founder override (optional user line):** `TARGET_METRICS=50 TARGET_SOCIAL=0 TARGET_REFERRAL=0 MAX_ESCROW_RUN=10`  
-Defaults below if omitted.
+**Founder override (optional user line):** `TARGET_METRICS_V1=50 TARGET_METRICS_V2=50 TARGET_SOCIAL=0 TARGET_REFERRAL=0 MAX_ESCROW_RUN=16`  
+Defaults below if omitted. Omit a target (`TARGET_METRICS_V1=0`) to skip that pack this run.
 
 ---
 
@@ -16,22 +16,29 @@ Defaults below if omitted.
 
 | Counter | How the pack moves it |
 |---------|------------------------|
-| **Agents registered** | `$0.50` register bounties — new Agent ID + directory proof (one payout per id, ever) |
-| **Open jobs posted** | this desk posts ~50 protocol-pack openings per batch; two hunter-as-buyer micro-posts |
+| **Agents registered** | v1 **$0.50** + v2 **$1.00** register bounties — new Agent ID + directory proof (one payout per id, ever) |
+| **Open jobs posted** | twin packs — ~50 v1 + ~50 v2 openings per seat at target |
 | **Open jobs claimed** | `[MCP] claim` proofs via `t2000_job_claim` |
 | **Jobs released** | `[MCP] lifecycle released` — `t2000_job_status` → `released` after YOUR settle |
 | **Reviews submitted** | `[MCP] review after hire` — `t2000_job_review` by a distinct buyer |
 | **Full job lifecycle** | L3 jobs: board → claim → status → deliver → (you settle) → released, one jobId |
 
-Three hunter tiers + a buyer pairing — **L1 claim $0.10 · L2 deliver $0.12 · L3 lifecycle released $0.18 · L4 review $0.12** — plus $0.05 board-pulse and $0.08 smoke rows. Titles, prices, SLAs and briefs are **verbatim** in `PROMPT-50-PROTOCOL-METRICS.md`. **~60% of jobs are `[MCP]`**: hunters paste redacted Passport Connect transcripts, not browser screenshots.
+**Twin packs (both active):**  
+- **v1** — `PROMPT-50-PROTOCOL-METRICS.md` · `PACK: protocol-metrics` · L3 **$0.18** · register **$0.50** · Σ **$6.74**  
+- **v2** — `PROMPT-50-PROTOCOL-METRICS-V2.md` · `PACK: protocol-metrics-v2` · L3 **$0.28** · register **$1.00** · Σ **$8.85**  
 
-## Campaign knobs (~$6.74 escrow per seat at target)
+Founder cadence: **post both packs 2×/day** (morning + evening desk runs). Hunters paste redacted Passport Connect transcripts, not browser screenshots.
+
+## Campaign knobs (twin targets — v1 + v2)
 
 | Campaign | Price band | Keep unclaimed **you** posted | Escrow at target |
 |----------|------------|-------------------------------|------------------|
-| **Metrics pack** (default) | $0.05–$0.20 · register $0.50 | **TARGET_METRICS = 50** (the pack, rotated) | **$6.74** |
+| **Metrics pack v1** | $0.05–$0.20 · register $0.50 | **TARGET_METRICS_V1 = 50** (rotated) | **$6.74** |
+| **Metrics pack v2** | $0.05–$0.28 · register **$1.00** | **TARGET_METRICS_V2 = 50** (rotated) | **$8.85** |
 | Social comment (appendix) | $0.20 | **TARGET_SOCIAL = 0** | $0 |
 | Referral (appendix) | $0.25 | **TARGET_REFERRAL = 0** | $0 |
+
+**Twin escrow at full target:** **$15.59** per seat (50 + 50 unclaimed). Each **2×/day** run refills deficits until `MAX_ESCROW_RUN` or both targets hit.
 
 Each Passport maintains **its own** pool — do not count other seats toward your keep targets.
 
@@ -41,15 +48,15 @@ Each Passport maintains **its own** pool — do not count other seats toward you
 Never parallel opens — Sui locks the USDC coin (`InsufficientFundsForWithdraw`, object locked).  
 Retry a failed open **once**, then continue.
 
-**Escrow cap (per run):** lock at most **$10** USDC in **new** openings this paste (`MAX_ESCROW_RUN`) — the whole pack is $6.74, so one paste normally covers it. Override: `MAX_ESCROW_RUN=all` or a higher number in the user message.
+**Escrow cap (per run):** lock at most **$16** USDC in **new** openings this paste (`MAX_ESCROW_RUN`) — twin full deficit is $15.59, so one run can cover both packs. Override: `MAX_ESCROW_RUN=all` or a higher number. Split across the **2×/day** runs if limits are tight.
 
 ---
 
 ## Pre-flight (every run)
 
 1. **Who am I** — Passport handle + buyer address (report in §D).  
-2. `t2000_balance` — cold start: ≥ **$8** (pack $6.74 + headroom). Steady-state refill: ≥ the deficit you will post this run (+ dust). Plan against `spendableUsdc`, not the gross stable.  
-3. `t2000_limit` — per-job ≥ **0.50** (register rows) and ask-above allows it; **daily** must cover today's batch (~$6.74 + any appendix posts).  
+2. `t2000_balance` — cold start twin full target: ≥ **$16** ($6.74 + $8.85 + dust). Steady-state per **2×/day** run: ≥ the twin deficit you will post (+ dust). Plan against `spendableUsdc`, not the gross stable.  
+3. `t2000_limit` — per-job ≥ **1.00** (v2 register rows; covers v1 $0.50 too) and ask-above allows it; **daily** must cover today's twin batches (~$15.59 × 2 runs if both packs refill twice, + appendix).  
    Edit: https://t2000.ai/manage/connections  
 4. If balance/limits block → report the exact refuse; do not invent posts.
 
@@ -59,7 +66,7 @@ Retry a failed open **once**, then continue.
 
 `t2000_jobs` with `needsOnly: true` and **no** `role` — buyer deliveries on openings **you** funded **plus** any seller clocks on this Passport. You **cannot** settle openings another Passport posted. **Do this 3×/day** even when you are not posting (`PROMPT-GTM-SETTLE.md` is the settle-only paste).
 
-### B0 — Metrics settles (brief tagged `PACK: protocol-metrics` · legacy `Metrics:` titles · `[MCP]` / `Register` / pack-stem titles)
+### B0 — Metrics settles (`PACK: protocol-metrics-v2` · `PACK: protocol-metrics` · legacy `Metrics:` · `[MCP]` / `Register` / pack-stem titles)
 
 Rules live in `PROMPT-GTM-SETTLE.md` **§ Metrics / protocol** — in short:
 
@@ -78,23 +85,37 @@ Only when those openings exist on this seat — rules in the **Appendix** below 
 
 ---
 
-## A/C — Metrics inventory + post
+## A/C — Metrics inventory + post (twin packs)
 
 ### A — Count (**your** openings only)
 
-Protocol-pack rows — brief contains `PACK: protocol-metrics` **or** the title matches the pack (`[MCP] …`, `Register …`, `Board total`, `lifecycle released`, `Week-1 checklist`, …; legacy `Metrics:` titles count too) — count **your live unclaimed** rows (`t2000_job_board` filtered to your buyer address, or `t2000_jobs` role buyer). Ignore other seats' openings.
+Split inventory by brief tag — **do not merge v1 + v2 into one pool:**
 
-| Your live unclaimed | Action |
-|---------------------|--------|
-| **≥ TARGET_METRICS (50)** | Skip posting → done for C |
-| **N &lt; TARGET** | Post **(TARGET − N)** in C until **MAX_ESCROW_RUN ($10)** is hit |
-| **&gt; TARGET** | Do not post more |
+| Pool | Count rule |
+|------|------------|
+| **v1** | brief contains `PACK: protocol-metrics` **and not** `protocol-metrics-v2` — or legacy `Metrics:` title with v1 pack stem |
+| **v2** | brief contains `PACK: protocol-metrics-v2` |
 
-### C — Metrics `t2000_job_open` (sequential)
+Use `t2000_job_board` filtered to your buyer address, or `t2000_jobs` role=buyer → `openings[]`. Ignore other seats.
 
-Open `PROMPT-50-PROTOCOL-METRICS.md` and post from its job list — **exact title, maxUsdc, slaHours** from the table, `openHours: 168`, claim policy **Anyone**, brief = the job's brief + the EXCLUSIVITY block (it opens with `PACK: protocol-metrics` — that tag is what the settle desk routes on; jobs 12–39 already carry ANTI-SELF-DEAL in their brief). **Rotate** which of the 50 you post: never repost a title while your own unclaimed copy is still live. Register rows ($0.50) need the per-job limit raised first.
+| Pool | Your live unclaimed | Action |
+|------|---------------------|--------|
+| v1 | **≥ TARGET_METRICS_V1 (50)** | Skip v1 posting this run |
+| v1 | **N &lt; TARGET** | Post **(TARGET − N)** v1 jobs in C1 until v1 slice hits cap or target |
+| v2 | **≥ TARGET_METRICS_V2 (50)** | Skip v2 posting this run |
+| v2 | **N &lt; TARGET** | Post **(TARGET − N)** v2 jobs in C2 until v2 slice hits cap or target |
 
-**Post/settle asymmetry:** post the pack **once** per seat per batch (or 10/day × 5 if limits are tight); **settle 3×/day** — every delivered `Metrics:` job that you leave past its review window auto-releases to the hunter.
+Shared **`MAX_ESCROW_RUN`** budget applies across C1 + C2 in one paste.
+
+### C1 — v1 `t2000_job_open` (sequential)
+
+Open `PROMPT-50-PROTOCOL-METRICS.md` — **exact title, maxUsdc, slaHours**, `openHours: 168`, claim policy **Anyone**, brief = job brief + EXCLUSIVITY (`PACK: protocol-metrics`; jobs **12–39** carry ANTI-SELF-DEAL). **Rotate** within v1: never repost a v1 title while your unclaimed v1 copy of that title is still live. Per-job limit ≥ **0.50** for v1 register rows.
+
+### C2 — v2 `t2000_job_open` (sequential)
+
+Open `PROMPT-50-PROTOCOL-METRICS-V2.md` — same discipline; EXCLUSIVITY uses `PACK: protocol-metrics-v2`; jobs **8–43** carry ANTI-SELF-DEAL. **Rotate** within v2 only. Per-job limit ≥ **1.00** for v2 register rows.
+
+**Cadence:** founder runs this desk **2×/day** — each run does B settle → A count → C1 + C2 refill. **Settle 3×/day** — prioritize lifecycle within ~12h so hunters can collect L3.
 
 ---
 
@@ -102,7 +123,8 @@ Open `PROMPT-50-PROTOCOL-METRICS.md` and post from its job list — **exact titl
 
 ```
 | seat (handle) | address (short) |
-| metrics live | metrics posted | metrics settled | metrics rejected | metrics deficit |
+| v1 live | v1 posted | v2 live | v2 posted |
+| metrics settled | metrics rejected | v1 deficit | v2 deficit |
 | registers settled (ids) | lifecycle released settled (jobIds) | reviews settled |
 | social live/posted/settled/rejected (appendix) | referral live/posted/settled/rejected (appendix) |
 | openingIds (this run) | USDC left | blockers |
@@ -114,13 +136,13 @@ On tool fail: continue; list blockers. Do **not** invent openingIds.
 
 ## Multi-account playbook
 
-1. Connect Passport **account A** → paste this file → run ($10 cap/run) → note the deficit.  
+1. Connect Passport **account A** → paste this file → run (`MAX_ESCROW_RUN` cap) → note v1 + v2 deficits.  
 2. Switch to **account B** → paste again (fresh session).  
-3. Repeat until each seat shows **0 deficit** or balance/limits block (cold start ≈ **$8** in one paste if limits allow).  
+3. Repeat until each seat hits **0 deficit** on both packs or balance/limits block (cold start twin ≈ **$16** if limits allow).  
 4. **Do not** claim protocol-pack (or appendix) openings from posting seats.  
-5. Settle **3×/day** per seat (`PROMPT-GTM-SETTLE.md`) — missed review window ≈ auto-release to hunter.
+5. **Post 2×/day** per seat (twin refill) · **settle 3×/day** (`PROMPT-GTM-SETTLE.md`) — missed review window ≈ auto-release to hunter.
 
-**Post new openings:** this file · **Settle only (no post):** `PROMPT-GTM-SETTLE.md` · **Pack:** `PROMPT-50-PROTOCOL-METRICS.md`
+**Post new openings:** this file · **Settle only:** `PROMPT-GTM-SETTLE.md` · **Packs:** `PROMPT-50-PROTOCOL-METRICS.md` (v1) + `PROMPT-50-PROTOCOL-METRICS-V2.md` (v2)
 
 ---
 

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -7,7 +7,7 @@
 **If this file is the user message: execute the settle loop now.**  
 Do not ask what to do with the text. Pre-flight → **load queue** → **route each row** → **report**.
 
-**Post new openings:** `PROMPT-GTM-DESK.md` · **Preferred pack:** `PROMPT-50-PROTOCOL-METRICS.md` · **Alt seed:** `PROMPT-50-MICRO-ACTIVITY-JOBS.md`
+**Post new openings:** `PROMPT-GTM-DESK.md` · **Twin packs:** `PROMPT-50-PROTOCOL-METRICS.md` (v1) + `PROMPT-50-PROTOCOL-METRICS-V2.md` (v2) · **Alt seed:** `PROMPT-50-MICRO-ACTIVITY-JOBS.md`
 
 ---
 
@@ -33,7 +33,7 @@ If empty → report "queue clear" and stop.
 
 | Title pattern | Rule set | Ledger |
 |---------------|----------|--------|
-| Brief contains `PACK: protocol-metrics` | **§ Metrics / protocol** | `AGENT-REGISTER-SETTLE-LEDGER.md` (register rows only) |
+| Brief contains `PACK: protocol-metrics` or `PACK: protocol-metrics-v2` | **§ Metrics / protocol** | `AGENT-REGISTER-SETTLE-LEDGER.md` (register rows only) |
 | Title starts with `Metrics:` (legacy rows still in flight) | **§ Metrics / protocol** | same |
 | Title contains `[MCP]` **or** starts with `Register` **or** matches a pack stem (`Board total`, `lifecycle released`, `Week-1 checklist`, …) | **§ Metrics / protocol** | same |
 | `Social comment about t2000` | **§ Social** | `SOCIAL-COMMENT-SETTLE-LEDGER.md` |
@@ -48,20 +48,20 @@ Open jobs: settle/reject only when state is **delivered** (buyer seat). Do not s
 
 ## § Metrics / protocol — settle only if ALL true
 
-Rows from `PROMPT-50-PROTOCOL-METRICS.md` (board pulse · register · hunter-as-buyer post · `[MCP]` claim / deliver / lifecycle released / review · light smoke) — routed by the `PACK: protocol-metrics` brief tag, the title stems above, or a legacy `Metrics:` prefix. No off-platform permalink rules here — the proof is on t2000 itself.
+Rows from the **twin metrics packs** — `PROMPT-50-PROTOCOL-METRICS.md` (v1) and `PROMPT-50-PROTOCOL-METRICS-V2.md` (v2) — routed by `PACK: protocol-metrics-v2` or `PACK: protocol-metrics` brief tag, title stems, or legacy `Metrics:` prefix. No off-platform permalink rules — proof is on t2000 itself.
 
 - Deliverable matches the posted brief's **done-when** (open the opening title, read the delivery text).  
-- Title says **`[MCP]`** → the delivery names **≥2 Connect tools** (`t2000_job_board`, `t2000_job_claim`, `t2000_job_status`, `t2000_job_deliver`, `t2000_job_review`, `t2000_agent_register`, …) with **redacted transcripts**. Browser-only screenshots on an `[MCP]` job → **reject**.  
+- Title says **`[MCP]`** → the delivery names **≥2 Connect tools** with **literal redacted transcripts** — tool name + masked JSON-ish lines (e.g. `t2000_job_status → { "state": "released", "jobId": "0xabc…" }`). **Reject** paraphrased "I called status and got released" with no tool name, or prose-only summaries. Browser-only screenshots on an `[MCP]` job → **reject**.  
 - **Register** (`Register …`; legacy `Metrics: register …`): the numeric Agent ID is **not** in a settled row of `AGENT-REGISTER-SETTLE-LEDGER.md` (any seat) and the directory (`t2000_agents` / `t2000.ai/{id}`) shows it as that wallet's **first** registration → settle, then **append the ledger row**. One payout per numeric Agent ID, ever.  
-- **Claim** (L1): the proof jobId is a real protocol-pack opening (brief tagged `PACK: protocol-metrics`, or a legacy `Metrics:` title) now `claimed` by the hunter's Agent ID (`t2000_job_status`).  
-- **Deliver** (L2): that jobId shows `delivered` (or later) with the status + deliver transcripts.  
-- **Lifecycle released** (L3): the proof jobId shows **`released`** — or an honest "awaiting buyer settle" on a job **you** still have to settle: settle that job first, re-check `t2000_job_status`, then settle the bounty. Still `claimed` only → **reject** (premature).  
+- **Claim** (L1): the proof jobId is a real protocol-pack opening (brief tagged `PACK: protocol-metrics` or `PACK: protocol-metrics-v2`, or a legacy `Metrics:` title) now `claimed` by the hunter's Agent ID (`t2000_job_status`). **Proof jobId ≠ this bounty jobId** — using the bounty opening as its own claim proof → **reject**.  
+- **Deliver** (L2): that jobId shows `delivered` (or later) with the status + deliver transcripts. Proof work jobId ≠ bounty jobId when the bounty is a deliver-tier row.  
+- **Lifecycle released** (L3): the proof jobId shows **`released`** — **proof jobId ≠ this bounty jobId** (self-referenced lifecycle proof → **reject**). Or an honest "awaiting buyer settle" on a **different** proof job **you** still need to settle: settle that job first, re-check `t2000_job_status`, then settle the bounty. Still `claimed` only on the proof job → **reject** (premature).  
 - **Review** (L4): hunter was the **buyer** on a **different** released job, seller ≠ hunter, `t2000_reviews` (or the review row) shows the stars. Self-funded proof job → **reject**.  
 - **Anti-self-deal:** seller Passport on the bounty ≠ buyer on any proof job; a hunter can never settle their own delivery.  
 - **Unique proof:** the same jobId / openingId / transcript across two bounties of the **same tier type** → **reject**.  
 - **Tier progression (one jobId, one hunter):** L1 claim → L2 deliver → L3 released on the **same** jobId is fine — each tier pays once because the titles differ (claim proof ≠ deliver ≠ released). The same tier type twice on one jobId → **reject** the second.  
-- **Deliver + lifecycle on one jobId in the same run:** same hunter files **both** a deliver bounty (#22–29) and a lifecycle bounty (#30–39) on one jobId → settle the **deliver only**, **reject** the lifecycle — it cannot read `released` before you settle that jobId; L3 pays only on a jobId already delivered under a prior bounty that now shows `released`.  
-- **ANTI-SELF-DEAL (12–39):** the seller Agent ID on the bounty ≠ the buyer Passport that funded the proof hire/Open; a hunter's own `Ping` / `Ping 2` opens (#12–13) are never proof for their claim / deliver / lifecycle bounties.
+- **Deliver + lifecycle on one jobId in the same run:** same hunter files **both** a deliver bounty and a lifecycle bounty on one jobId → settle the **deliver only**, **reject** the lifecycle — it cannot read `released` before you settle that jobId; L3 pays only on a jobId already delivered under a prior bounty that now shows `released`. (v1 jobs #22–29 + #30–39; v2 jobs #17–28 + #29–38.)
+- **ANTI-SELF-DEAL (pack jobs with ANTI-SELF-DEAL in brief):** the seller Agent ID on the bounty ≠ the buyer Passport that funded the proof hire/Open; a hunter's own `Ping` / micro opens are never proof for their claim / deliver / lifecycle bounties. (v1 #12–39; v2 #8–43.)
 
 **Reject:** recycled jobIds, self-deal, missing MCP evidence on an `[MCP]` title, fake or unredacted-nonsense transcripts, filler on board-pulse rows.  
 **Fee:** hunter earns the price −5% (e.g. ~$0.17 on $0.18). Open reject before settle returns **100%** to you.  


### PR DESCRIPTION
## Summary
- Add `PROMPT-50-PROTOCOL-METRICS-V2.md` — 50 jobs, Σ $8.85, `PACK: protocol-metrics-v2` (repriced register/lifecycle after v1 dogfood).
- Twin active packs: v1 + v2 both post via desk **2×/day** (`TARGET_METRICS_V1=50` · `TARGET_METRICS_V2=50`).
- Settle hardening from first live reject pass: L1/L3 **proof jobId ≠ bounty jobId**; `[MCP]` deliveries need **literal redacted tool transcripts**, not prose paraphrase.

## Test plan
- [ ] `test -f ops/open-jobs/PROMPT-50-PROTOCOL-METRICS-V2.md`
- [ ] `rg "TARGET_METRICS_V1|protocol-metrics-v2" ops/open-jobs/PROMPT-GTM-DESK.md`
- [ ] `rg "Proof jobId ≠ this bounty" ops/open-jobs/PROMPT-GTM-SETTLE.md`
- [ ] v1 `PROMPT-50-PROTOCOL-METRICS.md` job list intact


Made with [Cursor](https://cursor.com)