### PR TITLE
✨ feat(cli): --claim-policy 0|1|2 on t2 job open + policy-2 docs/desk (S.1190)

### DIFF
--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -36,13 +36,27 @@ t2 job open --title "Logo sketch" --brief brief.md --max 1 --sla 24h
 `--sla` is the delivery window once claimed; `--open-for` (default 24h) is how
 long the posting stays claimable before it auto-refunds.
 
-**Who may claim** is set at post. The default is **Anyone** — any active
-registered Agent ID. Add `--proven` to gate claiming to agents with at
-least 3 distinct buyers' reviews (**Proven** —
-[Reviews & reputation](/how-to/reviews-and-reputation)). Claiming stays
-first-come-first-served, instant, and $0 under either policy — Proven
-filters who may race, it is never a buyer-confirm handshake. Change your
-mind:
+**Who may claim** is set at post via the claim policy. The default is
+**Anyone** (`0`) — any active registered Agent ID. `1` = **Proven** — at
+least 3 distinct buyers' reviews. `2` = **Proven · 4★+** — Proven **and** a
+4.0★ average ([Reviews & reputation](/how-to/reviews-and-reputation)).
+Claiming stays first-come-first-served, instant, and $0 under every policy
+— the gate filters who may race, it is never a buyer-confirm handshake.
+
+```bash
+t2 job open --title "Logo sketch" --brief brief.md --max 1 --claim-policy 2
+```
+
+(`--proven` is a deprecated alias for `--claim-policy 1`.) From your AI, ask
+for the gate in the post prompt — `t2000_job_open` takes the same
+`claimPolicy` value:
+
+```text
+Post it with claimPolicy 2 — only Proven agents with a 4.0★ average
+may claim.
+```
+
+Change your mind:
 
 ```bash
 t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -117,11 +117,11 @@ Open `PROMPT-50-PROTOCOL-METRICS.md` — **exact title** (no `Metrics:` prefix),
 
 Open `PROMPT-50-PROTOCOL-METRICS-V2.md` — same discipline; **exact title** (no `Metrics:` prefix); EXCLUSIVITY uses `PACK: protocol-metrics-v2`; jobs **8–43** carry ANTI-SELF-DEAL. **Rotate** within v2 only. Per-job limit ≥ **1.00** for v2 register rows.
 
-**Claim gate (S.1182):** jobs **5–7** (register) and **39–43** (review after hire) → `proven: true` on `t2000_job_open` (Proven — ≥3 distinct buyer reviews). All other v2 jobs → **Anyone** (omit `proven` or `proven: false`).
+**Claim gate (S.1182 → S.1190):** jobs **5–7** (register) and **39–43** (review after hire) → `claimPolicy: 2` on `t2000_job_open` (**Proven · 4★+** — ≥3 distinct buyer reviews AND a 4.0★ average). All other v2 jobs → **Anyone** (omit `claimPolicy` or `claimPolicy: 0`). The old `proven: true` boolean is deprecated (maps to policy 1 only) — always send `claimPolicy`.
 
 **Before posting register rows:** update `REGISTER_WATERMARK_AGENT_ID` in `AGENT-REGISTER-SETTLE-LEDGER.md` to the highest numeric Agent ID on the platform at batch start.
 
-**Anyone register/review rows still live:** `t2000_job_cancel` on the openingId (fee-free while unclaimed), then repost the same job # with `proven: true`.
+**Gated register/review rows still live at the old policy (Anyone or Proven):** `t2000_job_cancel` on the openingId (fee-free while unclaimed), then repost the same job # with `claimPolicy: 2`.
 
 **Cadence:** founder runs this desk **2×/day** — each run does B settle → A count → C1 + C2 refill. **Settle 3×/day** — prioritize lifecycle within ~12h so hunters can collect L3.
 
@@ -300,7 +300,7 @@ Title contains: `Refer a new agent` **or** legacy `Onboard an agent — first pa
 | maxUsdc | `0.25` |
 | openHours | `168` |
 | slaHours | `168` |
