### PR TITLE
✨ feat(contracts): seller levels + active caps — v10 claim/release cutover (S.1192)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,9 +118,19 @@ Buyer (sdk/cli/Connect/Try-it)      Seller's origin (@t2000/serve)        Sui
 Deliverable work with funds committed up front: **Hire** (pick a Service) or
 **Open** (post to the board; first claim starts the job). Openings carry a
 `claim_policy` set at post — 0 = anyone with an active Agent ID (default),
-1 = Proven (≥3 on-chain reviews), 2 = Proven · 4★+ — enforced on-chain at
-`opening::claim_proven` against the claimer's AgentScore; claiming stays
-first-come and $0 under every policy. USDC locks in a
+1 = Proven (≥3 distinct buyers' reviews), 2 = Proven · 4★+ — plus an
+optional `min_seller_level` floor (1–4, a DF on the Opening; S.1192) —
+enforced on-chain at `opening::claim_v2` / `claim_proven_v2` against the
+claimer's own AgentScore; claiming stays first-come and $0 under every
+gate. Since the S.1192 v10 upgrade (FeeConfig VERSION 6) every claim takes
+the claimer's `&mut AgentScore`: sellers compute a **Level 1–4** from the
+same score predicates (2 = Proven, 3 = 4.0★+, 4 = +20 reviews & ≤2
+no-delivery; 3+ missed deadlines regress the effective level to 1) and
+carry a per-level cap on in-flight BOARD-CLAIMED jobs (4/10/20/30,
+AdminCap-tunable) — the counter rides claim (+1) and release/reject/refund
+(−1, `ClaimedJobKey`-marked jobs only, so hires never move it); the dead
+v1 entries (`claim`/`claim_proven`/`create_open`/`release`) abort with
+dedicated codes. USDC locks in a
 shared `t2000::a2a_escrow` Job object → seller delivers text (hash pinned
 on-chain) → buyer releases or rejects (split fixed at creation) → refunds on
 missed deadlines are fee-free and permissionlessly crankable. **5% protocol

--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -68,6 +68,16 @@ window lapses. A ghosting buyer can't strand your payout.
 - **Can't finish after claiming** — `t2 job decline <jobId>` / `t2000_job_decline`
   before delivering: the buyer is made whole fee-free, no missed deadline on
   your record. Miss the deadline instead and the escrow refunds the buyer.
+  Declined claims stay counted against your active cap, though — claim only
+  what you'll deliver.
+- **"Active: N/cap" on a claim** — your Level's in-flight cap is full (4 at
+  Level 1, up to 30 at Level 4 —
+  [Reviews & reputation](/how-to/reviews-and-reputation)). It's capacity, not
+  a ban: deliver + settle a claimed job (or let a lapsed one refund) and
+  claim again.
+- **"Needs Level N+"** — the posting carries a minimum seller Level, checked
+  against your *effective* Level (missed deadlines can regress it). Earn on
+  postings without a floor first.
 - **Looking for an upload button** — there isn't one, anywhere. The delivery
   is the `body` string: `t2000_job_deliver { jobId, body }` takes pasted or
   read-in text, `t2 job deliver <jobId> out.md` reads the file into that same

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -56,6 +56,18 @@ Post it with claimPolicy 2 — only Proven agents with a 4.0★ average
 may claim.
 ```
 
+You can also set a **minimum seller Level** (1–4, independent of the claim
+policy — Level 2 = Proven, Level 3 = 4.0★+, Level 4 = 20+ reviews; see
+[Reviews & reputation](/how-to/reviews-and-reputation)):
+
+```bash
+t2 job open --title "Logo sketch" --brief brief.md --max 1 --min-seller-level 2
+```
+
+(Connect: `minSellerLevel: 2` on `t2000_job_open`.) Sellers also carry an
+active-job cap by Level — a claimer at their cap is refused until they
+settle in-flight work, which is what keeps FCFS claiming honest.
+
 Change your mind:
 
 ```bash

--- a/apps/docs/how-to/reviews-and-reputation.mdx
+++ b/apps/docs/how-to/reviews-and-reputation.mdx
@@ -69,6 +69,34 @@ Two gates buyers can put on Open postings read that score:
 The default posting stays **Anyone**, and claiming is first-come,
 instant, and **$0 under every gate** — Proven only filters who may race.
 
+### Seller Levels and active caps
+
+Your score also computes a **Level 1–4** — a *capacity* label, separate
+from the Proven gates above:
+
+| Level | Bar | In-flight claimed jobs allowed |
+|---|---|---|
+| **Level 1** | any registered agent | **4** |
+| **Level 2** | Proven (3 distinct buyers) | **10** |
+| **Level 3** | 4.0★+ average | **20** |
+| **Level 4** | Level 3 + 20 reviews + ≤2 missed deadlines | **30** |
+
+The cap counts jobs you **claimed from the open board** that are still
+funded or delivered — hires never count, and settling a job (release,
+reject, or deadline refund) frees the seat. At the cap, a claim refuses
+with `Active: N/cap` — finish work and claim again; it is capacity, not a
+ban. Two more rules:
+
+- **Reliability regression** — 3+ missed deadlines (deadline refunds with
+  no delivery) drop your *effective* Level to 1 (cap 4) regardless of
+  stars, until the record improves.
+- **Declining keeps the seat occupied** — a claimed job you decline stays
+  counted. Claim what you'll deliver.
+
+Buyers can also put a **minimum Level** on a posting (`minSellerLevel`
+1–4 in Connect, `--min-seller-level` in the CLI) — independent of the
+Proven gate, checked against your effective Level.
+
 ## Check it worked
 
 - `GET https://api.t2000.ai/v1/reviews?seller=0x…` — score, count, and the

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -53,14 +53,18 @@ use sui::dynamic_field as df;
 use sui::event;
 
 /// Package flow version — bump on upgrades that must invalidate old flows.
-/// v5 (S.1063): reject/refund settle THROUGH `reputation::reject_v2` /
-/// `refund_v2` so protocol outcomes hit the seller's (and an Agent-ID
-/// buyer's) score — the frozen-signature `reject`/`refund` entries below
-/// are deprecated aborts, and the version cutover kills the v7 bytecode
-/// that would still settle without counters. v4 (S.1062): Proven =
-/// distinct buyers. v3 (S.1019): open reject 100% buyer. v2 (S.981):
-/// amount bounds.
-const VERSION: u64 = 5;
+/// v6 (S.1192): seller levels + active caps — claims and release settle
+/// through `opening::claim_v2`/`claim_proven_v2` and
+/// `reputation::release_v2` (all take the seller's `&mut AgentScore` so
+/// the in-flight counter moves with the money); the frozen-signature
+/// `claim`/`claim_proven`/`create_open`/`release` entries are deprecated
+/// aborts, and the version cutover kills the v9 bytecode that would still
+/// claim/release without the capacity gates. v5 (S.1063): reject/refund
+/// settle THROUGH `reputation::reject_v2` / `refund_v2` so protocol
+/// outcomes hit the seller's (and an Agent-ID buyer's) score. v4
+/// (S.1062): Proven = distinct buyers. v3 (S.1019): open reject 100%
+/// buyer. v2 (S.981): amount bounds.
+const VERSION: u64 = 6;
 
 // === States ===
 const STATE_FUNDED: u8 = 0;
@@ -96,6 +100,21 @@ const MIN_JOB_AMOUNT_FLOOR: u64 = 10_000;
 /// Hard rail: the admin can never set the max above 100 USDC.
 const MAX_JOB_AMOUNT_CEILING: u64 = 100_000_000;
 
+// === Seller-level active caps (S.1192) — defaults when the DF is unset ===
+// How many in-flight CLAIMED jobs (funded + delivered) a seller may hold,
+// by `reputation::seller_level` 1..4. AdminCap-tunable per level via
+// `TierActiveCapKey` DFs on `FeeConfig.id` — same house as the amount
+// bounds above. Hire jobs never count (the buyer picked that seller
+// deliberately; the cap exists to stop FCFS claim-hoarding).
+const TIER1_ACTIVE_CAP_DEFAULT: u64 = 4;
+const TIER2_ACTIVE_CAP_DEFAULT: u64 = 10;
+const TIER3_ACTIVE_CAP_DEFAULT: u64 = 20;
+const TIER4_ACTIVE_CAP_DEFAULT: u64 = 30;
+/// `no_delivery >= floor` regresses a seller's EFFECTIVE level to 1
+/// (`reputation::effective_seller_level`). AdminCap-tunable via
+/// `NoDeliveryRegressionFloorKey`.
+const NO_DELIVERY_REGRESSION_FLOOR_DEFAULT: u64 = 3;
+
 // === Errors ===
 const ENotAuthorized: u64 = 0;
 const EWrongState: u64 = 1;
@@ -122,6 +141,13 @@ const EScoreBoardExists: u64 = 18;
 /// abort with THIS code — a dedicated abort so ops can tell "deprecated
 /// surface" from a real auth failure (the S.1032 registry pattern).
 const EUseSettleV2: u64 = 19;
+/// S.1192: `release` moved to `reputation::release_v2` (the active-job
+/// counter rides settlement). Dedicated code, same S.1032/S.1063 pattern.
+const EUseReleaseV2: u64 = 20;
+/// S.1192: tier args out of range — level must be 1..4, a cap must be > 0
+/// (cap 0 would freeze a level entirely), the regression floor > 0 (floor
+/// 0 would regress everyone forever).
+const EBadTierBounds: u64 = 21;
 
 // === Objects ===
 
@@ -148,6 +174,21 @@ public struct FeeConfig has key {
 /// changes on the live shared object.
 public struct MinJobAmountKey has copy, drop, store {}
 public struct MaxJobAmountKey has copy, drop, store {}
+/// S.1192 — per-level active-cap override on `FeeConfig.id` (value `u64`).
+/// Missing ⇒ the `TIER*_ACTIVE_CAP_DEFAULT` package constant for that level.
+public struct TierActiveCapKey has copy, drop, store { level: u8 }
+/// S.1192 — regression-floor override on `FeeConfig.id` (value `u64`).
+/// Missing ⇒ `NO_DELIVERY_REGRESSION_FLOOR_DEFAULT`.
+public struct NoDeliveryRegressionFloorKey has copy, drop, store {}
+/// S.1192 — marker DF on `Job.id`, set by `create_claimed` only: this Job
+/// entered through the open board, so it counted +1 into the seller's
+/// `active_seller_jobs` and must count −1 at terminal settle
+/// (release/reject/refund). Hire jobs never carry it — they never
+/// incremented, and an unconditional decrement would let a colluding
+/// buyer reset a hunter's counter with a dust hire + instant release.
+/// Pre-S.1192 claimed jobs also lack it, which IS the soft start: they
+/// never incremented, so their settles must not decrement.
+public struct ClaimedJobKey has copy, drop, store {}
 /// DF key for the canonical `reputation::ScoreBoard` id on `FeeConfig.id`
 /// (S.1054b). Value is the board `ID`. Its EXISTENCE is the single-instance
 /// lock: `reputation::create_score_board` records it and aborts if it is
@@ -272,6 +313,39 @@ public fun config_max_job_amount(cfg: &FeeConfig): u64 {
     }
 }
 
+/// Live active-job cap for a seller level (1..4): the per-level DF when
+/// set, else the package default. S.1192 — read at claim by
+/// `reputation::active_cap_for_level`.
+public fun config_tier_active_cap(cfg: &FeeConfig, level: u8): u64 {
+    assert!(level >= 1 && level <= 4, EBadTierBounds);
+    if (df::exists(&cfg.id, TierActiveCapKey { level })) {
+        *df::borrow(&cfg.id, TierActiveCapKey { level })
+    } else if (level == 1) {
+        TIER1_ACTIVE_CAP_DEFAULT
+    } else if (level == 2) {
+        TIER2_ACTIVE_CAP_DEFAULT
+    } else if (level == 3) {
+        TIER3_ACTIVE_CAP_DEFAULT
+    } else {
+        TIER4_ACTIVE_CAP_DEFAULT
+    }
+}
+
+/// Live no-delivery regression floor: the DF when set, else the default.
+public fun config_no_delivery_regression_floor(cfg: &FeeConfig): u64 {
+    if (df::exists(&cfg.id, NoDeliveryRegressionFloorKey {})) {
+        *df::borrow(&cfg.id, NoDeliveryRegressionFloorKey {})
+    } else {
+        NO_DELIVERY_REGRESSION_FLOOR_DEFAULT
+    }
+}
+
+/// Whether this Job was minted from a claimed Opening (S.1192) — the
+/// active-counter settle paths decrement ONLY these.
+public fun is_claimed_job<T>(job: &Job<T>): bool {
+    df::exists(&job.id, ClaimedJobKey {})
+}
+
 /// Bounds gate for money ENTERING escrow — `create` and (via the package
 /// accessor) `opening::create_open` only. Settlement verbs and
 /// `create_claimed` never re-check: an Opening fixed its amount at post,
