### PR TITLE
📝 docs(ops): jobId-only settle — server auto-dedup for social/referral (S.1188)

### DIFF
--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -42,7 +42,7 @@ Founder cadence: **post both packs 2×/day** (morning + evening desk runs). Hunt
 
 Each Passport maintains **its own** pool — do not count other seats toward your keep targets.
 
-**Ledgers (SSOT in this repo):** `AGENT-REGISTER-SETTLE-LEDGER.md` (register bounties — read the file + directory by hand; no embedded check covers it) · `SOCIAL-COMMENT-SETTLE-LEDGER.md` · `REFERRAL-SETTLE-LEDGER.md` (both deduped by the `ledgerCampaign` fields on `t2000_job_settle` / `t2000_job_reject` — S.1187; the standalone `t2000_gtm_ledger` tool never surfaced in Connect). Connect never writes a ledger: **append the git row after each decision**.
+**Ledgers (SSOT in this repo):** `AGENT-REGISTER-SETTLE-LEDGER.md` (register bounties — read the file + directory by hand; no automatic check covers it) · `SOCIAL-COMMENT-SETTLE-LEDGER.md` · `REFERRAL-SETTLE-LEDGER.md` (both deduped automatically by `t2000_job_settle` / `t2000_job_reject` from the job title + delivery — S.1188; the standalone `t2000_gtm_ledger` tool never surfaced in Connect). Connect never writes a ledger: **append the git row after each decision**.
 
 **Posting discipline:** `t2000_job_open` **one at a time**. Wait for Completed (or a hard refuse) before the next.  
 Never parallel opens — Sui locks the USDC coin (`InsufficientFundsForWithdraw`, object locked).  
@@ -168,57 +168,35 @@ Social comment ($0.20) and referral ($0.25) bounties still work exactly as befor
 
 **Ledgers (SSOT in this repo; Connect reads them — S.1166):**  
 `ops/open-jobs/SOCIAL-COMMENT-SETTLE-LEDGER.md` · `ops/open-jobs/REFERRAL-SETTLE-LEDGER.md`  
-**The dedup is embedded in settle/reject (S.1186), and all five fields are REQUIRED (S.1187)** — Connect hides optional parameters from the agent.
+**The dedup runs server-side on settle/reject (S.1188)** — resolved from the job itself, because claude.ai chat loads a reduced schema and cannot send ledger parameters.
 
-**Every settle/reject call carries FIVE fields (S.1187).** Connect hides
-optional parameters from the agent, so the ledger fields are **required** —
-`ledgerCampaign: "off"` + empty strings means *no dedup* (the plain verb).
-
-**Metrics · micro · general — no ledger dedup:**
+**Settle and reject take the jobId ALONE (S.1188).**
 
 ```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "off",
-  proofUrl: "",
-  referredAgentId: "",
-  proofJobId: ""
-}
+t2000_job_settle { jobId }
+t2000_job_reject { jobId }
 ```
 
-**Social bounty:**
+The GTM ledger dedup runs **server-side**: the job's own title routes the
+campaign (social / referral / neither) and its delivery text carries the
+proof, so chat never passes `ledgerCampaign` or `proofUrl` — claude.ai
+loads a reduced schema and cannot send them. Already settled by any seat →
+the verb is **REFUSED**. Metrics, micro and every other row settle straight
+through with no ledger read.
 
-```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "social",
-  proofUrl: "<permalink>",
-  referredAgentId: "",
-  proofJobId: ""
-}
-```
-
-**Referral bounty:**
-
-```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "referral",
-  proofUrl: "",
-  referredAgentId: "<#id>",
-  proofJobId: "<0x…>"
-}
-```
-
-`t2000_job_reject` takes the same five fields. A campaign with no proof is
-**held**, never silently settled.
+A social/referral bounty whose delivery yields no usable proof (no X status
+permalink, no referred Agent ID / proof job id) is **HELD** with a message
+naming what is missing — that is the only case where you read the ledger by
+hand. Register bounties are unchanged: `AGENT-REGISTER-SETTLE-LEDGER.md`
+stays hand-read. Append the git ledger row after every social/referral
+decision — nothing writes it for you.
 
 It reads the published ledger on `main` (~60s cache) FIRST and **refuses** the verb when `duplicate: true`; a fetch error, or a campaign with no proof, holds it (never a silent settle). The standalone `t2000_gtm_ledger` tool is directory-only — it never surfaced in Connect Customize, so do not rely on a separate call. Connect never writes the ledger: **append the git row after each decision** (audit trail).
 
 
 ### Appendix B1 — Social comment settles
 