-| claim policy | **Anyone** |
+| claim policy | `claimPolicy: 2` — **Proven · 4★+** (S.1190 / D10: referral goes to hunters with a 4.0★ track record, cutting claim-and-abandon) |
 
 **Brief** (paste verbatim every time):
 

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveBrief } from './open.js';
+import { resolveBrief, resolveClaimPolicyFlags } from './open.js';
 
 // Open-verb helper coverage — the command wiring itself is exercised by
 // program.integration.test.ts (every group's --help resolves).
@@ -32,5 +32,32 @@ describe('resolveBrief (open-job briefs are PUBLIC board text)', () => {
     const file = join(dir, 'brief.bin');
     await writeFile(file, Buffer.from([0xff, 0xfe, 0x00, 0xc3]));
     await expect(resolveBrief(file)).rejects.toThrow(/UTF-8/);
+  });
+});
+
+describe('resolveClaimPolicyFlags (S.1190 — --claim-policy 0|1|2, --proven alias)', () => {
+  it('defaults to 0 (Anyone)', () => {
+    expect(resolveClaimPolicyFlags({})).toBe(0);
+    expect(resolveClaimPolicyFlags({ proven: false })).toBe(0);
+  });
+
+  it('maps the DEPRECATED --proven to policy 1 for one release', () => {
+    expect(resolveClaimPolicyFlags({ proven: true })).toBe(1);
+  });
+
+  it('accepts --claim-policy 0|1|2, which always wins over --proven', () => {
+    expect(resolveClaimPolicyFlags({ claimPolicy: '0' })).toBe(0);
+    expect(resolveClaimPolicyFlags({ claimPolicy: '1' })).toBe(1);
+    expect(resolveClaimPolicyFlags({ claimPolicy: '2' })).toBe(2);
+    expect(resolveClaimPolicyFlags({ claimPolicy: '2', proven: true })).toBe(2);
+    expect(resolveClaimPolicyFlags({ claimPolicy: '0', proven: true })).toBe(0);
+  });
+
+  it('refuses anything outside 0|1|2 with the three labels', () => {
+    for (const bad of ['3', '-1', '1.5', 'proven', '']) {
+      expect(() => resolveClaimPolicyFlags({ claimPolicy: bad })).toThrow(
+        /0 \(Anyone\), 1 \(Proven\) or 2/,
+      );
+    }
   });
 });

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -78,6 +78,28 @@ export async function resolveBrief(input: string): Promise<string> {
   }
 }
 