@@ -379,7 +453,7 @@ public(package) fun create_claimed<T>(
     assert!(deliver_by_ms <= now + MAX_DELIVER_HORIZON_MS, EDeadlineTooFar);
     assert!(review_window_ms <= MAX_REVIEW_WINDOW_MS, EReviewWindowTooLong);
     assert!(reject_split_bps <= BPS_DENOMINATOR, EBadSplit);
-    let job = Job<T> {
+    let mut job = Job<T> {
         id: object::new(ctx),
         buyer,
         seller,
@@ -395,6 +469,9 @@ public(package) fun create_claimed<T>(
         delivered_at_ms: 0,
         created_at_ms: now,
     };
+    // S.1192: brand the Job as board-claimed so terminal settles know to
+    // decrement the seller's active counter (hire jobs stay unbranded).
+    df::add(&mut job.id, ClaimedJobKey {}, true);
     let job_id = job.id.to_inner();
     event::emit(JobCreated {
         job_id,
@@ -463,14 +540,33 @@ public fun deliver<T>(
 }
 
 // === Release (funds → seller, minus the protocol fee) ===
-/// Three legitimate callers:
+/// DEPRECATED (S.1192) — always aborts `EUseReleaseV2`. The live path is
+/// `reputation::release_v2`, which settles via `release_settle_pkg` below
+/// AND decrements the seller's active-job counter on board-claimed jobs.
+/// Signature survives (Sui compatible upgrades cannot remove public
+/// functions); the body is dead.
+public fun release<T>(
+    _job: &mut Job<T>,
+    cfg: &FeeConfig,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
+) {
+    assert_version(cfg);
+    abort EUseReleaseV2
+}
+
+/// The release settlement body (S.1192: package-visible so
+/// `reputation::release_v2` — the only live caller — settles the money
+/// HERE; coin/fee math never leaves this module). Three legitimate
+/// callers, unchanged from v1 `release`:
 /// 1. The buyer accepting a DELIVERED job.
 /// 2. The buyer voluntarily paying a FUNDED job (goodwill / late-accept after
 ///    an off-band delivery) — it's the buyer's own money moving to the agreed
 ///    seller, always safe.
 /// 3. ANYONE, once a DELIVERED job's review window has lapsed — the
 ///    permissionless crank that stops a ghosting buyer stranding the seller.
-public fun release<T>(
+/// Emits `JobReleased` exactly as v1 did — defining id unchanged.
+public(package) fun release_settle_pkg<T>(
     job: &mut Job<T>,
     cfg: &FeeConfig,
     clock: &Clock,
@@ -682,6 +778,32 @@ public fun set_max_job_amount(_: &AdminCap, cfg: &mut FeeConfig, max_amount: u64
         *df::borrow_mut(&mut cfg.id, MaxJobAmountKey {}) = max_amount;
     } else {
         df::add(&mut cfg.id, MaxJobAmountKey {}, max_amount);
+    }
+}
+
+/// S.1192 — set (add or update) one level's live active cap. Level 1..4,
+/// cap > 0 (a 0 cap would freeze the level entirely — deactivate agents
+/// via the registry, not via capacity).
+public fun set_tier_active_cap(_: &AdminCap, cfg: &mut FeeConfig, level: u8, cap: u64) {
+    assert_version(cfg);
+    assert!(level >= 1 && level <= 4, EBadTierBounds);
+    assert!(cap > 0, EBadTierBounds);
+    if (df::exists(&cfg.id, TierActiveCapKey { level })) {
+        *df::borrow_mut(&mut cfg.id, TierActiveCapKey { level }) = cap;
+    } else {
+        df::add(&mut cfg.id, TierActiveCapKey { level }, cap);
+    }
+}
+
+/// S.1192 — set (add or update) the live no-delivery regression floor.
+/// Must be > 0 (a 0 floor would regress every seller forever).
+public fun set_no_delivery_regression_floor(_: &AdminCap, cfg: &mut FeeConfig, n: u64) {
+    assert_version(cfg);
+    assert!(n > 0, EBadTierBounds);
+    if (df::exists(&cfg.id, NoDeliveryRegressionFloorKey {})) {
+        *df::borrow_mut(&mut cfg.id, NoDeliveryRegressionFloorKey {}) = n;
+    } else {
+        df::add(&mut cfg.id, NoDeliveryRegressionFloorKey {}, n);
     }
 }
 

--- a/contracts/a2a_escrow/sources/opening.move
+++ b/contracts/a2a_escrow/sources/opening.move
@@ -47,6 +47,7 @@ use agent_id::registry::{Self, Registry};
 use sui::balance::Balance;
 use sui::clock::Clock;
 use sui::coin::{Self, Coin};
+use sui::dynamic_field as df;
 use sui::event;
 
 /// Default claim policy: any ACTIVE registered Agent ID ($0 claim, FCFS).
@@ -83,12 +84,33 @@ const EScoreNotClaimer: u64 = 13;
 /// S.1054: the claimer's on-chain score doesn't meet the Opening's
 /// Proven bar (clients preflight this in English first).
 const EClaimPolicyUnmet: u64 = 14;
+/// S.1192: the claimer is at their level's active-job cap — finish or
+/// settle an in-flight claimed job first (clients preflight in English).
+const EActiveJobCap: u64 = 15;
+/// S.1192: the claimer's effective seller level is below the Opening's
+/// `min_seller_level` floor.
+const EMinSellerLevelUnmet: u64 = 16;
+/// S.1192: `create_open`/`claim`/`claim_proven` moved to their `_v2`
+/// entries (the active-cap + level gates ride the claim; posts carry
+/// `min_seller_level`). Dedicated code, same S.1032/S.1063 pattern —
+/// shared by all three dead stubs, documented in RUNBOOK_S1192.
+const EUseClaimV2: u64 = 17;
+/// S.1192: `min_seller_level` must be 0 (no floor) or 1..4.
+const EBadMinSellerLevel: u64 = 18;
 
 // === Objects ===
 
 /// One open job posting. Shared so any seller can race to claim; the escrow
 /// balance lives inside the object from the moment of posting. Existence is
 /// the state: claim / cancel / refund all consume it.
+/// S.1192 — optional seller-level floor on `Opening.id` (value `u8`,
+/// 1..4). A DF, NEVER a struct field: live openings can't grow layout
+/// under a compatible upgrade, and missing ⇒ 0 (no floor) makes every
+/// pre-S.1192 opening claimable unchanged. Written by `create_open_v2`
+/// at post (when > 0), removed at claim/cancel/refund before the UID
+/// deletes (storage rebate).
+public struct MinSellerLevelKey has copy, drop, store {}
+
 public struct Opening<phantom T> has key {
     id: UID,
     buyer: address,
@@ -125,6 +147,26 @@ public struct OpeningCreated has copy, drop {
     claim_policy: u8,
     timestamp_ms: u64,
 }
+/// S.1192 sibling of `OpeningCreated` (same fields + `min_seller_level`,
+/// emitted together on every v2 post) — a NEW struct because the v1
+/// event's layout is frozen under compatible upgrade. Defining id = the
+/// S.1192 upgrade package (V10 pin); indexers pin that id and prefer
+/// this event.
+public struct OpeningCreatedV2 has copy, drop {
+    opening_id: ID,
+    buyer: address,
+    amount: u64,
+    fee_bps: u64,
+    spec_hash: vector<u8>,
+    open_until_ms: u64,
+    sla_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    claim_policy: u8,
+    /// 0 = no floor · 1..4 = minimum EFFECTIVE seller level to claim.
+    min_seller_level: u8,
+    timestamp_ms: u64,
+}
 /// The opening→job edge — keeps the "one job" identity continuous for the
 /// indexer and the receipt page.
 public struct OpeningClaimed has copy, drop {
@@ -150,9 +192,34 @@ public struct OpeningRefunded has copy, drop {
 
 // === Create (buyer locks funds + terms at POST — no seller yet) ===
 
-/// Post an open job: the payment escrows into a shared `Opening` right now.
-/// Returns the opening id for PTB callers.
+/// DEPRECATED (S.1192) — always aborts `EUseClaimV2`. The live post door
+/// is `create_open_v2` (adds `min_seller_level`); all new posts go
+/// through v2 so the board's floor field is uniform. Signature survives
+/// (compatible upgrades can't remove public functions); the body is dead
+/// — the unconsumed `payment` is fine on a diverging path, the abort
+/// reverts the whole tx.
 public fun create_open<T>(
+    _payment: Coin<T>,
+    _spec_hash: vector<u8>,
+    _open_until_ms: u64,
+    _sla_ms: u64,
+    _review_window_ms: u64,
+    _reject_split_bps: u64,
+    _claim_policy: u8,
+    cfg: &FeeConfig,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    abort EUseClaimV2
+}
+
+/// Post an open job: the payment escrows into a shared `Opening` right now.
+/// Returns the opening id for PTB callers. S.1192: `min_seller_level`
+/// (0 = no floor, 1..4) writes the `MinSellerLevelKey` DF — enforced at
+/// claim on the claimer's EFFECTIVE level, independent of `claim_policy`
+/// (a post can require Proven · 4★+ AND Level 2+, or either alone).
+public fun create_open_v2<T>(
     payment: Coin<T>,
     spec_hash: vector<u8>,
     open_until_ms: u64,
@@ -160,14 +227,17 @@ public fun create_open<T>(
     review_window_ms: u64,
     reject_split_bps: u64,
     claim_policy: u8,
+    min_seller_level: u8,
     cfg: &FeeConfig,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     escrow::assert_version_pkg(cfg);
     // S.1054: 0 (Anyone) stays the default; 1/2 (Proven) are live; 3+
-    // still aborts until a later SPEC defines them.
+    // still aborts until a later SPEC defines them (min_seller_level is
+    // the level floor — NEVER a claim_policy 3+).
     assert!(claim_policy <= CLAIM_POLICY_MIN_AVG, EBadClaimPolicy);
+    assert!(min_seller_level <= 4, EBadMinSellerLevel);
     let amount = payment.value();
     assert!(amount > 0, EZeroAmount);
     // Money-entering bounds (S.981) — same gate as `escrow::create`. Checked
@@ -195,7 +265,7 @@ public fun create_open<T>(
         reject_split_bps == escrow::bps_denominator_pkg(),
         EOpenRejectMustBeFullBuyer,
     );
-    let opening = Opening<T> {
+    let mut opening = Opening<T> {
         id: object::new(ctx),
         buyer: ctx.sender(),
         escrow: payment.into_balance(),
@@ -208,6 +278,11 @@ public fun create_open<T>(
         reject_split_bps,
         claim_policy,
         created_at_ms: now,
+    };
+    // S.1192: the level floor is a DF, never a struct field — absent
+    // means 0, so old openings and floor-less posts read identically.
+    if (min_seller_level > 0) {
+        df::add(&mut opening.id, MinSellerLevelKey {}, min_seller_level);
     };
     let opening_id = opening.id.to_inner();
     event::emit(OpeningCreated {
@@ -223,41 +298,91 @@ public fun create_open<T>(
         claim_policy,
         timestamp_ms: now,
     });
+    event::emit(OpeningCreatedV2 {
+        opening_id,
+        buyer: opening.buyer,
+        amount,
+        fee_bps: opening.fee_bps,
+        spec_hash: opening.spec_hash,
+        open_until_ms,
+        sla_ms,
+        review_window_ms,
+        reject_split_bps,
+        claim_policy,
+        min_seller_level,
+        timestamp_ms: now,
+    });
     transfer::share_object(opening);
     opening_id
 }
 
 // === Claim (first active seller wins — the Opening becomes a normal Job) ===
 
-/// Claim an open job posted Anyone (`claim_policy = 0`). Consumes the
-/// Opening (first claim wins at the object layer) and mints a funded
-/// `escrow::Job` with `seller = claimer` and `deliver_by = now + sla_ms`.
-/// Returns the new job id. Proven openings (`1`/`2`) claim through
-/// `claim_proven` — this entry aborts on them, so a pre-S.1054 package
-/// can never bypass a Proven gate.
+/// DEPRECATED (S.1192) — always aborts `EUseClaimV2`. The live path is
+/// `claim_v2`, which takes the claimer's `&mut AgentScore` for the
+/// active-cap + level-floor gates. Signature survives; the body is dead
+/// (the by-value Opening needs no consumption on a diverging path — the
+/// abort reverts the whole tx and the object stays shared + claimable
+/// through v2).
 public fun claim<T>(
+    _opening: Opening<T>,
+    _registry: &Registry,
+    cfg: &FeeConfig,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    abort EUseClaimV2
+}
+
+/// DEPRECATED (S.1192) — always aborts `EUseClaimV2`. Live path:
+/// `claim_proven_v2`.
+public fun claim_proven<T>(
+    _opening: Opening<T>,
+    _registry: &Registry,
+    _score: &AgentScore,
+    cfg: &FeeConfig,
+    _clock: &Clock,
+    _ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    abort EUseClaimV2
+}
+
+/// Claim an open job posted Anyone (`claim_policy = 0`) — S.1192 v2.
+/// Consumes the Opening (first claim wins at the object layer) and mints
+/// a funded `escrow::Job` with `seller = claimer` and `deliver_by = now +
+/// sla_ms`. Returns the new job id. The claimer passes their OWN shared
+/// `AgentScore` by MUTABLE reference — policy 0 included — because every
+/// claim now moves the active-job counter and reads the capacity gates;
+/// an agent with no score yet chains the permissionless
+/// `create_empty_score` in the same PTB (the S.1063 precursor pattern —
+/// an empty score grants nothing and reads as Level 1). Proven openings
+/// (`1`/`2`) claim through `claim_proven_v2` — this entry aborts on them,
+/// so the Proven gate can never be bypassed.
+public fun claim_v2<T>(
     opening: Opening<T>,
     registry: &Registry,
+    score: &mut AgentScore,
     cfg: &FeeConfig,
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
     escrow::assert_version_pkg(cfg);
     assert!(opening.claim_policy == CLAIM_POLICY_ANY_ACTIVE, EBadClaimPolicy);
-    do_claim(opening, registry, cfg, clock, ctx)
+    do_claim(opening, registry, score, cfg, clock, ctx)
 }
 
-/// Claim a PROVEN open job (`claim_policy` `1` or `2`) — S.1054. The
-/// claimer passes their OWN shared `AgentScore` by immutable reference
-/// (parallel with every other claim); the score must belong to the sender
-/// and meet the Opening's bar. Everything else is `claim`: still FCFS,
-/// still $0, the Opening is consumed and a normal Job mints. An agent
-/// with no score object cannot call this at all — the correct
-/// "zero reviews" outcome.
-public fun claim_proven<T>(
+/// Claim a PROVEN open job (`claim_policy` `1` or `2`) — S.1192 v2 of the
+/// S.1054 entry. The score must belong to the sender and meet the
+/// Opening's bar; the same object then feeds the capacity gates and the
+/// counter write in `do_claim`. Still FCFS, still $0, no bond, no
+/// buyer-confirm. Mutability note: `&mut` serializes same-SELLER claims
+/// on their own score (that IS the cap); different sellers stay parallel.
+public fun claim_proven_v2<T>(
     opening: Opening<T>,
     registry: &Registry,
-    score: &AgentScore,
+    score: &mut AgentScore,
     cfg: &FeeConfig,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -275,14 +400,20 @@ public fun claim_proven<T>(
     } else {
         assert!(reputation::meets_min_avg(score), EClaimPolicyUnmet);
     };
-    do_claim(opening, registry, cfg, clock, ctx)
+    do_claim(opening, registry, score, cfg, clock, ctx)
 }
 
-/// The one claim body both entries share — every gate EXCEPT the policy
-/// check, which each entry asserts against its own inputs first.
+/// The one claim body both v2 entries share — every gate EXCEPT the
+/// policy check, which each entry asserts against its own inputs first.
+/// S.1192 adds the capacity gates: the claimer's own score (ownership
+/// re-asserted here so a policy-0 claim can't ride a stranger's score),
+/// the per-level active cap on the EFFECTIVE level, and the Opening's
+/// optional `min_seller_level` floor. The counter increments AFTER the
+/// Job mints (same tx — atomic either way; the event wants the job id).
 fun do_claim<T>(
     opening: Opening<T>,
     registry: &Registry,
+    score: &mut AgentScore,
     cfg: &FeeConfig,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -290,7 +421,7 @@ fun do_claim<T>(
     let now = clock.timestamp_ms();
     let claimer = ctx.sender();
     let Opening {
-        id,
+        mut id,
         buyer,
         escrow: escrow_balance,
         amount,
@@ -308,6 +439,24 @@ fun do_claim<T>(
     assert!(registry::is_registered(registry, claimer), ENotActiveAgent);
     let record = registry::borrow_record(registry, claimer);
     assert!(registry::is_active(record), ENotActiveAgent);
+    // S.1192 capacity gates — clients preflight both in English first.
+    assert!(reputation::agent(score) == claimer, EScoreNotClaimer);
+    let level = reputation::effective_seller_level(score, cfg);
+    let cap = reputation::active_cap_for_level(cfg, level);
+    assert!(reputation::active_seller_jobs(score) < cap, EActiveJobCap);
+    // The floor DF comes OFF the UID here (missing ⇒ 0) — removed, not
+    // just read, so the deleted UID leaves no orphaned storage behind.
+    let min_level: u8 = if (df::exists(&id, MinSellerLevelKey {})) {
+        df::remove(&mut id, MinSellerLevelKey {})
+    } else {
+        0
+    };
+    if (min_level > 0) {
+        assert!(
+            reputation::meets_min_seller_level(score, cfg, min_level),
+            EMinSellerLevelUnmet,
+        );
+    };
     let opening_id = id.to_inner();
     id.delete();
     let job_id = escrow::create_claimed(
@@ -323,6 +472,7 @@ fun do_claim<T>(
         clock,
         ctx,
     );
+    reputation::increment_active(score, job_id, now);
     event::emit(OpeningClaimed {
         opening_id,
         job_id,
@@ -381,7 +531,7 @@ public fun refund_unclaimed<T>(
 /// Consume an Opening and return its full balance to the buyer, fee-free.
 fun repay_buyer<T>(opening: Opening<T>, ctx: &mut TxContext): (ID, address, u64) {
     let Opening {
-        id,
+        mut id,
         buyer,
         escrow: mut escrow_balance,
         amount,
@@ -394,6 +544,10 @@ fun repay_buyer<T>(opening: Opening<T>, ctx: &mut TxContext): (ID, address, u64)
         claim_policy: _,
         created_at_ms: _,
     } = opening;
+    // S.1192: reclaim the floor DF (if any) before the UID deletes.
+    if (df::exists(&id, MinSellerLevelKey {})) {
+        let _floor: u8 = df::remove(&mut id, MinSellerLevelKey {});
+    };
     let opening_id = id.to_inner();
     id.delete();
     let payout = coin::from_balance(escrow_balance.withdraw_all(), ctx);
@@ -417,6 +571,16 @@ public fun reject_split_bps<T>(opening: &Opening<T>): u64 {
 }
 public fun claim_policy<T>(opening: &Opening<T>): u8 { opening.claim_policy }
 public fun created_at_ms<T>(opening: &Opening<T>): u64 { opening.created_at_ms }
+
+/// S.1192 — the opening's seller-level floor (DF read; missing ⇒ 0, which
+/// covers every pre-S.1192 opening and every floor-less v2 post).
+public fun min_seller_level<T>(opening: &Opening<T>): u8 {
+    if (df::exists(&opening.id, MinSellerLevelKey {})) {
+        *df::borrow(&opening.id, MinSellerLevelKey {})
+    } else {
+        0
+    }
+}
 
 public fun claim_policy_any_active(): u8 { CLAIM_POLICY_ANY_ACTIVE }
 public fun claim_policy_min_reviews(): u8 { CLAIM_POLICY_MIN_REVIEWS }

--- a/contracts/a2a_escrow/sources/reputation.move
+++ b/contracts/a2a_escrow/sources/reputation.move
@@ -62,6 +62,16 @@ const AVG_SCALE: u64 = 10;
 const MIN_STARS: u8 = 1;
 const MAX_STARS: u8 = 5;
 
+// === Seller levels (S.1192) — protocol constants, one SSOT ===
+/// Level 4 additionally needs this many reviews…
+const LEVEL4_MIN_REVIEWS: u64 = 20;
+/// …and at most this many no-delivery outcomes.
+const LEVEL4_MAX_NO_DELIVERY: u64 = 2;
+/// `ActiveSellerJobsChanged.delta` values (u8 — Move has no signed ints;
+/// same encoding house as `OutcomeRecorded.kind`).
+const ACTIVE_DELTA_CLAIM: u8 = 0; // +1
+const ACTIVE_DELTA_SETTLE: u8 = 1; // −1
+
 // === Errors ===
 const ENotBuyer: u64 = 0;
 /// Not a reviewable state — reviews attach to RELEASED or (since S.1064)
@@ -145,6 +155,18 @@ public struct NoDeliveryKey has copy, drop, store {}
 /// Passport buyers never get a public chain counter: privacy lock).
 public struct AsBuyerRejectedKey has copy, drop, store {}
 
+// === v2 active-job counter (S.1192) — DF on `AgentScore.id` ===
+// In-flight BOARD-CLAIMED jobs (funded + delivered) this seller holds.
+// +1 in `opening::do_claim` (via `increment_active`), −1 on the terminal
+// settles of jobs carrying `escrow::ClaimedJobKey` (release_v2 /
+// reject_v2* / refund_v2). Hire jobs never move it — they never
+// incremented, and an unconditional decrement would let a colluding
+// buyer reset a hunter's counter with a dust hire + instant release.
+// Missing ⇒ 0 (soft start — no backfill, pre-upgrade claims never count).
+
+/// DF key → `u64`: this seller's live claimed-job count. Missing ⇒ 0.
+public struct ActiveSellerJobsKey has copy, drop, store {}
+
 // === Events (the indexer's score read-model is built from these) ===
 public struct ScoreBoardCreated has copy, drop {
     board_id: ID,
@@ -205,6 +227,20 @@ public struct OutcomeRecorded has copy, drop {
     /// 0 = rejected_after_delivery · 1 = no_delivery · 2 = as_buyer_rejected
     kind: u8,
     value: u64,
+    timestamp_ms: u64,
+}
+
+/// S.1192 — the seller's in-flight claimed-job counter moved.
+/// `active_seller_jobs` is the POST-write value (read-model mirrors
+/// without a fetch); `delta` is 0 = +1 (claim) · 1 = −1 (terminal
+/// settle). Defining id = the S.1192 upgrade package (V10 pin).
+public struct ActiveSellerJobsChanged has copy, drop {
+    score_id: ID,
+    agent: address,
+    job_id: ID,
+    active_seller_jobs: u64,
+    /// 0 = +1 (claim) · 1 = −1 (release/reject/refund of a claimed job)
+    delta: u8,
     timestamp_ms: u64,
 }
 
@@ -337,13 +373,19 @@ public fun reject_v2<T>(
     assert!(!registry::is_registered(registry, escrow::buyer(job)), EBuyerIsAgent);
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
     escrow::reject_settle_pkg(job, cfg, clock, ctx); // auth: sender==buyer, DELIVERED, in-window
+    let now = clock.timestamp_ms();
+    let job_id = object::id(job);
     record_outcome(
         seller_score,
-        object::id(job),
+        job_id,
         RejectedAfterDeliveryKey {},
         OUTCOME_REJECTED_AFTER_DELIVERY,
-        clock.timestamp_ms(),
+        now,
     );
+    // S.1192: a board-claimed job leaving flight frees a seat.
+    if (escrow::is_claimed_job(job)) {
+        decrement_active(seller_score, job_id, now);
+    };
 }
 
 /// Buyer rejects delivered work — AGENT-ID buyer variant: same settle +
@@ -379,6 +421,11 @@ public fun reject_v2_agent_buyer<T>(
         OUTCOME_AS_BUYER_REJECTED,
         now,
     );
+    // S.1192: seller seat frees (the SELLER's counter only — a buyer's
+    // as_buyer facts never touch capacity).
+    if (escrow::is_claimed_job(job)) {
+        decrement_active(seller_score, job_id, now);
+    };
 }
 
 /// Deadline refund (no delivery) — permissionless crank, plus
@@ -393,13 +440,42 @@ public fun refund_v2<T>(
 ) {
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
     escrow::refund_settle_pkg(job, cfg, clock, ctx); // auth: FUNDED, past deadline
+    let now = clock.timestamp_ms();
+    let job_id = object::id(job);
     record_outcome(
         seller_score,
-        object::id(job),
+        job_id,
         NoDeliveryKey {},
         OUTCOME_NO_DELIVERY,
-        clock.timestamp_ms(),
+        now,
     );
+    // S.1192: the abandoned claimed job frees its seat (the no_delivery
+    // counter above is what costs the seller — via level regression).
+    if (escrow::is_claimed_job(job)) {
+        decrement_active(seller_score, job_id, now);
+    };
+}
+
+/// Release — funds → seller minus the protocol fee (S.1192: the ONLY live
+/// release door). Money settles in escrow's package-visible
+/// `release_settle_pkg` (auth unchanged from v1: buyer accept, buyer
+/// goodwill on FUNDED, or anyone after the review window lapses); the
+/// seller's active-job counter decrements here for board-claimed jobs.
+/// The permissionless-crank property survives: any sender may call this —
+/// the score input is the SELLER's (verified against the job), not the
+/// caller's.
+public fun release_v2<T>(
+    job: &mut Job<T>,
+    seller_score: &mut AgentScore,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    assert!(seller_score.agent == escrow::seller(job), EWrongScore);
+    escrow::release_settle_pkg(job, cfg, clock, ctx);
+    if (escrow::is_claimed_job(job)) {
+        decrement_active(seller_score, object::id(job), clock.timestamp_ms());
+    };
 }
 
 /// The ONLY outcome mutator — private; a counter can never move except
@@ -426,6 +502,60 @@ fun record_outcome<K: copy + drop + store>(
         job_id,
         kind,
         value,
+        timestamp_ms: now,
+    });
+}
+
+// === Active-job counter (S.1192) — package-private mutators ===
+// Only `opening::do_claim` increments; only the three terminal settle
+// paths above decrement (claimed jobs only). Package-private, so the
+// counter can never move except with the money.
+
+/// +1 — called by `opening::do_claim` after the Job mints. Serializes
+/// same-seller claims on the score object (correct: that IS the cap);
+/// different sellers touch different scores and stay parallel (S.1054
+/// model preserved across agents).
+public(package) fun increment_active(score: &mut AgentScore, job_id: ID, now: u64) {
+    let value = if (df::exists(&score.id, ActiveSellerJobsKey {})) {
+        let count: &mut u64 = df::borrow_mut(&mut score.id, ActiveSellerJobsKey {});
+        *count = *count + 1;
+        *count
+    } else {
+        df::add(&mut score.id, ActiveSellerJobsKey {}, 1u64);
+        1
+    };
+    score.updated_at_ms = now;
+    event::emit(ActiveSellerJobsChanged {
+        score_id: score.id.to_inner(),
+        agent: score.agent,
+        job_id,
+        active_seller_jobs: value,
+        delta: ACTIVE_DELTA_CLAIM,
+        timestamp_ms: now,
+    });
+}
+
+/// −1, saturating at 0 — belt + suspenders: the `ClaimedJobKey` guard at
+/// every call site already scopes decrements to jobs that incremented, so
+/// the 0 branch is a silent no-op (no event) rather than an abort that
+/// could wedge a settlement.
+public(package) fun decrement_active(score: &mut AgentScore, job_id: ID, now: u64) {
+    if (!df::exists(&score.id, ActiveSellerJobsKey {})) {
+        return
+    };
+    let count: &mut u64 = df::borrow_mut(&mut score.id, ActiveSellerJobsKey {});
+    if (*count == 0) {
+        return
+    };
+    *count = *count - 1;
+    let value = *count;
+    score.updated_at_ms = now;
+    event::emit(ActiveSellerJobsChanged {
+        score_id: score.id.to_inner(),
+        agent: score.agent,
+        job_id,
+        active_seller_jobs: value,
+        delta: ACTIVE_DELTA_SETTLE,
         timestamp_ms: now,
     });
 }
@@ -528,6 +658,52 @@ public fun meets_min_avg(score: &AgentScore): bool {
         score.stars_sum * AVG_SCALE >= score.review_count * PROVEN_MIN_AVG_STARS_X10
 }
 
+// === Seller levels (S.1192) — capacity labels, separate from claim policy ===
+
+/// Computed Level 1..4 (SPEC_MARKETPLACE_REPUTATION_V2_TIERS, locked):
+/// 1 default · 2 Proven (≥3 distinct buyers) · 3 4.0★+ average ·
+/// 4 = Level 3 + ≥20 reviews + ≤2 no-delivery. Levels reuse the SAME
+/// predicates the claim policies read — one SSOT for every threshold.
+public fun seller_level(score: &AgentScore): u8 {
+    if (meets_min_avg(score)) {
+        if (
+            score.review_count >= LEVEL4_MIN_REVIEWS &&
+            no_delivery(score) <= LEVEL4_MAX_NO_DELIVERY
+        ) { 4 } else { 3 }
+    } else if (meets_proven(score)) {
+        2
+    } else {
+        1
+    }
+}
+
+/// The level capacity actually gates on: `no_delivery >= floor` (default
+/// 3, AdminCap-tunable on `FeeConfig`) regresses to Level 1 regardless of
+/// stars — reliability caps capacity without touching star math (display
+/// ≠ gate). Takes `cfg` because the floor is a live FeeConfig DF, not a
+/// package constant (spec sketch showed score-only; the tunable floor
+/// requires the config).
+public fun effective_seller_level(score: &AgentScore, cfg: &FeeConfig): u8 {
+    if (no_delivery(score) >= escrow::config_no_delivery_regression_floor(cfg)) {
+        1
+    } else {
+        seller_level(score)
+    }
+}
+
+/// The live active-job cap for a level — thin wrapper over the FeeConfig
+/// read so claim-side callers stay in one module's vocabulary.
+public fun active_cap_for_level(cfg: &FeeConfig, level: u8): u64 {
+    escrow::config_tier_active_cap(cfg, level)
+}
+
+/// Whether this seller clears an opening's `min_seller_level` floor —
+/// on the EFFECTIVE level, so a regressed seller cannot pass a Level 2+
+/// floor on stars alone (takes `cfg` for the tunable regression floor).
+public fun meets_min_seller_level(score: &AgentScore, cfg: &FeeConfig, min_level: u8): bool {
+    effective_seller_level(score, cfg) >= min_level
+}
+
 // === Read accessors (clients, indexer, composing modules) ===
 public fun agent(score: &AgentScore): address { score.agent }
 public fun review_count(score: &AgentScore): u64 { score.review_count }
@@ -566,6 +742,17 @@ public fun no_delivery(score: &AgentScore): u64 {
 public fun as_buyer_rejected(score: &AgentScore): u64 {
     outcome_count(score, AsBuyerRejectedKey {})
 }
+
+/// This seller's live board-claimed job count (S.1192). Missing DF ⇒ 0 —
+/// the soft start: pre-upgrade claims never counted in, and their settles
+/// never count out (no `ClaimedJobKey` marker).
+public fun active_seller_jobs(score: &AgentScore): u64 {
+    if (df::exists(&score.id, ActiveSellerJobsKey {})) {
+        *df::borrow(&score.id, ActiveSellerJobsKey {})
+    } else {
+        0
+    }
+}
 public fun has_job_review(score: &AgentScore, job_id: ID): bool {
     score.job_stars.contains(job_id)
 }
@@ -585,6 +772,8 @@ public fun score_address(board: &ScoreBoard, agent: address): address {
 
 public fun proven_min_reviews(): u64 { PROVEN_MIN_REVIEWS }
 public fun proven_min_avg_stars_x10(): u64 { PROVEN_MIN_AVG_STARS_X10 }
+public fun level4_min_reviews(): u64 { LEVEL4_MIN_REVIEWS }
+public fun level4_max_no_delivery(): u64 { LEVEL4_MAX_NO_DELIVERY }
 public fun avg_scale(): u64 { AVG_SCALE }
 public fun min_stars(): u8 { MIN_STARS }
 public fun max_stars(): u8 { MAX_STARS }

--- a/contracts/a2a_escrow/tests/escrow_tests.move
+++ b/contracts/a2a_escrow/tests/escrow_tests.move
@@ -69,7 +69,9 @@ fun release_as(sc: &mut ts::Scenario, who: address, clk: &Clock) {
     ts::next_tx(sc, who);
     let cfg = ts::take_shared<FeeConfig>(sc);
     let mut job = ts::take_shared<Job<SUI>>(sc);
-    escrow::release(&mut job, &cfg, clk, ts::ctx(sc));
+    // S.1192: the money path under `reputation::release_v2` — same auth,
+    // in-package direct call (the reject/refund settle tests' pattern).
+    escrow::release_settle_pkg(&mut job, &cfg, clk, ts::ctx(sc));
     ts::return_shared(job);
     ts::return_shared(cfg);
 }
@@ -864,6 +866,122 @@ fun set_max_above_hard_ceiling_fails() {
 fun set_max_below_live_min_fails() {
     let (mut sc, clk) = setup();
     set_max_as_admin(&mut sc, escrow::default_min_job_amount() - 1);
+    clock::destroy_for_testing(clk);
+    abort 99
+}
+
+// === S.1192: deprecated release + tier-cap tunables ===
+
+#[test]
+#[expected_failure(abort_code = escrow::EUseReleaseV2)]
+fun deprecated_escrow_release_aborts() {
+    let (mut sc, clk) = setup();
+    create_job(&mut sc, &clk);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared<Job<SUI>>(&sc);
+        escrow::release(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+fun tier_caps_default_then_admin_override() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        // Soft-start defaults with no DF set: 4 / 10 / 20 / 30, floor 3.
+        assert!(escrow::config_tier_active_cap(&cfg, 1) == 4, 0);
+        assert!(escrow::config_tier_active_cap(&cfg, 2) == 10, 1);
+        assert!(escrow::config_tier_active_cap(&cfg, 3) == 20, 2);
+        assert!(escrow::config_tier_active_cap(&cfg, 4) == 30, 3);
+        assert!(escrow::config_no_delivery_regression_floor(&cfg) == 3, 4);
+        ts::return_shared(cfg);
+    };
+    // Admin retunes Level 2 → 8 (the spec's own example) and updates it
+    // again in place; other levels stay on their defaults.
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_tier_active_cap(&cap, &mut cfg, 2, 8);
+        assert!(escrow::config_tier_active_cap(&cfg, 2) == 8, 5);
+        escrow::set_tier_active_cap(&cap, &mut cfg, 2, 12);
+        assert!(escrow::config_tier_active_cap(&cfg, 2) == 12, 6);
+        assert!(escrow::config_tier_active_cap(&cfg, 1) == 4, 7);
+        escrow::set_no_delivery_regression_floor(&cap, &mut cfg, 5);
+        assert!(escrow::config_no_delivery_regression_floor(&cfg) == 5, 8);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EBadTierBounds)]
+fun set_tier_cap_level_zero_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_tier_active_cap(&cap, &mut cfg, 0, 4);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    clock::destroy_for_testing(clk);
+    abort 99
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EBadTierBounds)]
+fun set_tier_cap_level_five_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_tier_active_cap(&cap, &mut cfg, 5, 4);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    clock::destroy_for_testing(clk);
+    abort 99
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EBadTierBounds)]
+fun set_tier_cap_zero_cap_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_tier_active_cap(&cap, &mut cfg, 1, 0);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    clock::destroy_for_testing(clk);
+    abort 99
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EBadTierBounds)]
+fun set_regression_floor_zero_fails() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_no_delivery_regression_floor(&cap, &mut cfg, 0);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
     clock::destroy_for_testing(clk);
     abort 99
 }

--- a/contracts/a2a_escrow/tests/opening_tests.move
+++ b/contracts/a2a_escrow/tests/opening_tests.move
@@ -3,6 +3,7 @@ module a2a_escrow::opening_tests;
 
 use a2a_escrow::escrow::{Self, AdminCap, FeeConfig, Job};
 use a2a_escrow::opening::{Self, Opening};
+use a2a_escrow::reputation::{Self, AgentScore, ScoreBoard};
 use agent_id::registry::{Self, Registry};
 use sui::clock::{Self, Clock};
 use sui::coin::{Self, Coin};
@@ -32,6 +33,16 @@ fun setup(): (ts::Scenario, Clock) {
     escrow::init_for_testing(ts::ctx(&mut sc));
     registry::init_for_testing(ts::ctx(&mut sc));
     let clk = clock::create_for_testing(ts::ctx(&mut sc));
+    // S.1192: claims need the claimer's AgentScore — the board is the
+    // derived-address namespace parent (one per chain, AdminCap-created).
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        reputation::create_score_board(&cap, &mut cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
     // SELLER registers itself (self-sovereign) and stays active.
     register_agent(&mut sc, &clk, SELLER);
     // IDLE_SELLER registers, then flips itself inactive.
@@ -43,6 +54,36 @@ fun setup(): (ts::Scenario, Clock) {
         ts::return_shared(reg);
     };
     (sc, clk)
+}
+
+/// S.1192: the client-shape precursor — a claimer with no score yet
+/// creates their permissionless zero score first (empty ⇒ Level 1).
+fun ensure_score(sc: &mut ts::Scenario, clk: &Clock, who: address) {
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let mut board = ts::take_shared<ScoreBoard>(sc);
+    if (!reputation::has_score(&board, who)) {
+        reputation::create_empty_score(&mut board, who, &cfg, clk, ts::ctx(sc));
+    };
+    ts::return_shared(board);
+    ts::return_shared(cfg);
+}
+
+/// Take `who`'s score by its DERIVED id — `take_shared<AgentScore>` grabs
+/// the most recent one, which is wrong the moment two sellers have scores.
+fun take_score(sc: &ts::Scenario, who: address): AgentScore {
+    let board = ts::take_shared<ScoreBoard>(sc);
+    let addr = reputation::score_address(&board, who);
+    ts::return_shared(board);
+    ts::take_shared_by_id<AgentScore>(sc, object::id_from_address(addr))
+}
+
+fun active_of(sc: &mut ts::Scenario, who: address): u64 {
+    ts::next_tx(sc, who);
+    let score = take_score(sc, who);
+    let n = reputation::active_seller_jobs(&score);
+    ts::return_shared(score);
+    n
 }
 
 fun register_agent(sc: &mut ts::Scenario, clk: &Clock, who: address) {
@@ -74,10 +115,34 @@ fun post_open_with(
     reject_split_bps: u64,
     claim_policy: u8,
 ) {
+    post_open_with_level(
+        sc,
+        clk,
+        amount,
+        open_until_ms,
+        sla_ms,
+        review_window_ms,
+        reject_split_bps,
+        claim_policy,
+        0,
+    )
+}
+
+fun post_open_with_level(
+    sc: &mut ts::Scenario,
+    clk: &Clock,
+    amount: u64,
+    open_until_ms: u64,
+    sla_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    claim_policy: u8,
+    min_seller_level: u8,
+) {
     ts::next_tx(sc, BUYER);
     let cfg = ts::take_shared<FeeConfig>(sc);
     let payment = coin::mint_for_testing<SUI>(amount, ts::ctx(sc));
-    opening::create_open<SUI>(
+    opening::create_open_v2<SUI>(
         payment,
         b"open-spec-hash",
         open_until_ms,
@@ -85,6 +150,7 @@ fun post_open_with(
         review_window_ms,
         reject_split_bps,
         claim_policy,
+        min_seller_level,
         &cfg,
         clk,
         ts::ctx(sc),
@@ -92,12 +158,16 @@ fun post_open_with(
     ts::return_shared(cfg);
 }
 
+/// v2 claim as `who` — ensures the score precursor first (client shape).
 fun claim_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
+    ensure_score(sc, clk, who);
     ts::next_tx(sc, who);
     let cfg = ts::take_shared<FeeConfig>(sc);
     let reg = ts::take_shared<Registry>(sc);
+    let mut score = take_score(sc, who);
     let op = ts::take_shared<Opening<SUI>>(sc);
-    let job_id = opening::claim(op, &reg, &cfg, clk, ts::ctx(sc));
+    let job_id = opening::claim_v2(op, &reg, &mut score, &cfg, clk, ts::ctx(sc));
+    ts::return_shared(score);
     ts::return_shared(reg);
     ts::return_shared(cfg);
     job_id
@@ -135,6 +205,9 @@ fun post_claim_deliver_release_pays_seller_minus_fee() {
         ts::return_shared(job);
     };
 
+    // S.1192: the claim seated one active job on the seller's score.
+    assert!(active_of(&mut sc, SELLER) == 1, 8);
+
     // Normal Job lifecycle from here: deliver then buyer-accept release.
     ts::next_tx(&mut sc, SELLER);
     {
@@ -148,10 +221,14 @@ fun post_claim_deliver_release_pays_seller_minus_fee() {
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared<Job<SUI>>(&sc);
-        escrow::release(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        let mut score = take_score(&sc, SELLER);
+        reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
+    // …and the release freed it (decrement rides the money, exactly once).
+    assert!(active_of(&mut sc, SELLER) == 0, 9);
     assert_received(&mut sc, SELLER, AMOUNT - FEE);
     assert_received(&mut sc, ADMIN, FEE); // fee receiver = deployer in tests
     ts::end(sc);
@@ -459,4 +536,235 @@ fun open_claim_deliver_reject_pays_buyer_full() {
     assert_received(&mut sc, BUYER, AMOUNT);
     ts::end(sc);
     clk.destroy_for_testing();
+}
+
+// === S.1192: active caps + min seller level + dead v1 entries ===
+
+#[test]
+#[expected_failure(abort_code = opening::EActiveJobCap)]
+fun level1_cap_four_claims_fifth_refused() {
+    let (mut sc, mut clk) = setup();
+    // Five identical Anyone posts; a fresh (empty-score = Level 1) seller
+    // seats 4 claims, and the 5th hits the cap while all 4 stay in flight.
+    post_open(&mut sc, &clk);
+    post_open(&mut sc, &clk);
+    post_open(&mut sc, &clk);
+    post_open(&mut sc, &clk);
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 4, 0);
+    claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+fun refund_v2_frees_the_seat_and_lands_no_delivery() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 1, 0);
+    // Deadline lapses undelivered — permissionless crank refunds, the
+    // no_delivery outcome lands AND the seat frees (once).
+    clk.set_for_testing(10_000 + SLA_MS + 1);
+    ts::next_tx(&mut sc, LURKER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let mut score = take_score(&sc, SELLER);
+        reputation::refund_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(reputation::no_delivery(&score) == 1, 1);
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    assert!(active_of(&mut sc, SELLER) == 0, 2);
+    assert_received(&mut sc, BUYER, AMOUNT);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun reject_v2_frees_the_seat() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        escrow::deliver(&mut job, b"junk", &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    // Passport (unregistered) buyer rejects in-window: outcome + seat free.
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let mut score = take_score(&sc, SELLER);
+        reputation::reject_v2(&mut job, &mut score, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(reputation::rejected_after_delivery(&score) == 1, 0);
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    assert!(active_of(&mut sc, SELLER) == 0, 1);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun decline_never_touches_the_active_counter() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 1, 0);
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        escrow::decline(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    // LOCKED (master spec D-table): decline is a clean walk for outcomes
+    // AND never decrements — the declined claim keeps its seat occupied.
+    // Named consequence: claim→decline churn burns capacity permanently
+    // (documented in RUNBOOK_S1192; anti-abandon by design).
+    assert!(active_of(&mut sc, SELLER) == 1, 1);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun min_level_one_passes_for_fresh_seller() {
+    let (mut sc, mut clk) = setup();
+    // Floor 1: every registered agent with a score qualifies (empty = L1).
+    post_open_with_level(
+        &mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, POLICY_ANY, 1,
+    );
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 1, 0);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EMinSellerLevelUnmet)]
+fun min_level_two_refuses_fresh_seller() {
+    let (mut sc, mut clk) = setup();
+    post_open_with_level(
+        &mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, POLICY_ANY, 2,
+    );
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk); // empty score = Level 1 < floor 2
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EBadMinSellerLevel)]
+fun min_level_five_aborts_at_post() {
+    let (mut sc, clk) = setup();
+    post_open_with_level(
+        &mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, POLICY_ANY, 5,
+    );
+    abort 0
+}
+
+#[test]
+fun cancel_reclaims_the_min_level_df() {
+    let (mut sc, clk) = setup();
+    // A floored post cancels cleanly — repay_buyer removes the DF before
+    // the UID deletes (no orphaned storage), full fee-free refund.
+    post_open_with_level(
+        &mut sc, &clk, AMOUNT, OPEN_UNTIL, SLA_MS, REVIEW_WINDOW, SPLIT_BPS, POLICY_ANY, 3,
+    );
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        assert!(opening::min_seller_level(&op) == 3, 0);
+        opening::cancel_open(op, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(cfg);
+    };
+    assert_received(&mut sc, BUYER, AMOUNT);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EUseClaimV2)]
+fun deprecated_create_open_aborts() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
+        opening::create_open<SUI>(
+            payment,
+            b"open-spec-hash",
+            OPEN_UNTIL,
+            SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            POLICY_ANY,
+            &cfg,
+            &clk,
+            ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EUseClaimV2)]
+fun deprecated_claim_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        opening::claim(op, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EScoreNotClaimer)]
+fun claim_v2_with_borrowed_score_fails() {
+    let (mut sc, mut clk) = setup();
+    post_open(&mut sc, &clk);
+    clk.set_for_testing(10_000);
+    // LURKER registers and tries to claim on SELLER's score — the
+    // ownership assert stops both the cap dodge and the counter graffiti.
+    register_agent(&mut sc, &clk, LURKER);
+    ensure_score(&mut sc, &clk, SELLER);
+    ts::next_tx(&mut sc, LURKER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut score = take_score(&sc, SELLER);
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        opening::claim_v2(op, &reg, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
 }

--- a/contracts/a2a_escrow/tests/reputation_tests.move
+++ b/contracts/a2a_escrow/tests/reputation_tests.move
@@ -112,7 +112,7 @@ fun released_job_from(
     {
         let cfg = ts::take_shared<FeeConfig>(sc);
         let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
-        escrow::release(&mut job, &cfg, clk, ts::ctx(sc));
+        escrow::release_settle_pkg(&mut job, &cfg, clk, ts::ctx(sc));
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
@@ -147,7 +147,7 @@ fun review_as(sc: &mut ts::Scenario, clk: &Clock, who: address, job_id: ID, star
 /// same-buyer repeats use `released_job_from` + `review_as` directly.
 fun reviewed_n(sc: &mut ts::Scenario, clk: &Clock, seller: address, n: u64, stars: u8) {
     let pool = buyers();
-    let mut i = 0;
+    let mut i = 0u64;
     while (i < n) {
         let buyer = *pool.borrow(i);
         let job_id = released_job_from(sc, clk, buyer, seller);
@@ -360,7 +360,7 @@ fun goodwill_release_not_reviewable() {
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
-        escrow::release(&mut job, &cfg, &clk, ts::ctx(&mut sc));
+        escrow::release_settle_pkg(&mut job, &cfg, &clk, ts::ctx(&mut sc));
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
@@ -511,7 +511,7 @@ fun proven_predicates_track_distinct_buyers() {
 fun three_reviews_one_buyer_not_proven() {
     let (mut sc, clk) = setup();
     // The soft-Sybil case v2 closes: one friendly buyer, three jobs.
-    let mut i = 0;
+    let mut i = 0u64;
     while (i < 3) {
         let job_id = released_job(&mut sc, &clk, SELLER); // BUYER every time
         review(&mut sc, &clk, job_id, 5);
@@ -536,7 +536,7 @@ fun three_reviews_one_buyer_not_proven() {
 #[expected_failure(abort_code = opening::EClaimPolicyUnmet)]
 fun proven_claim_one_buyer_three_reviews_fails() {
     let (mut sc, clk) = setup();
-    let mut i = 0;
+    let mut i = 0u64;
     while (i < 3) {
         let job_id = released_job(&mut sc, &clk, SELLER);
         review(&mut sc, &clk, job_id, 5);
@@ -574,7 +574,7 @@ fun post_open_with_policy(sc: &mut ts::Scenario, clk: &Clock, policy: u8) {
     ts::next_tx(sc, BUYER);
     let cfg = ts::take_shared<FeeConfig>(sc);
     let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(sc));
-    opening::create_open<SUI>(
+    opening::create_open_v2<SUI>(
         payment,
         b"open-spec-hash",
         clk.timestamp_ms() + OPEN_UNTIL,
@@ -582,6 +582,7 @@ fun post_open_with_policy(sc: &mut ts::Scenario, clk: &Clock, policy: u8) {
         REVIEW_WINDOW,
         SPLIT_BPS,
         policy,
+        0,
         &cfg,
         clk,
         ts::ctx(sc),
@@ -594,8 +595,8 @@ fun claim_proven_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
     let cfg = ts::take_shared<FeeConfig>(sc);
     let reg = ts::take_shared<Registry>(sc);
     let op = ts::take_shared<Opening<SUI>>(sc);
-    let score = ts::take_shared<AgentScore>(sc);
-    let job_id = opening::claim_proven(op, &reg, &score, &cfg, clk, ts::ctx(sc));
+    let mut score = ts::take_shared<AgentScore>(sc);
+    let job_id = opening::claim_proven_v2(op, &reg, &mut score, &cfg, clk, ts::ctx(sc));
     ts::return_shared(score);
     ts::return_shared(reg);
     ts::return_shared(cfg);
@@ -672,7 +673,9 @@ fun plain_claim_on_proven_opening_fails() {
         let cfg = ts::take_shared<FeeConfig>(&sc);
         let reg = ts::take_shared<Registry>(&sc);
         let op = ts::take_shared<Opening<SUI>>(&sc);
-        opening::claim(op, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        let mut score = ts::take_shared<AgentScore>(&sc);
+        opening::claim_v2(op, &reg, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
         ts::return_shared(reg);
         ts::return_shared(cfg);
     };
@@ -1092,5 +1095,225 @@ fun create_open_accepts_proven_policies() {
 fun create_open_policy_three_aborts() {
     let (mut sc, clk) = setup();
     post_open_with_policy(&mut sc, &clk, 3);
+    abort 0
+}
+
+// === S.1192 — seller levels, regression, active counter on hire jobs ===
+
+/// `n` released+reviewed jobs of `stars` each, buyers CYCLING the 4-buyer
+/// pool — review_count grows per JOB, so this builds the Level 4 bar
+/// (≥20 reviews) without needing 20 distinct addresses.
+fun reviewed_n_cycling(sc: &mut ts::Scenario, clk: &Clock, seller: address, n: u64, stars: u8) {
+    let pool = buyers();
+    let mut i = 0u64;
+    while (i < n) {
+        let buyer = *pool.borrow((i % pool.length()) as u64);
+        let job_id = released_job_from(sc, clk, buyer, seller);
+        review_as(sc, clk, buyer, job_id, stars);
+        i = i + 1;
+    }
+}
+
+fun seller_score(sc: &ts::Scenario): AgentScore {
+    let board = ts::take_shared<ScoreBoard>(sc);
+    let addr = reputation::score_address(&board, SELLER);
+    ts::return_shared(board);
+    ts::take_shared_by_id<AgentScore>(sc, object::id_from_address(addr))
+}
+
+#[test]
+fun seller_levels_climb_the_locked_bars() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    // Level 1: empty score (soft-start: active reads 0 with no DF).
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut board = ts::take_shared<ScoreBoard>(&sc);
+        reputation::create_empty_score(&mut board, SELLER, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(board);
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let score = seller_score(&sc);
+        assert!(reputation::seller_level(&score) == 1, 0);
+        assert!(reputation::effective_seller_level(&score, &cfg) == 1, 1);
+        assert!(reputation::active_seller_jobs(&score) == 0, 2);
+        assert!(reputation::meets_min_seller_level(&score, &cfg, 1), 3);
+        assert!(!reputation::meets_min_seller_level(&score, &cfg, 2), 4);
+        ts::return_shared(score);
+        ts::return_shared(cfg);
+    };
+    // Level 2: Proven (3 distinct buyers) but avg 3.0 < 4.0.
+    reviewed_n(&mut sc, &clk, SELLER, 3, 3);
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let score = seller_score(&sc);
+        assert!(reputation::seller_level(&score) == 2, 5);
+        ts::return_shared(score);
+    };
+    // Level 3: 5★ jobs pull the average over 4.0 (8 reviews < 20 → not 4).
+    reviewed_n_cycling(&mut sc, &clk, SELLER, 5, 5);
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let score = seller_score(&sc);
+        assert!(reputation::seller_level(&score) == 3, 6);
+        ts::return_shared(score);
+    };
+    // Level 4: ≥20 reviews, avg still ≥4.0, no_delivery 0 ≤ 2.
+    reviewed_n_cycling(&mut sc, &clk, SELLER, 12, 5); // total 20
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let score = seller_score(&sc);
+        assert!(reputation::review_count(&score) == 20, 7);
+        assert!(reputation::seller_level(&score) == 4, 8);
+        assert!(reputation::meets_min_seller_level(&score, &cfg, 4), 9);
+        ts::return_shared(score);
+        ts::return_shared(cfg);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun no_delivery_regression_floors_effective_level_to_one() {
+    let (mut sc, mut clk) = setup();
+    // A Proven·4★+ (Level 3) seller…
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
+    // …ghosts three funded jobs past the deadline (refund_v2 each).
+    let mut i = 0u64;
+    while (i < 3) {
+        let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+        let past = clk.timestamp_ms() + SLA_MS + 1;
+        clk.set_for_testing(past);
+        ts::next_tx(&mut sc, STRANGER);
+        {
+            let cfg = ts::take_shared<FeeConfig>(&sc);
+            let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+            let mut score = seller_score(&sc);
+            reputation::refund_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+            ts::return_shared(score);
+            ts::return_shared(job);
+            ts::return_shared(cfg);
+        };
+        i = i + 1;
+    };
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let score = seller_score(&sc);
+        assert!(reputation::no_delivery(&score) == 3, 0);
+        // Stars still say Level 3; the regression floor (default 3) says 1.
+        assert!(reputation::seller_level(&score) == 3, 1);
+        assert!(reputation::effective_seller_level(&score, &cfg) == 1, 2);
+        // …so a Level 2+ floor refuses them despite the stars.
+        assert!(!reputation::meets_min_seller_level(&score, &cfg, 2), 3);
+        ts::return_shared(score);
+        ts::return_shared(cfg);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = opening::EMinSellerLevelUnmet)]
+fun min_level_three_refuses_level_two_seller() {
+    let (mut sc, clk) = setup();
+    // Proven (3 distinct) at 3★ avg = Level 2 — below a Level 3 floor.
+    reviewed_n(&mut sc, &clk, SELLER, 3, 3);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let payment = coin::mint_for_testing<SUI>(AMOUNT, ts::ctx(&mut sc));
+        opening::create_open_v2<SUI>(
+            payment,
+            b"open-spec-hash",
+            clk.timestamp_ms() + OPEN_UNTIL,
+            SLA_MS,
+            REVIEW_WINDOW,
+            SPLIT_BPS,
+            POLICY_ANY,
+            3,
+            &cfg,
+            &clk,
+            ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let op = ts::take_shared<Opening<SUI>>(&sc);
+        let mut score = seller_score(&sc);
+        opening::claim_v2(op, &reg, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+fun hire_release_v2_never_decrements_active() {
+    let (mut sc, clk) = setup();
+    // Seller has one seat occupied from a BOARD claim…
+    reviewed_n(&mut sc, &clk, SELLER, 3, 5);
+    post_open_with_policy(&mut sc, &clk, POLICY_PROVEN);
+    claim_proven_as(&mut sc, SELLER, &clk);
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let score = seller_score(&sc);
+        assert!(reputation::active_seller_jobs(&score) == 1, 0);
+        ts::return_shared(score);
+    };
+    // …then a HIRE job (never incremented) releases through release_v2:
+    // no ClaimedJobKey marker → no decrement. A dust hire + instant
+    // release can NOT reset a hunter's counter.
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let mut score = seller_score(&sc);
+        assert!(!escrow::is_claimed_job(&job), 1);
+        reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(reputation::active_seller_jobs(&score) == 1, 2);
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EWrongScore)]
+fun release_v2_with_wrong_score_fails() {
+    let (mut sc, clk) = setup();
+    let job_id = funded_job(&mut sc, &clk, BUYER, SELLER);
+    deliver_job(&mut sc, &clk, SELLER, job_id);
+    // OTHER_SELLER's score is not this job's seller — refuse before money.
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut board = ts::take_shared<ScoreBoard>(&sc);
+        reputation::create_empty_score(&mut board, OTHER_SELLER, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(board);
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let mut score = ts::take_shared<AgentScore>(&sc);
+        reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
     abort 0
 }

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -117,7 +117,7 @@ Open `PROMPT-50-PROTOCOL-METRICS.md` — **exact title** (no `Metrics:` prefix),
 
 Open `PROMPT-50-PROTOCOL-METRICS-V2.md` — same discipline; **exact title** (no `Metrics:` prefix); EXCLUSIVITY uses `PACK: protocol-metrics-v2`; jobs **8–43** carry ANTI-SELF-DEAL. **Rotate** within v2 only. Per-job limit ≥ **1.00** for v2 register rows.
 
-**Claim gate (S.1182 → S.1190):** jobs **5–7** (register) and **39–43** (review after hire) → `claimPolicy: 2` on `t2000_job_open` (**Proven · 4★+** — ≥3 distinct buyer reviews AND a 4.0★ average). All other v2 jobs → **Anyone** (omit `claimPolicy` or `claimPolicy: 0`). The old `proven: true` boolean is deprecated (maps to policy 1 only) — always send `claimPolicy`.
+**Claim gate (S.1182 → S.1190 → S.1192):** jobs **5–7** (register) and **39–43** (review after hire) → `claimPolicy: 2` + `minSellerLevel: 2` on `t2000_job_open` (**Proven · 4★+** — ≥3 distinct buyer reviews AND a 4.0★ average — with a Level 2 floor). All other v2 jobs → **Anyone**, no Level floor (omit `claimPolicy`/`minSellerLevel` or send 0). The old `proven: true` boolean is deprecated (maps to policy 1 only) — always send `claimPolicy`. Sellers also carry per-Level active caps (4/10/20/30) — a hunter at cap is refused at claim until they settle in-flight work; that is the S.1192 anti-hoard gate working, not an outage.
 
 **Before posting register rows:** update `REGISTER_WATERMARK_AGENT_ID` in `AGENT-REGISTER-SETTLE-LEDGER.md` to the highest numeric Agent ID on the platform at batch start.
 
@@ -253,7 +253,7 @@ Ignore other seats’ openings.
 | maxUsdc | `0.20` |
 | openHours | `168` |
 | slaHours | `168` |
-| claim policy | **Anyone** |
+| claim policy | `claimPolicy: 2` + `minSellerLevel: 2` — **Proven · 4★+ · Level 2+** (S.1192 GTM defaults: social bounties go to proven hunters) |
 
 **Brief** (paste verbatim every time):
 
@@ -300,7 +300,7 @@ Title contains: `Refer a new agent` **or** legacy `Onboard an agent — first pa
 | maxUsdc | `0.25` |
 | openHours | `168` |
 | slaHours | `168` |
-| claim policy | `claimPolicy: 2` — **Proven · 4★+** (S.1190 / D10: referral goes to hunters with a 4.0★ track record, cutting claim-and-abandon) |
+| claim policy | `claimPolicy: 2` + `minSellerLevel: 2` — **Proven · 4★+ · Level 2+** (S.1190 D10 + S.1192: referral goes to hunters with a 4.0★ track record and headroom, cutting claim-and-abandon) |
 
 **Brief** (paste verbatim every time):
 

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { resolveBrief, resolveClaimPolicyFlags } from './open.js';
+import { resolveBrief, resolveClaimPolicyFlags, resolveMinSellerLevelFlag } from './open.js';
 
 // Open-verb helper coverage — the command wiring itself is exercised by
 // program.integration.test.ts (every group's --help resolves).
@@ -58,6 +58,24 @@ describe('resolveClaimPolicyFlags (S.1190 — --claim-policy 0|1|2, --proven ali
       expect(() => resolveClaimPolicyFlags({ claimPolicy: bad })).toThrow(
         /0 \(Anyone\), 1 \(Proven\) or 2/,
       );
+    }
+  });
+});
+
+describe('resolveMinSellerLevelFlag (S.1192 — --min-seller-level 1|2|3|4)', () => {
+  it('defaults to 0 (no floor) when absent', () => {
+    expect(resolveMinSellerLevelFlag(undefined)).toBe(0);
+  });
+
+  it('accepts 1 through 4', () => {
+    for (const lvl of ['1', '2', '3', '4']) {
+      expect(resolveMinSellerLevelFlag(lvl)).toBe(Number(lvl));
+    }
+  });
+
+  it('refuses 0, 5, garbage and empty (strict digit — Number("") is 0)', () => {
+    for (const bad of ['0', '5', '-1', '2.5', 'two', '']) {
+      expect(() => resolveMinSellerLevelFlag(bad)).toThrow(/1, 2, 3 or 4/);
     }
   });
 });

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -33,6 +33,8 @@ import {
   listOpenJobs,
   meetsClaimPolicy,
   postOpenJob,
+  preflightClaimOpening,
+  sellerLevelLabel,
   MAX_JOB_USDC,
   OPENING_CLAIM_POLICY_ANY_ACTIVE,
   OPENING_CLAIM_POLICY_PROVEN,
@@ -100,6 +102,18 @@ export function resolveClaimPolicyFlags(opts: {
     : OPENING_CLAIM_POLICY_ANY_ACTIVE;
 }
 
+/** S.1192 — `--min-seller-level 1|2|3|4` (absent = 0, no floor). Strict
+ *  digit match, same guard class as the claim-policy flag. */
+export function resolveMinSellerLevelFlag(raw?: string): number {
+  if (raw === undefined) {
+    return 0;
+  }
+  if (!/^[1-4]$/.test(raw.trim())) {
+    throw new Error('--min-seller-level must be 1, 2, 3 or 4 (omit for no floor).');
+  }
+  return Number(raw.trim());
+}
+
 function statusColor(status: OpenJobRow['status']): string {
   if (status === 'open') return pc.green(status);
   if (status === 'claimed') return pc.cyan(status);
@@ -140,6 +154,10 @@ export function registerOpenVerbs(group: Command) {
       `Who may claim: 0 Anyone (default) · 1 Proven (≥${PROVEN_MIN_REVIEWS} distinct buyers' reviews) · 2 Proven · 4★+ (adds a 4.0★ average); claiming stays instant and $0 under every policy`,
     )
     .option('--proven', 'DEPRECATED — same as --claim-policy 1')
+    .option(
+      '--min-seller-level <level>',
+      'Minimum seller Level to claim: 1–4 (default none) — Level 2 = Proven, 3 = 4.0★+ average, 4 = 20+ reviews; independent of --claim-policy (S.1192)',
+    )
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(
@@ -151,6 +169,7 @@ export function registerOpenVerbs(group: Command) {
         openFor: string;
         claimPolicy?: string;
         proven?: boolean;
+        minSellerLevel?: string;
         key?: string;
         api?: string;
       }) => {
@@ -162,6 +181,7 @@ export function registerOpenVerbs(group: Command) {
           }
           const brief = await resolveBrief(opts.brief);
           const claimPolicy = resolveClaimPolicyFlags(opts);
+          const minSellerLevel = resolveMinSellerLevelFlag(opts.minSellerLevel);
           // The budget escrows ON-CHAIN at post — a real outflow from the
           // buyer's wallet, so it belongs under the same cap as a hire.
           // (Claiming is free and is never recorded as spend.)
@@ -174,6 +194,7 @@ export function registerOpenVerbs(group: Command) {
             slaMinutes: Math.round(parseDuration(opts.sla) / 60_000),
             openHours: parseDuration(opts.openFor) / 3_600_000,
             claimPolicy,
+            ...(minSellerLevel > 0 ? { minSellerLevel } : {}),
           });
           recordSpendIfLanded(maxUsdc, digest);
           const openingId = await resolveCreated(digest, '::opening::Opening<');
@@ -188,6 +209,11 @@ export function registerOpenVerbs(group: Command) {
           if (claimPolicy !== OPENING_CLAIM_POLICY_ANY_ACTIVE) {
             printInfo(
               `${claimPolicyLabel(claimPolicy)} gate on: ${claimPolicyRequirement(claimPolicy)}`,
+            );
+          }
+          if (minSellerLevel > 0) {
+            printInfo(
+              `${sellerLevelLabel(minSellerLevel)}+ floor on: only sellers at that effective Level can claim.`,
             );
           }
           printBlank();
@@ -301,15 +327,20 @@ export function registerOpenVerbs(group: Command) {
         // missing opening or unconfigured board falls through to the
         // server's own checks.
         const live = await getOpening(getSuiClient(), id.trim()).catch(() => null);
-        if (live && live.claimPolicy !== 0 && A2A_SCORE_BOARD_ID) {
+        if (live && A2A_SCORE_BOARD_ID) {
+          // S.1192: one preflight covers all three gates — claim policy,
+          // the active-job cap on the claimer's effective Level, and the
+          // opening's Level floor. Best-effort: a read hiccup falls
+          // through to the server's own checks.
           const score = await getAgentScore(getSuiClient(), agent.address()).catch(() => null);
-          if (!meetsClaimPolicy(score, live.claimPolicy)) {
+          const pf = preflightClaimOpening(score, live);
+          if (!pf.valid) {
             const have = score
-              ? `${score.reviewCount} review${score.reviewCount === 1 ? '' : 's'} from ${score.distinctBuyers} distinct buyer${score.distinctBuyers === 1 ? '' : 's'}, ${score.averageStars}★ avg`
+              ? `${score.reviewCount} review${score.reviewCount === 1 ? '' : 's'} from ${score.distinctBuyers} distinct buyer${score.distinctBuyers === 1 ? '' : 's'}, ${score.averageStars}★ avg, ${score.activeSellerJobs} active claimed job${score.activeSellerJobs === 1 ? '' : 's'}`
               : 'no on-chain reviews yet';
             throw new Error(
-              `${claimPolicyRequirement(live.claimPolicy)} Your wallet has ${have}. ` +
-                'Earn reviews on Anyone openings first: t2 job board',
+              `${pf.error} Your wallet has ${have}. ` +
+                'Find claimable work: t2 job board',
             );
           }
         }

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -184,7 +184,7 @@ describe('B — intent assert', () => {
     // opening never existed in the original package — a tx claiming it does
     // is not ours.
     const b64 = await buildTxB64(
-      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::opening::claim`,
+      `${MAINNET_A2A_ESCROW_PACKAGE_ID}::opening::claim_v2`,
     );
     expect(() => assertTxMatchesIntent(b64, { action: 'open-claim' })).toThrow(
       /targets package/,
@@ -193,7 +193,7 @@ describe('B — intent assert', () => {
 
   it('accepts the open-board verbs against the opening package', async () => {
     const b64 = await buildTxB64(
-      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`,
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim_v2`,
     );
     expect(() =>
       assertTxMatchesIntent(b64, { action: 'open-claim' }),
@@ -222,7 +222,13 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
   const REAL_TARGETS: [string, string][] = [
     ['create', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::create`],
     ['deliver', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::deliver`],
-    ['release', `${MAINNET_A2A_ESCROW_PACKAGE_ID}::escrow::release`],
+    // S.1192: release settles through reputation::release_v2 (active
+    // counter rides the money); create_empty_score is its precursor too.
+    ['release', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::release_v2`],
+    [
+      'release',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::create_empty_score`,
+    ],
     // S.1063: reject/refund settle through reputation (outcome counters);
     // create_empty_score is the allowlisted precursor on both actions.
     ['reject', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::reject_v2`],
@@ -244,15 +250,20 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
     ['decline', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::escrow::decline`],
     [
       'open-create',
-      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open`,
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open_v2`,
     ],
-    ['open-claim', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim`],
-    // S.1054: Proven openings claim via claim_proven; buyer review stars
-    // land on-chain via the reputation module (both entries — the first
-    // review a seller ever gets lazily creates their AgentScore).
+    ['open-claim', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim_v2`],
+    // S.1192: Proven openings claim via claim_proven_v2; the scoreless
+    // claimer's precursor rides the same action cross-module. Buyer review
+    // stars land on-chain via the reputation module (both entries — the
+    // first review a seller ever gets lazily creates their AgentScore).
     [
       'open-claim',
-      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim_proven`,
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::claim_proven_v2`,
+    ],
+    [
+      'open-claim',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::create_empty_score`,
     ],
     [
       'job-review',
@@ -365,7 +376,7 @@ describe('B — framework coin prelude around a funded create (S.980)', () => {
     const b64 = await buildMultiTxB64((tx) => {
       tx.moveCall({ target: '0x2::coin::redeem_funds', arguments: [] });
       tx.moveCall({
-        target: `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open`,
+        target: `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::create_open_v2`,
         arguments: [],
       });
     });

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -47,11 +47,11 @@ export const ALLOW_UNTRUSTED_FLAG = '--allow-untrusted-api';
  *    buildDeclineJobTx      → OPENING pkg :: escrow  :: decline   (v3)
  *    buildCancelOpeningTx   → OPENING pkg :: opening :: cancel_open
  *    buildRefundUnclaimedTx → OPENING pkg :: opening :: refund_unclaimed
- *    buildOpenJobTx         → OPENING pkg :: opening :: create_open
- *    buildClaimOpeningTx    → OPENING pkg :: opening :: claim
+ *    buildOpenJobTx         → OPENING pkg :: opening :: create_open_v2
+ *    buildClaimOpeningTx    → OPENING pkg :: opening :: claim_v2|claim_proven_v2
  *    buildCreateJobTx       → ESCROW  pkg :: escrow  :: create
  *    buildDeliverJobTx      → ESCROW  pkg :: escrow  :: deliver
- *    jobCall                → ESCROW  pkg :: escrow  :: release|refund|reject
+ *    buildReleaseJobTx      → OPENING pkg :: reputation :: release_v2
  *
  *  `decline` is the one that looks like a typo and isn't: it lives in the
  *  OPENING package but the `escrow` module, because it shipped in the v3
@@ -87,10 +87,13 @@ const ACTION_TARGETS: Record<
     module: 'escrow',
     functions: ['deliver'],
   },
+  // S.1192: release settles through `reputation::release_v2` (the active
+  // counter rides the money); `create_empty_score` is the allowlisted
+  // precursor for a scoreless seller — same hop as reject/refund.
   release: {
-    pkgs: [MAINNET_A2A_ESCROW_PACKAGE_ID, MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
-    module: 'escrow',
-    functions: ['release'],
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'reputation',
+    functions: ['release_v2', 'create_empty_score'],
   },
   // S.1063: reject/refund settle through the reputation module so protocol
   // outcomes land on scores; `create_empty_score` is the allowlisted
@@ -113,16 +116,20 @@ const ACTION_TARGETS: Record<
   },
   // Open board.
   'open-create': {
+    // S.1192: every post rides create_open_v2 (adds the min_seller_level
+    // DF write); the v1 door is a dead abort stub.
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
     module: 'opening',
-    functions: ['create_open'],
+    functions: ['create_open_v2'],
   },
   'open-claim': {
-    // S.1054: Proven openings (claim_policy 1/2) claim via `claim_proven`
-    // (adds the claimer's own AgentScore as an immutable input).
+    // S.1192: every claim carries the claimer's own &mut AgentScore
+    // (claim_v2 for Anyone, claim_proven_v2 for Proven 1/2), with
+    // `create_empty_score` as the allowlisted precursor when the score
+    // doesn't exist yet.
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
     module: 'opening',
-    functions: ['claim', 'claim_proven'],
+    functions: ['claim_v2', 'claim_proven_v2', 'reputation::create_empty_score'],
   },
   'open-cancel': {
     pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
@@ -326,12 +333,13 @@ export function assertTxMatchesIntent(
   let foundIntent = false;
   for (const call of calls) {
     if (expectedPkgs.includes(normalizeSuiAddress(call.pkg))) {
-      if (call.module !== expected.module) {
-        throw new IntentMismatchError(
-          `Refusing to sign: "${intent.action}" should call ${expected.module}, but the transaction calls ${call.module}.`,
-        );
-      }
-      if (!expected.functions.includes(call.fn)) {
+      // S.1192: `functions` entries are bare names in the action's module,
+      // or `module::fn`-qualified for cross-module precursors (open-claim's
+      // `reputation::create_empty_score` hop rides an `opening` action).
+      const matches =
+        expected.functions.includes(`${call.module}::${call.fn}`) ||
+        (call.module === expected.module && expected.functions.includes(call.fn));
+      if (!matches) {
         throw new IntentMismatchError(
           `Refusing to sign: "${intent.action}" should call ${expected.module}::${expected.functions.join('|')}, but the transaction calls ${call.module}::${call.fn}.`,
         );

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -147,8 +147,18 @@ export {
   deriveAgentScoreId,
   getAgentScore,
   meetsClaimPolicy,
+  SELLER_LEVEL_ACTIVE_CAPS,
+  NO_DELIVERY_REGRESSION_FLOOR,
+  LEVEL4_MIN_REVIEWS,
+  LEVEL4_MAX_NO_DELIVERY,
+  sellerLevel,
+  effectiveSellerLevel,
+  activeCapForLevel,
+  meetsMinSellerLevel,
+  sellerLevelLabel,
+  preflightClaimOpening,
 } from './wallet/reputation.js';
-export type { AgentScore } from './wallet/reputation.js';
+export type { AgentScore, SellerLevel } from './wallet/reputation.js';
 
 // Commerce API client (agent services + content-addressed job specs) —
 // browser-safe (WebCrypto hashing, fetch only). Console surfaces share the

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -166,6 +166,7 @@ export {
   A2A_ESCROW_PACKAGE_V6_ID,
   A2A_ESCROW_PACKAGE_V7_ID,
   A2A_ESCROW_PACKAGE_V8_ID,
+  A2A_ESCROW_PACKAGE_V10_ID,
   MAX_OPEN_WINDOW_MS,
   OPENING_CLAIM_POLICY_ANY_ACTIVE,
   OPENING_CLAIM_POLICY_PROVEN,
@@ -194,8 +195,18 @@ export {
   deriveAgentScoreId,
   getAgentScore,
   meetsClaimPolicy,
+  SELLER_LEVEL_ACTIVE_CAPS,
+  NO_DELIVERY_REGRESSION_FLOOR,
+  LEVEL4_MIN_REVIEWS,
+  LEVEL4_MAX_NO_DELIVERY,
+  sellerLevel,
+  effectiveSellerLevel,
+  activeCapForLevel,
+  meetsMinSellerLevel,
+  sellerLevelLabel,
+  preflightClaimOpening,
 } from './wallet/reputation.js';
-export type { AgentScore } from './wallet/reputation.js';
+export type { AgentScore, SellerLevel } from './wallet/reputation.js';
 export {
   assertBuyerRequirements,
   DEFAULT_COMMERCE_API_BASE,

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -73,6 +73,9 @@ export interface OpenJobRow {
    *  (render with `claimPolicyLabel`, never the raw number). Absent on
    *  pre-S.1054 rows = 0. */
   claimPolicy?: number;
+  /** S.1192 — minimum EFFECTIVE seller level to claim (render with
+   *  `sellerLevelLabel`). Absent on pre-S.1192 rows = 0 (no floor). */
+  minSellerLevel?: number;
   createdAtMs: number;
   updatedAtMs: number;
 }
@@ -205,6 +208,9 @@ export function postOpenJob(
     openHours?: number;
     /** S.1054 — 0 Anyone (default), 1 Proven, 2 Proven · 4★+. */
     claimPolicy?: number;
+    /** S.1192 — minimum EFFECTIVE seller level to claim: 0 none
+     *  (default), 1..4. Independent of claimPolicy. */
+    minSellerLevel?: number;
   },
 ): Promise<string> {
   return sponsoredOpeningVerb(base, signer, 'open-create', input);

--- a/packages/sdk/src/wallet/job.test.ts
+++ b/packages/sdk/src/wallet/job.test.ts
@@ -172,23 +172,24 @@ const SCORE_ID = `0x${'e'.repeat(64)}`;
 const REGISTRY_ID = `0x${'f'.repeat(64)}`;
 
 describe('single-object verb builders', () => {
-  it.each([
-    ['deliver', () => buildDeliverJobTx(JOB_ID, '0xabcd')],
-    ['release', () => buildReleaseJobTx(JOB_ID)],
-  ])('%s targets the escrow module', (fn, build) => {
-    const tx = build();
-    const calls = tx
-      .getData()
-      .commands.filter((c) => 'MoveCall' in (c as Record<string, unknown>)) as Array<{
-      MoveCall: { module: string; function: string };
-    }>;
-    expect(calls).toHaveLength(1);
-    expect(calls[0].MoveCall.module).toBe('escrow');
-    expect(calls[0].MoveCall.function).toBe(fn);
-  });
+  it.each([['deliver', () => buildDeliverJobTx(JOB_ID, '0xabcd')]])(
+    '%s targets the escrow module',
+    (fn, build) => {
+      const tx = build();
+      const calls = tx
+        .getData()
+        .commands.filter((c) => 'MoveCall' in (c as Record<string, unknown>)) as Array<{
+        MoveCall: { module: string; function: string };
+      }>;
+      expect(calls).toHaveLength(1);
+      expect(calls[0].MoveCall.module).toBe('escrow');
+      expect(calls[0].MoveCall.function).toBe(fn);
+    },
+  );
 
   // S.1063: reject/refund settle through the reputation module (outcome
-  // counters) — never the deprecated escrow doors.
+  // counters); S.1192 adds release_v2 (the active counter rides the
+  // money) — never the deprecated escrow doors.
   it.each([
     [
       'reject_v2',
@@ -204,7 +205,8 @@ describe('single-object verb builders', () => {
         }),
     ],
     ['refund_v2', () => buildRefundJobTx(JOB_ID, { sellerScoreId: SCORE_ID })],
-  ])('%s targets the reputation module (S.1063)', (fn, build) => {
+    ['release_v2', () => buildReleaseJobTx(JOB_ID, { sellerScoreId: SCORE_ID })],
+  ])('%s targets the reputation module (S.1063/S.1192)', (fn, build) => {
     const tx = build();
     const calls = tx
       .getData()

--- a/packages/sdk/src/wallet/job.ts
+++ b/packages/sdk/src/wallet/job.ts
@@ -290,15 +290,6 @@ export function buildDeclineJobTx(jobId: string): Transaction {
   return tx;
 }
 
-function jobCall(jobId: string, fn: 'release'): Transaction {
-  const tx = new Transaction();
-  tx.moveCall({
-    target: `${A2A_ESCROW_LATEST_PACKAGE_ID}::${MODULE}::${fn}`,
-    typeArguments: [USDC_TYPE],
-    arguments: [tx.object(jobId), feeConfigArg(tx), tx.object(CLOCK_ID)],
-  });
-  return tx;
-}
 
 /** Buyer rejects delivered work — S.1063: settles through
  *  `reputation::reject_v2` (Passport buyer) or `reject_v2_agent_buyer`
@@ -372,9 +363,29 @@ export function buildDeliverJobTx(jobId: string, deliveryHash: string): Transact
   return tx;
 }
 
-/** Buyer accepts (or anyone, once the review window lapsed) → funds to seller. */
-export function buildReleaseJobTx(jobId: string): Transaction {
-  return jobCall(jobId, 'release');
+/** Buyer accepts (or anyone, once the review window lapsed) → funds to
+ *  seller. S.1192: settles through `reputation::release_v2` — the
+ *  SELLER's score (derive with `deriveAgentScoreId`) rides along so a
+ *  board-claimed job frees its active seat with the money. Hire jobs pass
+ *  the same score; the contract's `ClaimedJobKey` marker decides whether
+ *  a decrement lands. A scoreless seller needs the `create_empty_score`
+ *  precursor first (same hop as reject/refund since S.1063). */
+export function buildReleaseJobTx(
+  jobId: string,
+  v2: { sellerScoreId: string },
+): Transaction {
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${A2A_ESCROW_LATEST_PACKAGE_ID}::reputation::release_v2`,
+    typeArguments: [USDC_TYPE],
+    arguments: [
+      tx.object(jobId),
+      tx.object(v2.sellerScoreId),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
+  });
+  return tx;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/src/wallet/opening.test.ts
+++ b/packages/sdk/src/wallet/opening.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { MAX_JOB_USDC, MIN_JOB_USDC } from './job.js';
-import { preflightCreateOpening, type OpeningTerms } from './opening.js';
+import { buildClaimOpeningTx, preflightCreateOpening, type OpeningTerms } from './opening.js';
 
 function terms(overrides: Partial<OpeningTerms> = {}): OpeningTerms {
   return {
@@ -69,5 +69,60 @@ describe('preflightCreateOpening claim policy (S.1054)', () => {
     const pf = preflightCreateOpening(terms({ claimPolicy: 3 }));
     expect(pf.valid).toBe(false);
     expect(pf.error).toMatch(/Proven/);
+  });
+});
+
+describe('preflightCreateOpening minSellerLevel (S.1192)', () => {
+  it('accepts 0 (default) through 4', () => {
+    for (const minSellerLevel of [0, 1, 2, 3, 4]) {
+      expect(preflightCreateOpening(terms({ minSellerLevel })).valid).toBe(true);
+    }
+    expect(preflightCreateOpening(terms({})).valid).toBe(true);
+  });
+
+  it('refuses 5, negatives, and fractions', () => {
+    for (const minSellerLevel of [5, -1, 1.5]) {
+      const pf = preflightCreateOpening(terms({ minSellerLevel }));
+      expect(pf.valid).toBe(false);
+      if (!pf.valid) expect(pf.error).toMatch(/minSellerLevel/);
+    }
+  });
+});
+
+describe('buildClaimOpeningTx v2 routing (S.1192)', () => {
+  const OPENING_ID = `0x${'a'.repeat(64)}`;
+  const REGISTRY_ID = `0x${'b'.repeat(64)}`;
+  const SCORE_ID = `0x${'c'.repeat(64)}`;
+
+  function claimTarget(claimPolicy: number): string {
+    const tx = buildClaimOpeningTx({
+      openingId: OPENING_ID,
+      registryId: REGISTRY_ID,
+      scoreId: SCORE_ID,
+      claimPolicy,
+    });
+    const calls = tx
+      .getData()
+      .commands.filter((c) => 'MoveCall' in (c as Record<string, unknown>)) as Array<{
+      MoveCall: { module: string; function: string };
+    }>;
+    expect(calls).toHaveLength(1);
+    return `${calls[0].MoveCall.module}::${calls[0].MoveCall.function}`;
+  }
+
+  it('policy 0 → claim_v2; policies 1/2 → claim_proven_v2 (never the dead v1 doors)', () => {
+    expect(claimTarget(0)).toBe('opening::claim_v2');
+    expect(claimTarget(1)).toBe('opening::claim_proven_v2');
+    expect(claimTarget(2)).toBe('opening::claim_proven_v2');
+  });
+
+  it('refuses a missing scoreId in English (every claim moves the counter)', () => {
+    expect(() =>
+      buildClaimOpeningTx({
+        openingId: OPENING_ID,
+        registryId: REGISTRY_ID,
+        scoreId: '',
+      }),
+    ).toThrow(/AgentScore/);
   });
 });

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -1,4 +1,5 @@
 import { Transaction } from '@mysten/sui/transactions';
+import { deriveDynamicFieldID } from '@mysten/sui/utils';
 import { T2000Error } from '../errors.js';
 import { USDC_DECIMALS } from '../constants.js';
 import { USDC_TYPE } from '../token-registry.js';
@@ -92,6 +93,15 @@ export const A2A_ESCROW_PACKAGE_V7_ID =
  *  A DEFINING-id anchor like V2/V3/V6/V7 — never moves again. */
 export const A2A_ESCROW_PACKAGE_V8_ID =
   '0x1595b80bc05a03607f3908702c866ca63cf961025b4263b5ecbe419e07f8ff31';
+/** v10 (S.1192) — defining id for the seller-level surface: the
+ *  ActiveSellerJobsChanged/OpeningCreatedV2 events and the
+ *  ActiveSellerJobsKey/MinSellerLevelKey/TierActiveCapKey/ClaimedJobKey
+ *  DF key types. ⚠️ PLACEHOLDER '' until the founder upgrade broadcasts
+ *  (RUNBOOK_S1192 §4 pins the real id in the cutover commit, BEFORE the
+ *  npm release) — while empty, every V10-pinned DF read returns 0, which
+ *  is the honest pre-cutover value. Never moves again after pinning. */
+export const A2A_ESCROW_PACKAGE_V10_ID =
+  process.env.A2A_ESCROW_PACKAGE_V10_ID ?? '';
 
 const CLOCK_ID = '0x6';
 const MODULE = 'opening';
@@ -145,6 +155,11 @@ export interface OpeningTerms {
    *  2 Proven · 4★+. Never changes HOW a claim works: still FCFS, still
    *  $0. 3+ aborts on-chain until defined. */
   claimPolicy?: number;
+  /** S.1192 — minimum EFFECTIVE seller level to claim: 0 none (default),
+   *  1..4 (Level floor, independent of claimPolicy — a post can require
+   *  Proven · 4★+ AND Level 2+, or either alone). Stored as a DF on the
+   *  Opening, enforced on-chain at claim. */
+  minSellerLevel?: number;
 }
 
 /** Every claim policy `create_open` accepts (S.1054). */
@@ -214,6 +229,16 @@ export function preflightCreateOpening(terms: OpeningTerms): {
         'anything else aborts on-chain.',
     };
   }
+  const minLevel = terms.minSellerLevel ?? 0;
+  if (!Number.isInteger(minLevel) || minLevel < 0 || minLevel > 4) {
+    return {
+      valid: false,
+      code: 'INVALID_INPUT',
+      error:
+        'minSellerLevel must be 0 (no floor) or 1–4 (Level 1–4) — ' +
+        'anything else aborts on-chain (S.1192).',
+    };
+  }
   return { valid: true };
 }
 
@@ -235,7 +260,9 @@ export async function buildCreateOpeningTx({
     allowSwapAll: false,
   });
   tx.moveCall({
-    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::create_open`,
+    // S.1192: create_open is a dead abort stub after the v10 migrate —
+    // every post rides v2 (adds the min_seller_level DF write).
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::create_open_v2`,
     typeArguments: [USDC_TYPE],
     arguments: [
       coin,
@@ -245,6 +272,7 @@ export async function buildCreateOpeningTx({
       tx.pure.u64(terms.reviewWindowMs),
       tx.pure.u64(terms.rejectSplitBps),
       tx.pure.u8(terms.claimPolicy ?? OPENING_CLAIM_POLICY_ANY_ACTIVE),
+      tx.pure.u8(terms.minSellerLevel ?? 0),
       feeConfigArg(tx),
       tx.object(CLOCK_ID),
     ],
@@ -256,38 +284,47 @@ export async function buildCreateOpeningTx({
  *  `registryId` = the shared `agent_id::registry::Registry` object
  *  (callers pass `AGENT_ID_REGISTRY_ID` from `@t2000/id` — single source).
  *
- *  S.1054: for a PROVEN opening (`claimPolicy` 1/2) pass `scoreId` — the
- *  claimer's own `AgentScore` (compute with `deriveAgentScoreId`) — and the
- *  call routes to `claim_proven`, which reads it immutably. Omitting it on
- *  a Proven opening aborts on-chain; preflight with `meetsClaimPolicy`
- *  first for an English refusal. */
+ *  S.1192: EVERY claim — policy 0 included — passes `scoreId`, the
+ *  claimer's own `AgentScore` (compute with `deriveAgentScoreId`): the
+ *  active-cap + level-floor gates read it and the in-flight counter
+ *  writes to it. A claimer with no score yet runs the permissionless
+ *  `buildCreateEmptyScoreTx` as its own PRECURSOR tx first (a shared
+ *  object cannot be created and used in one tx — the S.1063 sponsored
+ *  precursor hop; an empty score grants nothing and reads as Level 1).
+ *  `claimPolicy` (the OPENING's policy, from the board row or
+ *  `getOpening`) routes 0 → `claim_v2`, 1/2 → `claim_proven_v2`.
+ *  Preflight with `preflightClaimOpening` first for English refusals. */
 export function buildClaimOpeningTx({
   openingId,
   registryId,
   scoreId,
+  claimPolicy = OPENING_CLAIM_POLICY_ANY_ACTIVE,
 }: {
   openingId: string;
   registryId: string;
-  scoreId?: string;
+  scoreId: string;
+  claimPolicy?: number;
 }): Transaction {
+  if (!scoreId) {
+    throw new T2000Error(
+      'INVALID_INPUT',
+      "Claiming needs the claimer's own AgentScore id (S.1192 — every claim " +
+        'moves the active-job counter). Derive it with deriveAgentScoreId; ' +
+        'create it first with buildCreateEmptyScoreTx when it does not exist yet.',
+    );
+  }
+  const proven = claimPolicy !== OPENING_CLAIM_POLICY_ANY_ACTIVE;
   const tx = new Transaction();
   tx.moveCall({
-    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::${scoreId ? 'claim_proven' : 'claim'}`,
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::${proven ? 'claim_proven_v2' : 'claim_v2'}`,
     typeArguments: [USDC_TYPE],
-    arguments: scoreId
-      ? [
-          tx.object(openingId),
-          tx.object(registryId),
-          tx.object(scoreId),
-          feeConfigArg(tx),
-          tx.object(CLOCK_ID),
-        ]
-      : [
-          tx.object(openingId),
-          tx.object(registryId),
-          feeConfigArg(tx),
-          tx.object(CLOCK_ID),
-        ],
+    arguments: [
+      tx.object(openingId),
+      tx.object(registryId),
+      tx.object(scoreId),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
   });
   return tx;
 }
@@ -324,7 +361,35 @@ export interface Opening {
   reviewWindowMs: number;
   rejectSplitBps: number;
   claimPolicy: number;
+  /** S.1192 — minimum EFFECTIVE seller level to claim (0 = none; DF read,
+   *  best-effort: 0 for every pre-S.1192 opening, when the V10 pin isn't
+   *  set yet, or on a read hiccup — Move is the enforcement). */
+  minSellerLevel: number;
   createdAtMs: number;
+}
+
+/** Best-effort read of the `MinSellerLevelKey` DF off an Opening's UID —
+ *  same shape as reputation's counter reads: 0 when absent/unpinned. */
+async function readMinSellerLevelDf(
+  client: SuiCoreClient,
+  openingId: string,
+): Promise<number> {
+  if (!A2A_ESCROW_PACKAGE_V10_ID) return 0;
+  try {
+    const fieldId = deriveDynamicFieldID(
+      openingId,
+      `${A2A_ESCROW_PACKAGE_V10_ID}::${MODULE}::MinSellerLevelKey`,
+      new Uint8Array([0]),
+    );
+    const resp = await client.core.getObject({
+      objectId: fieldId,
+      include: { json: true },
+    });
+    const json = resp?.object?.json as { value?: unknown } | null | undefined;
+    return Number(json?.value ?? 0);
+  } catch {
+    return 0;
+  }
 }
 
 function bytesToHex(bytes: number[] | Uint8Array): string {
@@ -346,6 +411,7 @@ export async function getOpening(
   if (!json || !objType.includes(`::${MODULE}::Opening<`)) {
     return null;
   }
+  const minSellerLevel = await readMinSellerLevelDf(client, openingId);
   return {
     id: openingId,
     buyer: String(json.buyer),
@@ -357,6 +423,7 @@ export async function getOpening(
     reviewWindowMs: Number(json.review_window_ms),
     rejectSplitBps: Number(json.reject_split_bps),
     claimPolicy: Number(json.claim_policy ?? 0),
+    minSellerLevel,
     createdAtMs: Number(json.created_at_ms ?? 0),
   };
 }

--- a/packages/sdk/src/wallet/reputation.test.ts
+++ b/packages/sdk/src/wallet/reputation.test.ts
@@ -8,6 +8,14 @@ import {
   claimPolicyRequirement,
   deriveAgentScoreId,
   meetsClaimPolicy,
+  activeCapForLevel,
+  effectiveSellerLevel,
+  meetsMinSellerLevel,
+  NO_DELIVERY_REGRESSION_FLOOR,
+  preflightClaimOpening,
+  SELLER_LEVEL_ACTIVE_CAPS,
+  sellerLevel,
+  sellerLevelLabel,
   type AgentScore,
 } from './reputation.js';
 
@@ -30,6 +38,7 @@ function score(
     rejectedAfterDelivery: 0,
     noDelivery: 0,
     asBuyerRejected: 0,
+    activeSellerJobs: 0,
   };
 }
 
@@ -123,5 +132,79 @@ describe('review tx builders', () => {
     for (const stars of [0, 6, 4.5, Number.NaN]) {
       expect(() => buildSubmitReviewTx({ scoreId: BOARD, jobId: JOB, stars })).toThrow(/1-5/);
     }
+  });
+});
+
+describe('seller levels (S.1192) — mirror the Move bars', () => {
+  it('null / empty score = Level 1', () => {
+    expect(sellerLevel(null)).toBe(1);
+    expect(sellerLevel(score(0, 0))).toBe(1);
+    expect(effectiveSellerLevel(null)).toBe(1);
+  });
+
+  it('Level 2 = Proven (3 distinct), Level 3 = 4.0★+, Level 4 = 20 reviews + ≤2 no-delivery', () => {
+    expect(sellerLevel(score(3, 9))).toBe(2); // 3.0★ avg, proven
+    expect(sellerLevel(score(3, 12))).toBe(3); // exactly 4.0★
+    expect(sellerLevel(score(20, 80))).toBe(4); // 20 reviews at 4.0★
+    expect(sellerLevel({ ...score(20, 80), noDelivery: 3 })).toBe(3); // reliability bar
+    expect(sellerLevel(score(19, 76))).toBe(3); // one review short of L4
+  });
+
+  it('regression: no_delivery >= 3 floors the EFFECTIVE level to 1', () => {
+    const regressed = { ...score(20, 100), noDelivery: NO_DELIVERY_REGRESSION_FLOOR };
+    expect(sellerLevel(regressed)).toBe(3); // stars still say 3 (L4 bar needs ≤2)
+    expect(effectiveSellerLevel(regressed)).toBe(1);
+    expect(meetsMinSellerLevel(regressed, 2)).toBe(false);
+    expect(meetsMinSellerLevel(regressed, 1)).toBe(true);
+  });
+
+  it('caps ladder 4/10/20/30 + labels', () => {
+    expect(SELLER_LEVEL_ACTIVE_CAPS).toEqual([4, 10, 20, 30]);
+    expect(activeCapForLevel(1)).toBe(4);
+    expect(activeCapForLevel(4)).toBe(30);
+    expect(sellerLevelLabel(2)).toBe('Level 2');
+  });
+});
+
+describe('preflightClaimOpening (S.1192) — English before the rail', () => {
+  it('fresh seller on a floor-less Anyone opening passes', () => {
+    expect(preflightClaimOpening(null, { claimPolicy: 0 }).valid).toBe(true);
+    expect(preflightClaimOpening(score(0, 0), { claimPolicy: 0 }).valid).toBe(true);
+  });
+
+  it('at the cap: refuses with Active: N/cap capacity language, not a ban', () => {
+    const capped = { ...score(0, 0), activeSellerJobs: 4 };
+    const pf = preflightClaimOpening(capped, { claimPolicy: 0 });
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/Active: 4\/4/);
+    expect(pf.error).toMatch(/Finish|deadline refund/);
+    // One under the cap still claims.
+    expect(
+      preflightClaimOpening({ ...score(0, 0), activeSellerJobs: 3 }, { claimPolicy: 0 }).valid,
+    ).toBe(true);
+  });
+
+  it('the cap follows the EFFECTIVE level (a Level 2 seller gets 10 seats)', () => {
+    const proven = { ...score(3, 9), activeSellerJobs: 9 };
+    expect(preflightClaimOpening(proven, { claimPolicy: 0 }).valid).toBe(true);
+    expect(
+      preflightClaimOpening({ ...proven, activeSellerJobs: 10 }, { claimPolicy: 0 }).valid,
+    ).toBe(false);
+  });
+
+  it('min level floor refuses below-floor sellers by name', () => {
+    const pf = preflightClaimOpening(score(0, 0), { claimPolicy: 0, minSellerLevel: 2 });
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/Level 2\+/);
+    expect(pf.error).toMatch(/Level 1/);
+    expect(
+      preflightClaimOpening(score(3, 9), { claimPolicy: 0, minSellerLevel: 2 }).valid,
+    ).toBe(true);
+  });
+
+  it('claim policy still gates first (S.1054 order preserved)', () => {
+    const pf = preflightClaimOpening(null, { claimPolicy: 2 });
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/distinct buyers and a 4\.0★ average/);
   });
 });

--- a/packages/sdk/src/wallet/reputation.ts
+++ b/packages/sdk/src/wallet/reputation.ts
@@ -9,6 +9,7 @@ import {
   A2A_ESCROW_LATEST_PACKAGE_ID,
   A2A_ESCROW_PACKAGE_V7_ID,
   A2A_ESCROW_PACKAGE_V8_ID,
+  A2A_ESCROW_PACKAGE_V10_ID,
   feeConfigArg,
 } from './opening.js';
 
@@ -57,6 +58,22 @@ export const PROVEN_MIN_AVG_STARS_X10 = 40;
 export const REVIEW_MIN_STARS = 1;
 export const REVIEW_MAX_STARS = 5;
 
+// === Seller levels (S.1192) — mirror `reputation.move`, never copy ===
+/** A seller's capacity label, 1-indexed (buyer copy: "Level 1"…"Level 4").
+ *  Separate from claim policy — an opening can require both. */
+export type SellerLevel = 1 | 2 | 3 | 4;
+/** Default in-flight claimed-job caps per level (index = level − 1).
+ *  Package defaults — the LIVE values are AdminCap-tunable FeeConfig DFs;
+ *  the chain is the enforcement, these feed display + preflight. */
+export const SELLER_LEVEL_ACTIVE_CAPS: readonly number[] = [4, 10, 20, 30];
+/** `noDelivery >= floor` regresses the EFFECTIVE level to 1 (default;
+ *  AdminCap-tunable on-chain). */
+export const NO_DELIVERY_REGRESSION_FLOOR = 3;
+/** Level 4 additionally needs ≥ this many reviews… */
+export const LEVEL4_MIN_REVIEWS = 20;
+/** …and ≤ this many no-delivery outcomes. */
+export const LEVEL4_MAX_NO_DELIVERY = 2;
+
 function boardIdOrThrow(boardId?: string): string {
   const id = boardId ?? A2A_SCORE_BOARD_ID;
   if (!id) {
@@ -96,6 +113,9 @@ export interface AgentScore {
   rejectedAfterDelivery: number;
   noDelivery: number;
   asBuyerRejected: number;
+  /** S.1192 — live board-claimed jobs in flight (funded + delivered).
+   *  0 when the DF is absent (soft start) or pre-V10-pin. */
+  activeSellerJobs: number;
 }
 
 /** Read one u64 counter DF off a score's UID (0 when the DF is absent,
@@ -144,12 +164,13 @@ export async function getAgentScore(
   }
   const reviewCount = Number(json.review_count ?? 0);
   const starsSum = Number(json.stars_sum ?? 0);
-  const [distinctBuyers, rejectedAfterDelivery, noDelivery, asBuyerRejected] =
+  const [distinctBuyers, rejectedAfterDelivery, noDelivery, asBuyerRejected, activeSellerJobs] =
     await Promise.all([
       readCounterDf(client, scoreId, A2A_ESCROW_PACKAGE_V7_ID, 'DistinctCountKey'),
       readCounterDf(client, scoreId, A2A_ESCROW_PACKAGE_V8_ID, 'RejectedAfterDeliveryKey'),
       readCounterDf(client, scoreId, A2A_ESCROW_PACKAGE_V8_ID, 'NoDeliveryKey'),
       readCounterDf(client, scoreId, A2A_ESCROW_PACKAGE_V8_ID, 'AsBuyerRejectedKey'),
+      readCounterDf(client, scoreId, A2A_ESCROW_PACKAGE_V10_ID, 'ActiveSellerJobsKey'),
     ]);
   return {
     id: scoreId,
@@ -161,6 +182,7 @@ export async function getAgentScore(
     rejectedAfterDelivery,
     noDelivery,
     asBuyerRejected,
+    activeSellerJobs,
   };
 }
 
@@ -224,6 +246,90 @@ export function claimPolicyRequirement(claimPolicy: number): string {
     return `Claiming needs at least ${PROVEN_MIN_REVIEWS} reviews from distinct buyers and a 4.0★ average.`;
   }
   return 'Anyone can claim (active Agent ID required).';
+}
+
+// === Seller levels (S.1192) — mirror the Move predicates exactly ===
+
+/** Computed Level 1..4 from on-chain aggregates (`null` score = Level 1,
+ *  the empty-score default). Reuses the SAME predicates the claim
+ *  policies read — one SSOT for every threshold. */
+export function sellerLevel(score: AgentScore | null): SellerLevel {
+  if (!score) return 1;
+  const provenAvg =
+    score.distinctBuyers >= PROVEN_MIN_REVIEWS &&
+    score.starsSum * 10 >= score.reviewCount * PROVEN_MIN_AVG_STARS_X10;
+  if (provenAvg) {
+    return score.reviewCount >= LEVEL4_MIN_REVIEWS &&
+      score.noDelivery <= LEVEL4_MAX_NO_DELIVERY
+      ? 4
+      : 3;
+  }
+  return score.distinctBuyers >= PROVEN_MIN_REVIEWS ? 2 : 1;
+}
+
+/** The level capacity actually gates on: `noDelivery >= floor` regresses
+ *  to Level 1 regardless of stars (reliability caps capacity without
+ *  touching star math). Uses the package-default floor — the live value
+ *  is an AdminCap DF; the chain is the enforcement. */
+export function effectiveSellerLevel(score: AgentScore | null): SellerLevel {
+  if (!score) return 1;
+  if (score.noDelivery >= NO_DELIVERY_REGRESSION_FLOOR) return 1;
+  return sellerLevel(score);
+}
+
+/** Default active-job cap for a level (the live cap is AdminCap-tunable
+ *  on-chain; this feeds display + preflight). */
+export function activeCapForLevel(level: SellerLevel): number {
+  return SELLER_LEVEL_ACTIVE_CAPS[level - 1];
+}
+
+/** Whether this seller clears an opening's `minSellerLevel` floor — on
+ *  the EFFECTIVE level, matching the Move gate. */
+export function meetsMinSellerLevel(score: AgentScore | null, minLevel: number): boolean {
+  if (minLevel <= 0) return true;
+  return effectiveSellerLevel(score) >= minLevel;
+}
+
+/** Human label — every surface uses this, never the raw number. */
+export function sellerLevelLabel(level: number): string {
+  return level >= 1 && level <= 4 ? `Level ${level}` : `Level ? (${level})`;
+}
+
+/** English preflight for a claim (S.1192) — refuse BEFORE the sponsored
+ *  rail instead of surfacing a raw Move abort. Checks, in gate order:
+ *  claim policy (S.1054), the active-job cap on the claimer's effective
+ *  level, then the opening's level floor. Capacity language, not ban
+ *  language — a capped seller finishes work and claims again. */
+export function preflightClaimOpening(
+  score: AgentScore | null,
+  opening: { claimPolicy: number; minSellerLevel?: number },
+): { valid: boolean; error?: string } {
+  if (!meetsClaimPolicy(score, opening.claimPolicy)) {
+    return { valid: false, error: claimPolicyRequirement(opening.claimPolicy) };
+  }
+  const level = effectiveSellerLevel(score);
+  const cap = activeCapForLevel(level);
+  const active = score?.activeSellerJobs ?? 0;
+  if (active >= cap) {
+    return {
+      valid: false,
+      error:
+        `Active: ${active}/${cap} — ${sellerLevelLabel(level)} caps in-flight claimed jobs at ${cap}. ` +
+        'Finish (deliver + settle) a job or wait for a deadline refund, then claim again.',
+    };
+  }
+  const minLevel = opening.minSellerLevel ?? 0;
+  if (!meetsMinSellerLevel(score, minLevel)) {
+    return {
+      valid: false,
+      error:
+        `This opening needs ${sellerLevelLabel(minLevel)}+ — this wallet is ` +
+        `${sellerLevelLabel(level)}. Level 2 = reviews from ${PROVEN_MIN_REVIEWS}+ distinct buyers; ` +
+        'Level 3 adds a 4.0★ average; reliability (no-shows) can regress a level. ' +
+        'Earn it on openings without a floor first.',
+    };
+  }
+  return { valid: true };
 }
 
 function assertStars(stars: number): void {

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -52,7 +52,11 @@ DELIVERED ──reject (buyer, within window)──▶ REJECTED    → split per
 
 The two timeout paths are permissionless cranks: a ghosting buyer can't strand
 a delivering seller, and a no-show seller can never keep committed funds.
-Jobs are capped at **100 USDC**.
+Jobs are capped at **100 USDC**. Sellers carry a per-Level cap on
+in-flight BOARD-CLAIMED jobs (Level 1–4 → 4/10/20/30 seats; Level 2 =
+Proven, 3 = 4.0★+, 4 = 20+ reviews) — at the cap a claim refuses with
+`Active: N/cap` until settled work frees a seat; hires never count, and a
+declined claim keeps its seat occupied, so claim only what you'll deliver.
 
 **Protocol fee: 5%**, enforced by the contract on the seller-bound payout at
 settlement (release, or the seller's share of a reject split). The bps lock
@@ -165,9 +169,10 @@ brief, and budget with your human BEFORE posting — posting moves money.
 
 ```bash
 # 1. Post — this escrows the budget on-chain NOW.
-#    Default claim gate: Anyone (any active Agent ID). Add --proven to
-#    restrict claiming to sellers reviewed by ≥3 distinct buyers. Claiming stays
-#    first-come, instant, and $0 under either policy — Proven filters who
+#    Default claim gate: Anyone (any active Agent ID). --claim-policy 1|2
+#    restricts to Proven (≥3 distinct buyers) / Proven · 4★+ sellers, and
+#    --min-seller-level 1-4 adds an independent Level floor. Claiming stays
+#    first-come, instant, and $0 under every policy — the gates filter who
 #    may race; it is never a buyer-confirm handshake.
 t2 job open --title "Logo sketch" --brief brief.md --max 5 --sla 24h
 


### PR DESCRIPTION
## S.1192 — Seller levels + active caps (Phase C, t2000 half)

Spec: `SPEC_MARKETPLACE_REPUTATION_V2_MASTER.md` § Phase C + `SPEC_MARKETPLACE_REPUTATION_V2_TIERS.md` (LOCKED). **The reputation-v2 program's first Move upgrade** — VERSION **5 → 6**, S.1063 ritual. Runbook (PENDING, written before any broadcast): t2000-internal `spec/runbooks/RUNBOOK_S1192_SELLER_LEVELS.md` (`8ad8496`). Companion audric PR follows the npm publish.

### ⚠️ Founder upgrade + migrate — NOT executed, checklist

1. Merge this PR → `sui move test` on main (129/129) → `sui client upgrade` (UpgradeCap `0x404975a0…9b46`; expect Published.toml **version 10**)
2. **Immediately** `escrow::migrate(AdminCap, FeeConfig)` → FeeConfig VERSION **6** (v9 bytecode dies via EWrongVersion)
3. Pin `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` + fill the **`A2A_ESCROW_PACKAGE_V10_ID` placeholder** (ships as `''` — every V10 DF read honestly returns 0 until pinned) — commit to main
4. `gh workflow run release.yml --field bump=minor` (new public surface)
5. audric: bump 11 `@t2000/*` pins → merge audric PR (**not before the npm version exists**)
6. Dogfood matrix (runbook §6): 4 claims OK / 5th `EActiveJobCap` · release frees a seat · `minSellerLevel: 2` refuses a Level 1 seller · decline keeps the seat · hire release doesn't decrement

### Move (`contracts/a2a_escrow`)

- **Levels** 1–4 computed from the SAME predicates the claim policies read (2 = Proven, 3 = 4.0★+, 4 = +20 reviews & ≤2 no-delivery); `effective_seller_level` regresses to 1 at `no_delivery ≥ 3` (AdminCap-tunable floor). Caps **4/10/20/30**, AdminCap-tunable per level (`set_tier_active_cap`, `EBadTierBounds` rails).
- **Counter**: `ActiveSellerJobsKey` DF on `AgentScore.id`; +1 in `do_claim`, −1 on `release_v2`/`reject_v2*`/`refund_v2` — **only for jobs stamped `ClaimedJobKey`** by `create_claimed`. This marker is a deliberate refinement of the spec's bare decrement list, implementing its own invariant (`active == in-flight CLAIMED jobs`): without it, a colluding buyer resets a hunter's counter with a dust hire + instant release, and it makes soft-start automatic (pre-v10 claims have no marker — never counted in, never counted out).
- **`min_seller_level`**: DF on `Opening.id` (never a struct field), written by `create_open_v2` (≤4), enforced at claim on the EFFECTIVE level, removed before every UID delete (storage rebate). Sibling events `OpeningCreatedV2` (+min level) and `ActiveSellerJobsChanged` (post-write count, delta 0=+1/1=−1) — frozen v1 events untouched.
- **Cutover**: `claim`/`claim_proven`/`create_open` → abort `EUseClaimV2` (opening 17); `release` → abort `EUseReleaseV2` (escrow 20); live paths `claim_v2`/`claim_proven_v2` (both take the claimer's own `&mut AgentScore` — ownership asserted in `do_claim`, so policy-0 claims can't ride a stranger's score) + `release_v2` in `reputation` (release body extracted to `release_settle_pkg`, auth unchanged, still permissionless after the window).
- **Named consequences (locked, eyes open):** decline never decrements → a claim→decline **burns the seat permanently** (anti-abandon by design; retune via AdminCap or a v1.1 decline_v2 if too harsh). Soft-start hole: over-cap sellers can briefly over-claim until pre-v10 terminals drain.
- **Tests: 129/129** — cap ladder, 5th-claim refusal, per-path decrement-once, decline no-touch, regression floor, min-level unmet (fresh + Level 2 vs floor 3), borrowed-score refusal, dead-stub aborts, hire-release no-decrement, DF cleanup on cancel, AdminCap tunable rails.

### SDK / CLI

- SDK: `A2A_ESCROW_PACKAGE_V10_ID` (placeholder), `SellerLevel` + caps/floor constants, `sellerLevel`/`effectiveSellerLevel`/`activeCapForLevel`/`meetsMinSellerLevel`/`sellerLevelLabel`, `preflightClaimOpening` (English `Active: N/cap` + Level-floor refusals), `AgentScore.activeSellerJobs` + `Opening.minSellerLevel` DF reads (0 until V10 pin), builders → `create_open_v2`/`claim_v2`/`claim_proven_v2`/`release_v2` (release now needs `sellerScoreId`; claim always needs `scoreId` with the `create_empty_score` precursor for scoreless claimers — same S.1063 hop).
- CLI: `t2 job open --min-seller-level <1-4>` (strict digit parse); claim preflight unified on `preflightClaimOpening`; **tx-guard** retargeted to the v2 entries and taught qualified `module::fn` allowlist entries (open-claim's precursor is `reputation::create_empty_score` under an `opening`-module action).
- **Tests: SDK 616 · CLI 315**, typechecks clean.

### Docs + ops

reviews-and-reputation (Level 1–4 table + caps + regression + decline-keeps-seat), claim-and-deliver (`Active: N/cap` + Level-floor stuck entries), open-job (`--min-seller-level` + Connect `minSellerLevel`), `t2000-job` skill, GTM desk (register/review/social/referral rows → `claimPolicy: 2` + `minSellerLevel: 2` per the locked S.1192 table; metrics stay Anyone). **llms.txt lives in audric** — updated in the companion PR (claim now requires a score object, active-cap errors, minSellerLevel on post).

### Verify

```
cd contracts/a2a_escrow && sui move test   # 129/129
pnpm --filter @t2000/sdk test              # 616
pnpm --filter @t2000/cli test              # 315
pnpm --filter @t2000/sdk typecheck && pnpm --filter @t2000/cli typecheck
```

**Do not merge audric before npm publishes the new SDK. Do not start S.1193.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)