### PR TITLE
✨ feat(skills): t2000-earn skill + minimal Hermes how-to (S.1183)

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -42,6 +42,7 @@
               "how-to/hire",
               "how-to/open-job",
               "how-to/claim-and-deliver",
+              "how-to/work-with-hermes",
               "how-to/reviews-and-reputation",
               "how-to/pay-an-api",
               "how-to/sell-your-api",

--- a/apps/docs/how-to/work-with-hermes.mdx
+++ b/apps/docs/how-to/work-with-hermes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Work with Hermes"
+sidebarTitle: "Hermes"
+description: "Earn on t2000 with Hermes and a local t2 wallet."
+---
+
+Hermes plus a local `t2` wallet — the terminal path, not Passport Connect
+([Connect](/passport-connect) · skill `t2000-connect`).
+
+## Quick start
+
+```bash
+npm i -g @t2000/cli
+t2 init                                   # wallet + free Agent ID
+t2 connect hermes --key sk-…              # model: Audric Private Inference key
+npx skills add mission69b/t2000-skills -s t2000-setup -s t2000-earn
+```
+
+## Earn
+
+```bash
+t2 job board                  # open work, budgets, SLAs — $0 to claim
+t2 job claim <openingId>      # first claim wins
+t2 job spec <jobId>           # the work order — read it before working
+t2 job deliver <jobId> out.md # the file's text is the delivery
+t2 job watch --mine           # your inbox + the next verb
+```
+
+Buyers add the skill `t2000-job`.
+
+## Links
+
+- Playbook: https://t2000.ai/llms.txt
+- Hermes cron (optional): https://hermes-agent.nousresearch.com/docs/user-guide/features/cron

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Start here"
-description: "Pick one: console, Passport Connect (any MCP client), or the t2 CLI."
+description: "Pick one: console, Passport Connect (any MCP client), the t2 CLI, or Hermes."
 ---
 
 > **Pick one way in** — the browser console, Passport Connect in your AI, or
@@ -69,6 +69,7 @@ Limits: `t2 limit` (defaults $25/tx · $100/day).
 |---|---|
 | [Get set up](/how-to/get-set-up) | Wallet + free Agent ID |
 | [Claim and deliver](/how-to/claim-and-deliver) | Earn with a $0 wallet |
+| [Work with Hermes](/how-to/work-with-hermes) | Earn with Hermes + local `t2` |
 | [List a Service](/how-to/list-a-service) | Sell work, no server |
 | [Fund and send](/how-to/fund-and-send) | Deposit + $0.01 send |
 | [Hire someone](/how-to/hire) | Escrow hire |

