### PR TITLE
🔧 chore(sdk): browser require export + Mintlify $ escapes on paired amounts (S.1195)

### DIFF
--- a/apps/docs/agent-wallet.mdx
+++ b/apps/docs/agent-wallet.mdx
@@ -55,7 +55,7 @@ Every command takes `--json` (machine-parseable) and `--key <path>` (non-default
 
 Every door has a leash:
 
-- **CLI** — on by default, **$25/tx · $100/day**, local to the machine:
+- **CLI** — on by default, **\$25/tx · \$100/day**, local to the machine:
 
 ```bash
 t2 limit set --per-tx 50 --daily 200

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -225,7 +225,7 @@ t2 agents --category research
 
 ## Spending limits
 
-On by default: $25 per transaction, $100 per day. Any write can bypass a limit once with `--force`.
+On by default: \$25 per transaction, \$100 per day. Any write can bypass a limit once with `--force`.
 
 | Command | What it does |
 | --- | --- |

--- a/apps/docs/fees-and-limits.mdx
+++ b/apps/docs/fees-and-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fees & limits"
-description: "One card: the 5% escrow settlement fee, the $100 and $5 caps, what's gasless, and the spend limits on every surface."
+description: "One card: the 5% escrow settlement fee, the job and per-call caps, what's gasless, and the spend limits on every surface."
 ---
 
 Two rails, one fee.
@@ -8,7 +8,7 @@ Two rails, one fee.
 | | **Escrow** (deliverable work) | **x402** (per-call APIs) |
 |---|---|---|
 | Fee | **5%** of the seller payout at settlement — refunds are free | **none** |
-| Size | **$0.01 – $100** per job (contract-enforced) | **$5** cap per call |
+| Size | **\$0.01 – \$100** per job (contract-enforced) | **\$5** cap per call |
 | Money path | Locks in an on-chain `Job` object, releases on delivery | Settles straight to the seller's wallet at call time |
 
 The 5% is enforced by the Move contract; the rate snapshots into the Job at
@@ -30,14 +30,14 @@ one large escrow.
 
 ## Spend limits
 
-- **Wallet (CLI/SDK):** on by default at **$25/tx · $100/day**. `t2 limit
+- **Wallet (CLI/SDK):** on by default at **\$25/tx · \$100/day**. `t2 limit
   show / set / reset`; `--force` overrides one call. Setting limits is
   CLI-only — agents can read the leash, never lengthen it.
 - **Passport Connect:** three numbers per session — **per job**, **daily**,
   and **ask above** (refuses with a link to the limits editor — no one-shot
-  approve). **New-session defaults:** $50 per job · $1000 per day · ask above
+  approve). **New-session defaults:** \$50 per job · \$1000 per day · ask above
   $100; existing sessions keep the limits they were created with. The
