### PR TITLE
📝 docs(ops): settle desk uses ledger fields on settle/reject (S.1186)

### DIFF
--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -168,12 +168,12 @@ Social comment ($0.20) and referral ($0.25) bounties still work exactly as befor
 
 **Ledgers (SSOT in this repo; Connect reads them — S.1166):**  
 `ops/open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md` · `ops/open-jobs/REFERRAL-SETTLE-LEDGER.md`  
-**Before every settle** call `t2000_gtm_ledger` (free read of the published ledger on `main`, ~60s cache) with the proof — `campaign: "social"` + `proofUrl`, or `campaign: "referral"` + `referredAgentId` / `proofJobId`. `duplicate: true` → `t2000_job_reject` **before** settle (100% back to you). A fetch error is not an empty ledger — do not settle until it reads. Connect never writes the ledger: **append the git row after each decision** (audit trail).
+**The dedup is embedded in settle/reject (S.1186).** Pass the ledger fields ON the verb — `t2000_job_settle { jobId, ledgerCampaign, proofUrl }` (social) or `{ …, ledgerCampaign: "referral", referredAgentId, proofJobId }`, same fields on `t2000_job_reject`. It reads the published ledger on `main` (~60s cache) FIRST and **refuses** the verb when `duplicate: true`; a fetch error holds it (never a silent settle). The standalone `t2000_gtm_ledger` tool is directory-only — it never surfaced in Connect Customize, so do not rely on a separate call. Connect never writes the ledger: **append the git row after each decision** (audit trail).
 
 
 ### Appendix B1 — Social comment settles
 
-**Ledger:** `t2000_gtm_ledger { campaign: "social", proofUrl }` — `duplicate: true` (already **settled**, any seat) → **reject**. Then append the row to `SOCIAL-COMMENT-SETTLE-LEDGER.md` in git.
+**Ledger (embedded — S.1186):** `t2000_job_settle { jobId, ledgerCampaign: "social", proofUrl }` (or `t2000_job_reject { … }`) — refuses when `duplicate: true` (already **settled**, any seat). Then append the row to `SOCIAL-COMMENT-SETTLE-LEDGER.md` in git.
 
 **Settle only if all true:**
 - Public **permalink** + quoted comment text.  
@@ -181,17 +181,17 @@ Social comment ($0.20) and referral ($0.25) bounties still work exactly as befor
 - On **X**: tags **@t2000ai**.  
 - Honest voice — no fake metrics/partners (`brandkit/VOICE.md`).  
 - Paid disclosure in the comment, e.g. `(disclosure: this reply is a paid bounty)` — **not** `#ad` alone.  
-- `t2000_gtm_ledger` says `duplicate: false` · not private/deleted/unverifiable.
+- the embedded ledger check passes (not a duplicate) · not private/deleted/unverifiable.
 
 **Reject** spam, recycled URLs, off-topic. `t2000_job_review` **`stars: 1–5`** if you rate.  
 Duplicate delivered (not settled): **reject** — **100%** of $0.20 returns to you.  
 Hunter payout after fee: **~$0.19** (5% protocol fee).
 
-Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-only).
+Append the ledger row in git after each decision (the embedded check is read-only).
 
 ### Appendix B2 — Referral settles
 
-**Ledger:** `t2000_gtm_ledger { campaign: "referral", referredAgentId, proofJobId }` — `duplicate: true` (either already in a **settled** row, any seat) → **reject**. Then append the row to `REFERRAL-SETTLE-LEDGER.md` in git.
+**Ledger (embedded — S.1186):** `t2000_job_settle { jobId, ledgerCampaign: "referral", referredAgentId, proofJobId }` (or `t2000_job_reject { … }`) — refuses when `duplicate: true` (either already in a **settled** row, any seat). Then append the row to `REFERRAL-SETTLE-LEDGER.md` in git.
 
 **Settle only if all true:**
 - Proof lists **Hunter Agent ID** + **Referred Agent ID** (both, different).  
@@ -200,12 +200,12 @@ Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-onl
 - Proof job title is **not** `Refer a new agent…` / `Onboard an agent…`.  
 - **First seller release:** `t2000_jobs_lookup` on referred ref + `state: "released"` → **`releasedCount` exactly 1** and equals proof job id. **Do not** use `t2000_reviews` for counts.  
 - **Proof job buyer ≠ hunter:** the buyer on the proof job must not be the hunter's Passport (blocks Path A self-funding).  
-- `t2000_gtm_ledger` says `duplicate: false`.
+- the embedded ledger check passes (not a duplicate).
 
 **Reject** self-deal, friend-claimed-this-bounty, hunter-funded proof job (Path A), another referral as proof job, not first job, recycled receipt.  
 Duplicate delivered: **reject** — **100%** of $0.25 returns to you. Hunter **~$0.24** after fee.
 
-Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-only).
+Append the ledger row in git after each decision (the embedded check is read-only).
 
 ---
 

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -71,24 +71,24 @@ After settle: append the **register** ledger row when applicable (register rows 
 
 ## § Social comment — settle only if ALL true
 
-**Ledger:** `t2000_gtm_ledger { campaign: "social", proofUrl }` first — `duplicate: true` (already **settled**, any seat) → **reject**; a fetch error means do not settle yet.
+**Ledger (embedded — S.1186):** the dedup rides ON the settle/reject call — `t2000_job_settle { jobId, ledgerCampaign: "social", proofUrl }` (or `t2000_job_reject { jobId, ledgerCampaign: "social", proofUrl }`). It reads the published ledger FIRST and **refuses** the verb when `duplicate: true` (already **settled**, any seat); a fetch error holds the verb (never a silent settle). No standalone `t2000_gtm_ledger` call — that tool is directory-only and never surfaced in Connect Customize.
 
 - Public **permalink** + quoted comment text.  
 - Clearly mentions **t2000** (marketplace / hire · work · earn).  
 - On **X**: tags **@t2000ai**.  
 - Honest voice — no fake metrics/partners (`brandkit/VOICE.md`).  
 - Paid disclosure in comment, e.g. `(disclosure: this reply is a paid bounty)` — **not** `#ad` alone.  
-- `t2000_gtm_ledger` says `duplicate: false` · not private/deleted/unverifiable.
+- the embedded ledger check passes (not a duplicate) · not private/deleted/unverifiable.
 
 **Reject:** spam, recycled URLs, off-topic, duplicate delivered.  
 **Fee:** hunter ~$0.19 on $0.20 (5% protocol).  
-Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-only; Connect never writes the ledger).
+Append the ledger row in git after each decision (the embedded check is read-only; Connect never writes the ledger).
 
 ---
 
 ## § Referral — settle only if ALL true
 
-**Ledger:** `t2000_gtm_ledger { campaign: "referral", referredAgentId, proofJobId }` first — `duplicate: true` (either already in a **settled** row, any seat) → **reject**; a fetch error means do not settle yet.
+**Ledger (embedded — S.1186):** the dedup rides ON the call — `t2000_job_settle { jobId, ledgerCampaign: "referral", referredAgentId, proofJobId }` (or `t2000_job_reject { … }`). It refuses when `duplicate: true` (either already in a **settled** row, any seat); a fetch error holds the verb. No standalone `t2000_gtm_ledger` call.
 
 - Proof lists **Hunter Agent ID** + **Referred Agent ID** (different).  
 - Referred has active Agent ID.  
@@ -96,11 +96,11 @@ Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-onl
 - Proof job is **not** another referral bounty title.  
 - **`t2000_jobs_lookup`** on referred + `state: "released"` → **`releasedCount` exactly 1** = proof job id. **Not** `t2000_reviews`.  
 - **Proof job buyer ≠ hunter** — reject hunter-funded micro hires (Path A).  
-- `t2000_gtm_ledger` says `duplicate: false`.
+- the embedded ledger check passes (not a duplicate).
 
 **Reject:** self-deal, friend claimed this bounty, hunter-as-buyer on proof job, not first job, recycled receipt.  
 **Fee:** hunter ~$0.24 on $0.25 (5% protocol).  
-Append the ledger row in git after each decision (`t2000_gtm_ledger` is read-only; Connect never writes the ledger).
+Append the ledger row in git after each decision (the embedded check is read-only; Connect never writes the ledger).
 
 ---
 


### PR DESCRIPTION
## Summary

Pairs with audric #478 (embedded ledger dedup in `t2000_job_settle` / `t2000_job_reject`). The GTM settle desk stopped relying on a standalone `t2000_gtm_ledger` call — that tool is on the directory `tools/list` (35) but never surfaces in Connect Customize, so the desk could not reach it from chat.

- `PROMPT-GTM-SETTLE.md` § Social + § Referral: the ledger read now rides ON the verb — `t2000_job_settle { jobId, ledgerCampaign: "social", proofUrl }` (or `t2000_job_reject { … }`), referral form with `referredAgentId` / `proofJobId`. It refuses when `duplicate: true`; a fetch error holds the verb. `duplicate: false` bullets reworded to "the embedded ledger check passes".
- `PROMPT-GTM-DESK.md`: the "before every settle" pre-flight paragraph + both appendix B1/B2 Ledger lines rewritten to the embedded fields; "append the git row after each decision" kept everywhere.
- No standalone `t2000_gtm_ledger { … }` calls remain in either settle flow.

## Verify

- `rg 't2000_gtm_ledger \{' PROMPT-GTM-SETTLE.md PROMPT-GTM-DESK.md` → 0.
- `ledgerCampaign` present in both docs (settle/reject examples).
- `@t2000/cli` docs-consistency 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)