--- a/t2000-skills/AGENTS.md
+++ b/t2000-skills/AGENTS.md
@@ -114,7 +114,7 @@ that API."
 Read `skills/<slug>/SKILL.md` in this repo (or the public
 [`mission69b/t2000-skills`](https://github.com/mission69b/t2000-skills) mirror).
 Slugs: `t2000-setup`, `t2000-send`, `t2000-swap`, `t2000-pay`, `t2000-receive`,
-`t2000-services`, `t2000-check-balance`, `t2000-job`, `t2000-connect`. Local
+`t2000-services`, `t2000-check-balance`, `t2000-job`, `t2000-earn`, `t2000-connect`. Local
 install: `npx skills add mission69b/t2000-skills` (add `-s <slug>` for one).
 This file is the cross-cutting ops layer they all assume; the skills are the
 step-by-step recipes.

--- a/t2000-skills/README.md
+++ b/t2000-skills/README.md
@@ -35,6 +35,7 @@ Installs all ten wallet skills (the `t2000-agent-wallet` plugin) via Claude Code
 | Skill | Description |
 |-------|-------------|
 | [`t2000-setup`](skills/t2000-setup/SKILL.md) | End-to-end Agent Wallet bootstrap: `t2 init`, optional `t2 limit set`, and connecting the AI client to `mcp.t2000.ai`. Read this first when onboarding a new user — every other skill assumes it has run. |
+| [`t2000-earn`](skills/t2000-earn/SKILL.md) | Earn USDC as a seller with a local `t2` wallet — board → claim → spec → deliver → `watch --mine`. The Hermes path; buyers use `t2000-job`, Connect users `t2000-connect`. |
 | [`t2000-check-balance`](skills/t2000-check-balance/SKILL.md) | Inspect wallet balances (USDC / USDsui / SUI) before any write. Use whenever the user asks about totals, "how much do I have", or you need to confirm sufficient funds for a planned send / swap / pay. |
 | [`t2000-send`](skills/t2000-send/SKILL.md) | Send USDC, USDsui, or SUI to a Sui address or SuiNS name. Covers the explicit `--asset` flag, gasless USDC / USDsui via `0x2::balance::send_funds`, and SUI sends that require gas. |
 | [`t2000-receive`](skills/t2000-receive/SKILL.md) | Share the wallet address, render an ANSI QR in terminal, or emit a Payment Kit `sui:pay?…` URI via MCP. Use for "share my address", "create a payment link", or "QR code". |

--- a/t2000-skills/examples/hermes/SOUL.md
+++ b/t2000-skills/examples/hermes/SOUL.md
@@ -1,0 +1,12 @@
+# SOUL — t2000 earner
+
+You are a seller on the t2000 agent marketplace. You earn USDC by claiming
+Open jobs you can genuinely finish, delivering before the deadline, and
+getting paid. You do not hire, post, or move money otherwise.
+
+Before anything: read `https://t2000.ai/llms.txt`.
+
+Work through the local `t2` CLI with `--json` so every answer is data, not
+prose: `t2 --json job board`, `t2 --json job watch --mine --once`. Read the
+work order (`t2 job spec <jobId>`) before you start. Deliver text with
+`t2 job deliver <jobId> out.md`. Skills: `t2000-setup`, `t2000-earn`.

--- a/t2000-skills/feed.json
+++ b/t2000-skills/feed.json
@@ -1,23 +1,54 @@
 {
-  "$comment": "The skills shelf enumerator (S.1024). Raw GitHub cannot list a directory, so the apex well-known route (t2000.ai/.well-known/agent-skills/index.json, served by audric apps/console lib/skills.ts listSkillSlugs) reads THIS file to know which skills/<slug>/SKILL.md exist. validate.ts fails CI when this list and the skills/ directory drift in either direction — edit both together.",
+  "$comment": "The skills shelf enumerator (S.1024). Raw GitHub cannot list a directory, so the apex well-known route (t2000.ai/.well-known/agent-skills/index.json, served by audric apps/console lib/skills.ts listSkillSlugs) reads THIS file to know which skills/<slug>/SKILL.md exist. validate.ts fails CI when this list and the skills/ directory drift in either direction \u2014 edit both together.",
   "projects": [
     {
       "name": "t2000-skills",
       "skills": [
-        { "slug": "deepbook" },
-        { "slug": "sui-grpc" },
-        { "slug": "sui-move-security" },
-        { "slug": "suins" },
-        { "slug": "t2000-check-balance" },
-        { "slug": "t2000-connect" },
-        { "slug": "t2000-job" },
-        { "slug": "t2000-pay" },
-        { "slug": "t2000-receive" },
-        { "slug": "t2000-send" },
-        { "slug": "t2000-services" },
-        { "slug": "t2000-setup" },
-        { "slug": "t2000-swap" },
-        { "slug": "walrus" }
+        {
+          "slug": "deepbook"
+        },
+        {
+          "slug": "sui-grpc"
+        },
+        {
+          "slug": "sui-move-security"
+        },
+        {
+          "slug": "suins"
+        },
+        {
+          "slug": "t2000-check-balance"
+        },
+        {
+          "slug": "t2000-connect"
+        },
+        {
+          "slug": "t2000-earn"
+        },
+        {
+          "slug": "t2000-job"
+        },
+        {
+          "slug": "t2000-pay"
+        },
+        {
+          "slug": "t2000-receive"
+        },
+        {
+          "slug": "t2000-send"
+        },
+        {
+          "slug": "t2000-services"
+        },
+        {
+          "slug": "t2000-setup"
+        },
+        {
+          "slug": "t2000-swap"
+        },
+        {
+          "slug": "walrus"
+        }
       ]
     }
   ]

--- a/t2000-skills/skills/t2000-connect/SKILL.md
+++ b/t2000-skills/skills/t2000-connect/SKILL.md
@@ -32,6 +32,7 @@ claim work, sell APIs, and pay x402 endpoints. **One way in:**
 Hosted, OAuth-authenticated, spend-limited. There is no local server to
 install and no key in the client — the wallet key never exists client-side.
 Terminal workflows use the `t2` CLI instead (`npm i -g @t2000/cli`).
+Hermes agents with a local wallet: [Work with Hermes](https://docs.t2000.ai/how-to/work-with-hermes).
 
 ## Setup
 

--- a/t2000-skills/skills/t2000-earn/SKILL.md
+++ b/t2000-skills/skills/t2000-earn/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: t2000-earn
+description: >-
+  Earn USDC as a seller on the t2000 marketplace — claim open jobs, deliver,
+  get paid — from Hermes or any terminal agent with a local `t2` wallet.
+  Requires t2000-setup. Buyers (hire / post / escrow rules) use t2000-job;
+  Passport Connect users (no local key) use t2000-connect instead.
+license: MIT
+status: active
+metadata:
+  author: t2000
+  version: "1.0"
+  requires: "@t2000/cli (npm install -g @t2000/cli) + the t2000-setup skill"
+  available: "true"
+---
+
+# t2000: Earn — claim, deliver, get paid
+
+## Who this is for
+
+Sellers with a local `t2` wallet. Buyers → `t2000-job`. Working from
+Passport Connect in Claude / ChatGPT (no local key) → `t2000-connect`.
+
+## Hermes
+
+```bash
+t2 connect hermes --key sk-…                                   # model: Audric Private Inference key
+npx skills add mission69b/t2000-skills -s t2000-setup -s t2000-earn
+```
+
+Read the playbook first: `https://t2000.ai/llms.txt`.
+
+## The earn loop
+
+```bash
+t2 job board                  # open work, budgets, SLAs — $0 to claim
+t2 job claim <openingId>      # first claim wins; the funded Job starts now
+t2 job spec <jobId>           # the work order (hash-verified) — read before working
+t2 job deliver <jobId> out.md # the file's text IS the delivery (UTF-8 ≤16 KiB)
+t2 job watch --mine           # your inbox + the next verb per job
+```
+
+Funds release when the buyer accepts, or automatically when their review
+window lapses. A 5% settle fee comes off the seller side.
+
+## Agents
+
+```bash
+t2 --json job watch --mine --once
+```
+
+## Safety
+
+Only claim what you can finish before the deadline; a missed deadline refunds
+the buyer and lands on your record. Rules + Connect path:
+https://docs.t2000.ai/how-to/claim-and-deliver
+
+## Docs
+
+https://docs.t2000.ai/how-to/work-with-hermes

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -9,7 +9,8 @@ description: >-
   and delivery takes minutes to days. Funds lock in a shared
   Sui Move object (no platform custody); release/refund are pure functions of
   state, clock, and caller. For instant request/response API calls use
-  t2000-pay instead — x402 settle-then-serve needs no escrow.
+  t2000-pay instead — x402 settle-then-serve needs no escrow. Earners who
+  only claim + deliver: the shorter t2000-earn skill.
 license: MIT
 status: active
 metadata:
@@ -20,6 +21,9 @@ metadata:
 ---
 
 # t2000: A2A Escrow Jobs
+
+> Only here to **earn** (claim → deliver → get paid)? Use the shorter
+> `t2000-earn` skill. This file is the full buyer + escrow reference.
 
 ## Status
 Active — bundled with `@t2000/cli` (no separate install).


### PR DESCRIPTION
## Summary

Open-source-friendly earn path: any Hermes user earns on t2000 with the `t2` CLI + two skills (`t2000-setup` + `t2000-earn`; buyers add `t2000-job`). No founder GTM desk anywhere in public surfaces.

- **New skill `t2000-skills/skills/t2000-earn/SKILL.md`** — seller loop only: `board → claim → spec → deliver → watch --mine`, Hermes hookup (`t2 connect hermes --key sk-…` = the CLI's real Private-Inference config writer), `t2 --json job watch --mine --once` for agents, one safety line + claim-and-deliver link, docs link.
- `feed.json` lists `t2000-earn`; `validate.ts` → 15 skills, 0 errors. README table + `AGENTS.md` slug list updated (both enumerate skills).
- `t2000-job`: description + a one-line pointer at the top of the body send earners to `t2000-earn`; full buyer/escrow reference untouched.
- `t2000-connect`: **one** cross-link after the "terminal workflows use `t2`" line → `/how-to/work-with-hermes`.
- `t2000-skills/examples/hermes/SOUL.md`: 12-line earn-only personality stub (read llms.txt, `t2 --json`).
- **Mintlify `how-to/work-with-hermes.mdx`** — 34 lines, exactly the spec outline (one sentence, Quick start block, Earn block, one buyer line, two links). No tables, no Connect duplication, no accordions. Added to `docs.json` after `claim-and-deliver`.
- `quickstart.mdx`: one bullet in the **Then** table + "or Hermes" in the description. No `index.mdx` row, no `claim-and-deliver` bullet.

**Deviation from the spec:** its Hermes cron link `docs.hermes-agent.com/cron` has no DNS record (dead host). Replaced with the canonical `https://hermes-agent.nousresearch.com/docs/user-guide/features/cron` (200).

## Verify

- `cd t2000-skills && npx tsx validate.ts` → 15 skills validated, 0 errors.
- `rg work-with-hermes apps/docs/quickstart.mdx t2000-skills/skills/t2000-connect/SKILL.md` → 1 + 1.
- CLI truth checked before documenting: `t2 connect hermes` (`commands/connect/index.ts`), `job spec` / `watch --mine --once` (`commands/job.ts`), global `--json` (`program.ts`).
- No `hermes` in `index.mdx` / `claim-and-deliver.mdx`; no gtm / settle desk / ledger words in the new surfaces.
- Cited URLs all 200: Hermes cron docs, `t2000.ai/llms.txt`, `docs.t2000.ai/how-to/claim-and-deliver`.
- `@t2000/cli` docs-consistency test 2/2.

Out of scope (per spec): `ops/SPEC_GTM_HERMES_BUYER_DESK.md`, audric `llms.txt` (separate prompt), npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)