### PR TITLE
🐛 fix(sdk): human money errors in coinSelection — symbol + floored amounts (S.1194)

### DIFF
--- a/packages/sdk/src/wallet/coinSelection.test.ts
+++ b/packages/sdk/src/wallet/coinSelection.test.ts
@@ -481,3 +481,56 @@ describe('buildCoinToAddressBalanceMigration — gasless x402 coin→AB migratio
     );
   });
 });
+
+describe('S.1194 — money errors are human (symbol + floored amounts, never raw coin types)', () => {
+  const USDC = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
+
+  function balanceClient(balance: string) {
+    return {
+      core: {
+        getBalance: vi.fn().mockResolvedValue({ balance: { balance } }),
+        listCoins: vi.fn().mockResolvedValue({ objects: [], hasNextPage: false }),
+      },
+    } as unknown as Parameters<typeof selectAndSplitCoin>[1];
+  }
+
+  it('over-ask names the symbol and both amounts, floored (never the coin type)', async () => {
+    await expect(
+      selectAndSplitCoin(new Transaction(), balanceClient('530000'), OWNER, USDC, 51_000_000n, {
+        allowSwapAll: false,
+      }),
+    ).rejects.toThrow(/^Insufficient USDC: need 51, the wallet holds 0\.53\.$/);
+  });
+
+  it('zero balance with a known ask states need + holds 0', async () => {
+    await expect(
+      selectAndSplitCoin(new Transaction(), balanceClient('0'), OWNER, USDC, 1_000_000n, {
+        allowSwapAll: false,
+      }),
+    ).rejects.toThrow(/^Insufficient USDC: need 1, the wallet holds 0\.$/);
+  });
+
+  it("zero balance with amount 'all' reads as an empty wallet", async () => {
+    await expect(
+      selectAndSplitCoin(new Transaction(), balanceClient('0'), OWNER, USDC, 'all'),
+    ).rejects.toThrow(/^No USDC in this wallet\.$/);
+  });
+
+  it('raw units survive in details for programmatic consumers', async () => {
+    await expect(
+      selectAndSplitCoin(new Transaction(), balanceClient('530000'), OWNER, USDC, 51_000_000n, {
+        allowSwapAll: false,
+      }),
+    ).rejects.toMatchObject({
+      code: 'INSUFFICIENT_BALANCE',
+      data: { available: '530000', required: '51000000', coinType: USDC },
+    });
+  });
+
+  it('an unregistered coin type degrades to its last type segment, never the 0x string', async () => {
+    const weird = `0x${'9'.repeat(64)}::mystery::MYST`;
+    await expect(
+      selectAndSplitCoin(new Transaction(), balanceClient('0'), OWNER, weird, 'all'),
+    ).rejects.toThrow(/^No MYST in this wallet\.$/);
+  });
+});

--- a/packages/sdk/src/wallet/coinSelection.ts
+++ b/packages/sdk/src/wallet/coinSelection.ts
@@ -33,6 +33,20 @@ import {
 } from '@mysten/sui/transactions';
 import type { SuiCoreClient } from '../utils/sui.js';
 import { T2000Error } from '../errors.js';