-**Ledger (embedded — S.1186/S.1187):** `ledgerCampaign: "social"` + the `proofUrl` permalink (`referredAgentId` / `proofJobId` as `""`) on `t2000_job_settle` or `t2000_job_reject` — refuses when `duplicate: true` (already **settled**, any seat). Then append the row to `SOCIAL-COMMENT-SETTLE-LEDGER.md` in git.
+**Ledger (automatic — S.1188):** `t2000_job_settle { jobId }` / `t2000_job_reject { jobId }` — the title routes to the social ledger, the permalink comes out of the delivery, and an already-**settled** proof (any seat) refuses the verb. Then append the row to `SOCIAL-COMMENT-SETTLE-LEDGER.md` in git.
 
 **Settle only if all true:**
 - Public **permalink** + quoted comment text.  
@@ -236,7 +214,7 @@ Append the ledger row in git after each decision (the embedded check is read-onl
 
 ### Appendix B2 — Referral settles
 
-**Ledger (embedded — S.1186/S.1187):** `ledgerCampaign: "referral"` + real `referredAgentId` / `proofJobId` (`proofUrl` as `""`) on `t2000_job_settle` or `t2000_job_reject` — refuses when `duplicate: true` (either already in a **settled** row, any seat). Then append the row to `REFERRAL-SETTLE-LEDGER.md` in git.
+**Ledger (automatic — S.1188):** `t2000_job_settle { jobId }` / `t2000_job_reject { jobId }` — the title routes to the referral ledger, the referred Agent ID / proof job id come out of the delivery, and either already in a **settled** row (any seat) refuses the verb. Then append the row to `REFERRAL-SETTLE-LEDGER.md` in git.
 
 **Settle only if all true:**
 - Proof lists **Hunter Agent ID** + **Referred Agent ID** (both, different).  

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -44,48 +44,26 @@ If empty → report "queue clear" and stop.
 
 Open jobs: settle/reject only when state is **delivered** (buyer seat). Do not settle undelivered or already terminal rows.
 
-**Every settle/reject call carries FIVE fields (S.1187).** Connect hides
-optional parameters from the agent, so the ledger fields are **required** —
-`ledgerCampaign: "off"` + empty strings means *no dedup* (the plain verb).
-
-**Metrics · micro · general — no ledger dedup:**
+**Settle and reject take the jobId ALONE (S.1188).**
 
 ```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "off",
-  proofUrl: "",
-  referredAgentId: "",
-  proofJobId: ""
-}
+t2000_job_settle { jobId }
+t2000_job_reject { jobId }
 ```
 
-**Social bounty:**
+The GTM ledger dedup runs **server-side**: the job's own title routes the
+campaign (social / referral / neither) and its delivery text carries the
+proof, so chat never passes `ledgerCampaign` or `proofUrl` — claude.ai
+loads a reduced schema and cannot send them. Already settled by any seat →
+the verb is **REFUSED**. Metrics, micro and every other row settle straight
+through with no ledger read.
 
-```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "social",
-  proofUrl: "<permalink>",
-  referredAgentId: "",
-  proofJobId: ""
-}
-```
-
-**Referral bounty:**
-
-```
-t2000_job_settle {
-  jobId,
-  ledgerCampaign: "referral",
-  proofUrl: "",
-  referredAgentId: "<#id>",
-  proofJobId: "<0x…>"
-}
-```
-
-`t2000_job_reject` takes the same five fields. A campaign with no proof is
-**held**, never silently settled.
+A social/referral bounty whose delivery yields no usable proof (no X status
+permalink, no referred Agent ID / proof job id) is **HELD** with a message
+naming what is missing — that is the only case where you read the ledger by
+hand. Register bounties are unchanged: `AGENT-REGISTER-SETTLE-LEDGER.md`
+stays hand-read. Append the git ledger row after every social/referral
+decision — nothing writes it for you.
 
 
 ---
@@ -115,7 +93,7 @@ After settle: append the **register** ledger row when applicable (register rows 
 
 ## § Social comment — settle only if ALL true
 
-**Ledger (embedded — S.1186/S.1187):** the dedup rides ON the call — `ledgerCampaign: "social"` + the `proofUrl` permalink, `referredAgentId` and `proofJobId` as `""` (all five fields, every time). It reads the published ledger FIRST and **refuses** the verb when `duplicate: true` (already **settled**, any seat); a fetch error, or a `"social"` call with an empty `proofUrl`, **holds** the verb (never a silent settle). No standalone `t2000_gtm_ledger` call — that tool is directory-only and never surfaced in Connect Customize.
+**Ledger (automatic — S.1188):** `t2000_job_settle { jobId }` (or `t2000_job_reject { jobId }`). The title routes this to the **social** ledger and the X/Twitter status permalink is read out of the delivery text; an already-**settled** proof (any seat) **refuses** the verb. A ledger fetch error, or a delivery with no permalink, **holds** it (never a silent settle) — that is when you read the ledger by hand. No ledger parameters, and no standalone `t2000_gtm_ledger` call.
 
 - Public **permalink** + quoted comment text.  
 - Clearly mentions **t2000** (marketplace / hire · work · earn).  
@@ -132,7 +110,7 @@ Append the ledger row in git after each decision (the embedded check is read-onl
 
 ## § Referral — settle only if ALL true
 
-**Ledger (embedded — S.1186/S.1187):** the dedup rides ON the call — `ledgerCampaign: "referral"` + real `referredAgentId` / `proofJobId`, `proofUrl` as `""` (all five fields, every time). It refuses when `duplicate: true` (either already in a **settled** row, any seat); a fetch error, or a `"referral"` call with both ids empty, **holds** the verb. No standalone `t2000_gtm_ledger` call.
+**Ledger (automatic — S.1188):** `t2000_job_settle { jobId }` (or `t2000_job_reject { jobId }`). The title routes this to the **referral** ledger and the referred Agent ID / proof job id are read out of the delivery text (the hunter's own id is never a dedup key); either already in a **settled** row (any seat) **refuses** the verb. A fetch error, or a delivery with neither id, **holds** it. No ledger parameters, no standalone `t2000_gtm_ledger` call.
 
 - Proof lists **Hunter Agent ID** + **Referred Agent ID** (different).  
 - Referred has active Agent ID.  


### PR DESCRIPTION
## Summary

Pairs with audric #480. claude.ai chat loads a reduced schema and cannot send ledger parameters, so the desk copy drops them entirely: settle/reject take the **jobId alone** and the ledger dedup runs server-side from the job's title + delivery.

- Both prompts: the S.1187 five-field JSON blocks are replaced with `t2000_job_settle { jobId }` / `t2000_job_reject { jobId }` plus one paragraph on how the auto-dedup routes (title → campaign, delivery → proof), what refuses (already-settled proof, any seat), and what holds.
- § Social / § Referral ledger paragraphs and both appendix B1/B2 lines rewritten to the automatic path; the desk ledgers header updated.
- **Manual ledger read is now the fallback only** — for a bounty whose delivery yields no usable proof (the hold case). Register bounties unchanged: `AGENT-REGISTER-SETTLE-LEDGER.md` stays hand-read.
- "Append the git row after every social/referral decision" kept everywhere.

## Verify

- `rg 'ledgerCampaign'` → 1 per file, and both are the deliberate "chat never passes `ledgerCampaign`" explainer — zero call examples.
- `rg 't2000_job_settle \{ jobId \}'` → 3 per file; `S.1188` noted in both.
- `@t2000/cli` docs-consistency 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)