-  defaults are unchanged by the $100 job cap — posting or hiring above $50
+  defaults are unchanged by the \$100 job cap — posting or hiring above \$50
   from Connect needs a raised per-job limit at
   [t2000.ai/manage/connections](https://t2000.ai/manage/connections) first.
   Revoke stops new spends immediately; sessions expire within 7 days.

--- a/apps/docs/how-to/fund-and-send.mdx
+++ b/apps/docs/how-to/fund-and-send.mdx
@@ -66,6 +66,6 @@ t2 send 0.01 USDC 0xRECIPIENT      # or a SuiNS name like alice.sui
 - **"Insufficient SUI"** on a send — only USDC and USDsui sends are gasless;
   SUI sends pay their own gas. Swaps also need a little SUI
   ([swap →](/how-to/swap)).
-- **Blocked by limits** — sends respect your spending caps ($25/tx · $100/day
+- **Blocked by limits** — sends respect your spending caps (\$25/tx · \$100/day
   by default); `t2 limit show` explains, `--force` overrides one call
   ([fees & limits](/fees-and-limits)).

--- a/apps/docs/how-to/hire.mdx
+++ b/apps/docs/how-to/hire.mdx
@@ -10,7 +10,7 @@ accept (or the review window lapses).
 
 ## Before you start
 
-- [ ] [Get set up](/how-to/get-set-up) and funded — $0.50–$1 covers a first hire
+- [ ] [Get set up](/how-to/get-set-up) and funded — \$0.50–\$1 covers a first hire
       ([fund →](/how-to/fund-and-send))
 - [ ] A brief: what you want, in a sentence or a file
 
@@ -67,9 +67,9 @@ become the seller's public score —
 
 - **Missing requirement keys** — the rejection names them; every key the
   listing asks for must be non-empty before escrow funds.
-- **Over a limit** — hires cap at $100/job, and your own spend limits apply
+- **Over a limit** — hires cap at \$100/job, and your own spend limits apply
   ([fees & limits](/fees-and-limits)) — a Connect session's default per-job
-  limit is still $50, raised at
+  limit is still \$50, raised at
   [t2000.ai/manage/connections](https://t2000.ai/manage/connections).
 - **Seller went quiet** — nothing delivered by the deadline → `t2 job refund
   <jobId>` returns your money; anyone may crank it. Job text is public — keep

--- a/apps/docs/how-to/list-a-service.mdx
+++ b/apps/docs/how-to/list-a-service.mdx
@@ -67,7 +67,7 @@ unlists. Packages from code: [Sell headlessly](/how-to/sell-headlessly).
 - **`--category` required** — one directory category per profile
   (`ai-models | data-feeds | finance | research | dev-tools | creative | travel | comms | other`);
   set once, later services inherit it.
-- **Price rejected** — services are $0.01–$100 (the no-arbitration cap —
+- **Price rejected** — services are \$0.01–\$100 (the no-arbitration cap —
   [Fees & limits](/fees-and-limits)).
 - **Card not visible** — listings hang off an active Agent ID; re-run
   `t2 agent register` (idempotent). **No image** — upload on the Agent desk.

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -93,9 +93,9 @@ The API behind `t2000_job_open` / `t2 job open` caps each IP on a rolling 60s:
 
 ## Stuck?
 
-- **Budget rejected** — openings cap at $100 ([Fees & limits](/fees-and-limits));
+- **Budget rejected** — openings cap at \$100 ([Fees & limits](/fees-and-limits));
   the budget must be spendable USDC in your wallet at post time. From Connect,
-  your session's own per-job limit (default $50) also applies — raise it at
+  your session's own per-job limit (default \$50) also applies — raise it at
   [t2000.ai/manage/connections](https://t2000.ai/manage/connections) to post
   above it.
 - **Nobody claimed** — the escrow returns automatically after `--open-for`

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -103,7 +103,7 @@ always tells you exactly what it exposes. For the escrow loop in practice see
 ## Limits, approvals, revoke
 
 Three numbers, set when you connect (product defaults for **new** sessions:
-**$50 per job · $1000 per day · ask above $100** — existing sessions keep the
+**\$50 per job · \$1000 per day · ask above \$100** — existing sessions keep the
 limits they were minted with) and changeable under **Connections**:
 
 - **Per job** — a single spend above this is refused outright.

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -61,17 +61,17 @@ t2 job board
 ```
 
 Optional: `npx skills add mission69b/t2000-skills`
-Limits: `t2 limit` (defaults $25/tx · $100/day).
+Limits: `t2 limit` (defaults \$25/tx · \$100/day).
 
 ## Then
 
 | | |
 |---|---|
 | [Get set up](/how-to/get-set-up) | Wallet + free Agent ID |
-| [Claim and deliver](/how-to/claim-and-deliver) | Earn with a $0 wallet |
+| [Claim and deliver](/how-to/claim-and-deliver) | Earn with a \$0 wallet |
 | [Work with Hermes](/how-to/work-with-hermes) | Earn with Hermes + local `t2` |
 | [List a Service](/how-to/list-a-service) | Sell work, no server |
-| [Fund and send](/how-to/fund-and-send) | Deposit + $0.01 send |
+| [Fund and send](/how-to/fund-and-send) | Deposit + \$0.01 send |
 | [Hire someone](/how-to/hire) | Escrow hire |
 
 ## Troubleshooting

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=20"
   },
-  "description": "TypeScript SDK for Agent Wallets on Sui — gasless USDC + USDsui transfers, Cetus swap routing, NAVI lending (programmatic), MPP paid API access, zkLogin compatible.",
+  "description": "TypeScript SDK for Agent Wallets on Sui \u2014 gasless USDC + USDsui transfers, Cetus swap routing, NAVI lending (programmatic), MPP paid API access, zkLogin compatible.",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -17,7 +17,8 @@
     },
     "./browser": {
       "types": "./dist/browser.d.ts",
-      "import": "./dist/browser.js"
+      "import": "./dist/browser.js",
+      "require": "./dist/browser.cjs"
     }
   },
   "files": [

--- a/packages/sdk/src/browser-exports.test.ts
+++ b/packages/sdk/src/browser-exports.test.ts
@@ -1,0 +1,52 @@
+import { createRequire } from 'node:module';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import pkg from '../package.json';
+
+// S.1195 — the `./browser` subpath must stay loadable from BOTH module
+// systems. It shipped import-only, which made every CJS resolution
+// (audric's `tsx --test` console suites, plain `require`) die with
+// ERR_PACKAGE_PATH_NOT_EXPORTED — the S.1191 gap that forced consumers to
+// hand-copy constants instead of importing them. tsup has always emitted
+// dist/browser.cjs; the exports map just never pointed at it.
+
+type ExportEntry = { types?: string; import?: string; require?: string };
+const exportsMap = pkg.exports as Record<string, ExportEntry>;
+
+describe('S.1195 — @t2000/sdk/browser exports parity', () => {
+  it('./browser declares the same conditions as "." (types + import + require)', () => {
+    const root = exportsMap['.'];
+    const browser = exportsMap['./browser'];
+    expect(Object.keys(browser).sort()).toEqual(Object.keys(root).sort());
+    expect(browser.require).toBe('./dist/browser.cjs');
+    expect(browser.import).toBe('./dist/browser.js');
+  });
+
+  it('every declared file ships (dist emitted by the build)', () => {
+    // Skipped when dist/ hasn't been built in this checkout — the publish
+    // pipeline always builds first, and the require-side smoke below runs
+    // whenever the artifact exists.
+    for (const entry of Object.values(exportsMap)) {
+      for (const rel of Object.values(entry)) {
+        const abs = join(__dirname, '..', rel);
+        if (existsSync(join(__dirname, '..', 'dist'))) {
+          expect(existsSync(abs), `${rel} missing from dist`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('CJS require() of the built browser bundle exposes the money constants', () => {
+    const cjsPath = join(__dirname, '..', 'dist', 'browser.cjs');
+    if (!existsSync(cjsPath)) {
+      return; // pre-build checkout — the parity pin above still guards the map
+    }
+    const require = createRequire(import.meta.url);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const browser = require(cjsPath) as Record<string, unknown>;
+    expect(browser.MAX_JOB_USDC).toBe(100);
+    expect(browser.MIN_JOB_USDC).toBe(0.01);
+    expect(typeof browser.sellerLevelLabel).toBe('function');
+  });
+});


### PR DESCRIPTION
## S.1195 — hygiene: two background chips (t2000 half)

Companion audric PR follows the npm patch (seller-setup → SDK constants). No Move changes, no product surface. **Do not start S.1193.**

### 1. `@t2000/sdk/browser` loadable from CJS

The subpath declared only `types` + `import`, so every CJS resolution (audric's `tsx --test` console suites, plain `require`) died with `ERR_PACKAGE_PATH_NOT_EXPORTED` — the S.1191 gap that forced consumers to hand-copy money constants instead of importing them. `tsup` has always emitted `dist/browser.cjs`; the exports map now points at it, exactly matching the root `"."` pattern (`types` / `import` / `require`).

**Proof**: new `browser-exports.test.ts` pins `"."`↔`"./browser"` condition parity + that every declared dist file ships + a real `createRequire` smoke over the built bundle (`MAX_JOB_USDC === 100`). Also verified end-to-end against the **packed tarball**: `require('@t2000/sdk/browser')` from a bare CJS consumer resolves through the exports map and exposes the constants (the old error is gone; only real peer deps remain, as for any consumer).

### 2. Mintlify KaTeX on money lines

Mintlify parses paired `$…$` in prose as inline math — `**$0.01 – $100**` rendered as garbled KaTeX spans on every money page (pre-existing site-wide; `styling.latex: false` does not disable it). Swept `apps/docs/**/*.mdx` with a fence-aware script: **prose** `$<digit>` occurrences escaped as `\$` on lines/paragraphs carrying 2+ amounts — including **cross-line pairs inside one paragraph** (hire, open-job bullets), which are the same bug. Code fences and inline code untouched (verified: the only remaining multi-`$` lines are inside the passport-connect seller-setup fence, which KaTeX never parses). 11 files, 17 lines. The one frontmatter `description` with a pair (fees-and-limits) was **reworded** instead of escaped — YAML backslash semantics are a gamble, and the amounts live in the table right below.

Post-deploy check (docs auto-deploy on merge):

```bash
curl -sS https://docs.t2000.ai/fees-and-limits | grep -c 'class="katex"'   # expect 0
```

### Verify

```
pnpm --filter @t2000/sdk build && pnpm --filter @t2000/sdk test   # 36 files, 624 tests
pnpm --filter @t2000/cli test                                     # 315 (docs-consistency unaffected)
node --input-type=commonjs -e "console.log(require('./packages/sdk/dist/browser.cjs').MAX_JOB_USDC)"   # 100
```

After merge: `release.yml` **patch** → audric PR bumps + converts `seller-setup-prompt.ts` to SDK constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)