+import { getDecimalsForCoinType, resolveSymbol } from '../token-registry.js';
+
+/** Raw units → exact display string for error copy (S.1194): decimal point
+ *  inserted via string math (no float loss), truncated to the display
+ *  precision — truncation IS the floor rule for positive amounts (the
+ *  t2000-financial-amounts law: shown ≤ actual, never rounded up). */
+function formatRawAmount(raw: bigint, coinType: string): string {
+  const decimals = getDecimalsForCoinType(coinType);
+  const dp = Math.min(decimals, 8);
+  const s = raw.toString().padStart(decimals + 1, '0');
+  const whole = s.slice(0, s.length - decimals);
+  const frac = s.slice(s.length - decimals).slice(0, dp).replace(/0+$/, '');
+  return frac ? `${whole}.${frac}` : whole;
+}
 
 export interface CoinPage {
   ids: string[];
@@ -153,17 +167,32 @@ export async function selectAndSplitCoin(
   const balanceResp = await client.core.getBalance({ owner, coinType });
   const totalBalance = BigInt(balanceResp.balance.balance);
 
+  // S.1194: money errors speak SYMBOL + human amounts, never the raw
+  // coin type — `0xdba3…::usdc::USDC` is machine data and was reaching
+  // console/CLI error lines verbatim. Raw units stay in `details`.
+  const symbol = resolveSymbol(coinType);
   if (totalBalance === 0n) {
-    throw new T2000Error('INSUFFICIENT_BALANCE', `No balance found for ${coinType}`);
+    throw new T2000Error(
+      'INSUFFICIENT_BALANCE',
+      amount === 'all'
+        ? `No ${symbol} in this wallet.`
+        : `Insufficient ${symbol}: need ${formatRawAmount(amount, coinType)}, the wallet holds 0.`,
+      { available: '0', required: amount === 'all' ? '0' : amount.toString(), coinType },
+    );
   }
 
   const allowSwapAll = options.allowSwapAll ?? true;
 
   if (amount !== 'all' && amount > totalBalance && !allowSwapAll) {
-    throw new T2000Error('INSUFFICIENT_BALANCE', `Insufficient balance for ${coinType}`, {
-      available: totalBalance.toString(),
-      required: amount.toString(),
-    });
+    throw new T2000Error(
+      'INSUFFICIENT_BALANCE',
+      `Insufficient ${symbol}: need ${formatRawAmount(amount, coinType)}, the wallet holds ${formatRawAmount(totalBalance, coinType)}.`,
+      {
+        available: totalBalance.toString(),
+        required: amount.toString(),
+        coinType,
+      },
+    );
   }
 
   const requested = amount === 'all' ? totalBalance : amount;
@@ -235,7 +264,7 @@ async function selectCoinObjectsOnly(
     if (cached.remaining === 0n || requested > cached.remaining) {
       throw new T2000Error(
         'ADDRESS_BALANCE_UNSPONSORABLE',
-        `Not enough ${coinType} in coin objects to cover all legs of this ` +
+        `Not enough ${resolveSymbol(coinType)} in coin objects to cover all legs of this ` +
           `sponsored bundle. The remaining funds are in your address balance, ` +
           `which sponsored transactions can't access yet.`,
         { remaining: cached.remaining.toString(), requested: requested.toString(), coinType },
@@ -360,7 +389,7 @@ export function buildCoinToAddressBalanceMigration(args: {
   }
 
   if (migratedRaw < minAmount) {
-    throw new T2000Error('INSUFFICIENT_BALANCE', `Insufficient ${coinType} coin objects to migrate`, {
+    throw new T2000Error('INSUFFICIENT_BALANCE', `Insufficient ${resolveSymbol(coinType)} coin objects to migrate`, {
       available: migratedRaw.toString(),
       required: minAmount.toString(),
     });

--- a/packages/sdk/src/wallet/job.test.ts
+++ b/packages/sdk/src/wallet/job.test.ts
@@ -164,7 +164,10 @@ describe('buildCreateJobTx', () => {
     client.core.getBalance = vi.fn().mockResolvedValue({ balance: { balance: '100' } });
     await expect(
       buildCreateJobTx({ client, buyer: BUYER, terms: terms() }),
-    ).rejects.toThrow(/Insufficient balance/);
+    // S.1194: money errors speak symbol + human amounts, never the raw
+    // coin type (terms() is a $5 job; the mock wallet holds 100 raw =
+    // $0.0001, floored to "0.0001").
+    ).rejects.toThrow(/Insufficient USDC: need 5, the wallet holds 0\.0001\./);
   });
 });
 


### PR DESCRIPTION
## S.1194 — coinSelection error copy (root fix for the console raw-coin-type leak)

Companion to the audric console-polish PR. Four `coinSelection.ts` messages interpolated the raw Sui coin type (`0xdba3…::usdc::USDC`) into user-facing errors, and the two INSUFFICIENT_BALANCE ones reached the console hire/open modals verbatim via the prepare rail.

- Both `INSUFFICIENT_BALANCE` throws now read `Insufficient USDC: need 51, the wallet holds 0.53.` — symbol via `resolveSymbol`, amounts via exact bigint string math **truncated to display precision** (truncation = the floor rule from `t2000-financial-amounts`: shown ≤ actual, never rounded up, no float loss). Zero-balance + `amount: 'all'` reads `No USDC in this wallet.`
- The sponsored-bundle (`ADDRESS_BALANCE_UNSPONSORABLE`) and `migrate` messages swap the raw type for the symbol too.
- Raw units (and now `coinType`) stay in the structured `data` for programmatic consumers — nothing lost, only the prose changed.
- Unregistered coin types degrade to the last type segment (`resolveSymbol`'s existing fallback), never the 0x string.

**Tests**: +5 message pins in `coinSelection.test.ts` (over-ask copy, zero-with-ask, empty-wallet, data passthrough, unregistered-type fallback); the job.test.ts pin retargeted. SDK **621**, CLI **315**, typechecks clean. No behavior change — same codes, same throw conditions, same `data` keys (one added).

Release note: rides the next patch/minor; audric picks it up at its next lockstep bump (the console PR also ships a client-side sanitizer as fallback, so the UX fix doesn't wait on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)