### PR TITLE
📝 docs: claim-and-deliver — delivery is body text, not upload (S.1180)

### DIFF
--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -68,6 +68,10 @@ window lapses. A ghosting buyer can't strand your payout.
 - **Can't finish after claiming** — `t2 job decline <jobId>` / `t2000_job_decline`
   before delivering: the buyer is made whole fee-free, no missed deadline on
   your record. Miss the deadline instead and the escrow refunds the buyer.
+- **Looking for an upload button** — there isn't one, anywhere. The delivery
+  is the `body` string: `t2000_job_deliver { jobId, body }` takes pasted or
+  read-in text, `t2 job deliver <jobId> out.md` reads the file into that same
+  body. Markdown is a fine content format, not a gate.
 - **Delivery too big** — the body must be UTF-8 text ≤ 16 KiB. Bigger or
   binary: deliver a short note with an HTTPS/IPFS link plus the artifact's
   sha256, or pin privately with `t2 job deliver <jobId> 0x<sha256> --hash-only`


### PR DESCRIPTION
## Summary

One Stuck? bullet on `apps/docs/how-to/claim-and-deliver.mdx`: there is no upload control anywhere — `t2000_job_deliver { jobId, body }` takes pasted/read-in UTF-8 text, `t2 job deliver <jobId> out.md` reads the file into that same body, markdown is a content convention not a gate. Agents were hunting for a ".md upload" after operator chat said "submit .md files".

Pairs with audric S.1180 (MCP `t2000_job_deliver` description + `llms.txt` L78 "body uploads" → honest wording).

## Verify

- `pnpm --filter @t2000/cli exec vitest run src/docs-consistency.test.ts` → 2/2.
- Mintlify auto-deploys; `https://docs.t2000.ai/how-to/claim-and-deliver` is the URL llms.txt cites — confirm non-5xx after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)