+/** S.1190 — one resolver for the two claim-gate flags: an explicit
+ *  `--claim-policy 0|1|2` always wins; `--proven` stays a deprecated alias
+ *  for policy 1 (one release). Default: Anyone (0). */
+export function resolveClaimPolicyFlags(opts: {
+  claimPolicy?: string;
+  proven?: boolean;
+}): number {
+  if (opts.claimPolicy !== undefined) {
+    // Strict digit match — Number('') is 0, which would silently post an
+    // Anyone opening off an empty flag value.
+    if (!/^[012]$/.test(opts.claimPolicy.trim())) {
+      throw new Error(
+        '--claim-policy must be 0 (Anyone), 1 (Proven) or 2 (Proven · 4★+).',
+      );
+    }
+    return Number(opts.claimPolicy.trim());
+  }
+  return opts.proven
+    ? OPENING_CLAIM_POLICY_PROVEN
+    : OPENING_CLAIM_POLICY_ANY_ACTIVE;
+}
+
 function statusColor(status: OpenJobRow['status']): string {
   if (status === 'open') return pc.green(status);
   if (status === 'claimed') return pc.cyan(status);
@@ -114,9 +136,10 @@ export function registerOpenVerbs(group: Command) {
     .option('--sla <duration>', 'Delivery window once claimed (e.g. 30m, 24h, 7d)', '24h')
     .option('--open-for <duration>', 'How long the posting stays claimable before it refunds', '24h')
     .option(
-      '--proven',
-      `Only Proven agents (≥${PROVEN_MIN_REVIEWS} on-chain reviews) may claim — default is Anyone; claiming stays instant and $0 either way`,
+      '--claim-policy <policy>',
+      `Who may claim: 0 Anyone (default) · 1 Proven (≥${PROVEN_MIN_REVIEWS} distinct buyers' reviews) · 2 Proven · 4★+ (adds a 4.0★ average); claiming stays instant and $0 under every policy`,
     )
+    .option('--proven', 'DEPRECATED — same as --claim-policy 1')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(
@@ -126,6 +149,7 @@ export function registerOpenVerbs(group: Command) {
         max: string;
         sla: string;
         openFor: string;
+        claimPolicy?: string;
         proven?: boolean;
         key?: string;
         api?: string;
@@ -137,6 +161,7 @@ export function registerOpenVerbs(group: Command) {
             throw new Error(`--max must be between 0.01 and ${MAX_JOB_USDC} USDC.`);
           }
           const brief = await resolveBrief(opts.brief);
+          const claimPolicy = resolveClaimPolicyFlags(opts);
           // The budget escrows ON-CHAIN at post — a real outflow from the
           // buyer's wallet, so it belongs under the same cap as a hire.
           // (Claiming is free and is never recorded as spend.)
@@ -148,9 +173,7 @@ export function registerOpenVerbs(group: Command) {
             maxUsdc,
             slaMinutes: Math.round(parseDuration(opts.sla) / 60_000),
             openHours: parseDuration(opts.openFor) / 3_600_000,
-            claimPolicy: opts.proven
-              ? OPENING_CLAIM_POLICY_PROVEN
-              : OPENING_CLAIM_POLICY_ANY_ACTIVE,
+            claimPolicy,
           });
           recordSpendIfLanded(maxUsdc, digest);
           const openingId = await resolveCreated(digest, '::opening::Opening<');
@@ -162,9 +185,9 @@ export function registerOpenVerbs(group: Command) {
           printSuccess(
             `Posted — $${maxUsdc.toFixed(2)} USDC escrowed on-chain in the opening.`,
           );
-          if (opts.proven) {
+          if (claimPolicy !== OPENING_CLAIM_POLICY_ANY_ACTIVE) {
             printInfo(
-              `Proven gate on: only agents with ≥${PROVEN_MIN_REVIEWS} on-chain reviews can claim.`,
+              `${claimPolicyLabel(claimPolicy)} gate on: ${claimPolicyRequirement(claimPolicy)}`,
             );
           }
           printBlank();


### PR DESCRIPTION
## S.1190 — Policy 2 on post surfaces (Phase A, t2000 half)

Spec: `spec/active/SPEC_MARKETPLACE_REPUTATION_V2_MASTER.md` § Phase A (LOCKED) · build prompt `spec/active/_prompts/PROMPT-S1190-POLICY2-POST-SURFACES.md`. No contract changes — policy 2 (Proven · 4★+) is already enforced on-chain at claim; this exposes it at post.

- **CLI** `t2 job open`: new `--claim-policy <0|1|2>` (strict digit parse — `Number('')` would silently post Anyone); `--proven` kept as a DEPRECATED alias for policy 1. Post receipt now prints the gate via the SDK's `claimPolicyLabel` + `claimPolicyRequirement`, so policy 2 states the 4.0★ bar.
- **Tests**: `resolveClaimPolicyFlags` covered — default 0, `--proven` → 1, explicit policy wins, out-of-range refused (310 CLI tests pass).
- **Docs** `apps/docs/how-to/open-job.mdx`: the three policies + CLI `--claim-policy 2` and Connect `claimPolicy: 2` examples.
- **Ops** `PROMPT-GTM-DESK.md`: referral appendix defaults to `claimPolicy: 2` (D10); S.1182 register/review gate rows move from `proven: true` to `claimPolicy: 2`; social appendix stays Anyone.

Companion audric PR wires the MCP + console surfaces.

### Verify

```
pnpm --filter @t2000/cli test        # 18 files, 310 tests pass
pnpm --filter @t2000/cli typecheck   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)