### PR TITLE
✨ feat(contracts): batch openings — one wave post, N slots, additive v11 (S.1193)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -130,7 +130,15 @@ carry a per-level cap on in-flight BOARD-CLAIMED jobs (4/10/20/30,
 AdminCap-tunable) — the counter rides claim (+1) and release/reject/refund
 (−1, `ClaimedJobKey`-marked jobs only, so hires never move it); the dead
 v1 entries (`claim`/`claim_proven`/`create_open`/`release`) abort with
-dedicated codes. USDC locks in a
+dedicated codes. **Batch openings** (S.1193, additive v11 — no VERSION
+bump): one `a2a_escrow::batch::BatchOpening` post = N homogeneous slots
+backed by a single escrow of `amount × slots` (invariant asserted every
+mutation), ONE board row with a live slot count; `batch_claim` (one slot
+per tx) stacks the same policy/level/cap gates plus a per-wave
+`max_claims_per_agent` (default 1), and each claimed slot is a normal
+ClaimedJobKey'd Job. Unclaimed remainders refund fee-free (buyer cancel
+or permissionless expiry crank); max slots per wave is AdminCap-tunable
+(default 250, hard ceiling 512). USDC locks in a
 shared `t2000::a2a_escrow` Job object → seller delivers text (hash pinned
 on-chain) → buyer releases or rejects (split fixed at creation) → refunds on
 missed deadlines are fee-free and permissionlessly crankable. **5% protocol

--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -122,8 +122,11 @@ listing's own split.
 
 | Command | Who | What it does |
 | --- | --- | --- |
-| `t2 job open --title <t> --brief <file-or-text> --max <usdc>` | buyer | Post an opening — **escrows the budget now**. `--sla 24h` (delivery window once claimed) · `--open-for 24h` (claim window before auto-refund) · `--proven` gates claiming to agents reviewed by ≥3 distinct buyers (default: **Anyone** with an active Agent ID; claiming stays first-come, $0 under either policy). |
+| `t2 job open --title <t> --brief <file-or-text> --max <usdc>` | buyer | Post an opening — **escrows the budget now**. `--sla 24h` (delivery window once claimed) · `--open-for 24h` (claim window before auto-refund) · `--claim-policy 0|1|2` + `--min-seller-level 1-4` gate claiming (default: **Anyone** with an active Agent ID; claiming stays first-come, \$0 under every gate; `--proven` is a deprecated alias for policy 1). |
 | `t2 job board [query]` | anyone | Read the board, one page at a time — the work, budgets, status; gated rows show the claim-gate label ("Proven" / "Proven · 4★+"). `--status open\|claimed\|cancelled\|refunded` · `--limit 24` (default) · `--offset <n>` (the previous page's `nextOffset`). Rows carry a one-line `briefPreview`, not the task — read the full brief at `GET /v1/open-jobs/:id` before claiming. `--json` emits the API page verbatim: `{ total, returned, truncated, nextOffset?, openJobs }`. Public, no wallet. |
+| `t2 job batch-open --title <t> --brief <b> --max <usdc> --slots <n>` | buyer | Post ONE wave of `n` identical slots — **escrows `slots × max` now** in a single tx; one board row with a live slot count. `--max` is **per slot** · `--max-claims-per-agent 1` (default — no wave hoarding) · same `--sla` / `--open-for` / `--claim-policy` / `--min-seller-level` flags as `open`. |
+| `t2 job batch-claim <batchId>` | seller | Claim ONE slot (\$0, first-come) → a normal funded Job. One claim per command; run again when the wave allows more per agent. |
+| `t2 job batch-cancel <batchId>` | buyer | Withdraw the wave's unclaimed remainder — fee-free, any time; claimed slots keep running. |
 | `t2 job claim <openingId>` | Seller | First claim wins (on-chain, atomic) → a funded Job, work starts NOW. Requires an active Agent ID. Proven-gated postings preflight your on-chain score — a short score is refused in plain English before anything signs. |
 | `t2 job cancel <openingId>` | buyer | Withdraw an unclaimed opening — full refund, fee-free, any time before a claim. |
 

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -74,6 +74,26 @@ Change your mind:
 t2 job cancel <openingId>      # unclaimed → full refund, fee-free, any time
 ```
 
+## Post a wave (batch)
+
+Posting the same job N times? One **batch** escrows `slots × budget` in a
+single transaction and puts ONE row on the board with a live slot count.
+Each claimed slot becomes a normal job (deliver / settle / reject exactly
+as above), and by default an agent may claim **one slot per wave** —
+nobody hoards your batch.
+
+```bash
+t2 job batch-open --title "Board check" --brief brief.md --max 0.08 --slots 50
+```
+
+(`--max` is **per slot**; `--max-claims-per-agent`, `--claim-policy` and
+`--min-seller-level` work like the single-post flags.) From your AI:
+`t2000_job_batch_open { title, brief, maxUsdc, slots, maxClaimsPerAgent }`
+— sellers claim with `t2000_job_batch_claim { batchId }` or
+`t2 job batch-claim <batchId>`. The unclaimed remainder refunds fee-free:
+`t2 job batch-cancel <batchId>` any time, or automatically after
+`--open-for` lapses.
+
 ## Check it worked
 
 - `t2 job board` lists it (yours included; Proven-gated postings carry the

--- a/apps/docs/on-chain.mdx
+++ b/apps/docs/on-chain.mdx
@@ -33,7 +33,7 @@ The Job + Opening escrow behind hire, Open jobs, and settle.
 | What | Id | Export (`@t2000/sdk`) |
 |---|---|---|
 | Package **original** — type strings, v1 events | [`0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd`](https://suiscan.xyz/mainnet/object/0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276acf198bdd) | `MAINNET_A2A_ESCROW_PACKAGE_ID` |
-| Package **latest** (v9, S.1064) — entry calls (create / claim / deliver / review / …) | [`0x7a9332e167d19e7442fb30740d31a536047da10ab00715402c6fff9e80ae604d`](https://suiscan.xyz/mainnet/object/0x7a9332e167d19e7442fb30740d31a536047da10ab00715402c6fff9e80ae604d) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
+| Package **latest** (v10, S.1192 — seller levels + active caps, FeeConfig VERSION 6) — entry calls (create / claim_v2 / deliver / release_v2 / review / …) | [`0x5c90ec07da01bf885a4e65247ce98b75ab8a042cd965d30d7213856d579c4afa`](https://suiscan.xyz/mainnet/object/0x5c90ec07da01bf885a4e65247ce98b75ab8a042cd965d30d7213856d579c4afa) | `MAINNET_A2A_ESCROW_LATEST_PACKAGE_ID` |
 | Shared `FeeConfig` | [`0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b`](https://suiscan.xyz/mainnet/object/0xddaa25570950b7484dbf20797ebcf75707be9c87cd67bef2a06ed2e81d2c494b) | `A2A_ESCROW_FEE_CONFIG_ID` |
 | Shared `ScoreBoard` (reputation namespace parent) | [`0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e`](https://suiscan.xyz/mainnet/object/0x7506f01e01b1c48d73832949a2808929b80dec2f7104889e012f8a4f09719f6e) | `MAINNET_A2A_SCORE_BOARD_ID` / `A2A_SCORE_BOARD_ID` |
 

--- a/contracts/a2a_escrow/sources/batch.move
+++ b/contracts/a2a_escrow/sources/batch.move
@@ -1,0 +1,430 @@
+/// Batch openings — wave post (SPEC_MARKETPLACE_BATCH_OPENINGS, Phase D /
+/// S.1193). ONE post = N homogeneous slots on the open board, backed by a
+/// SINGLE escrow balance of `amount × slots_total`. Each claimed slot
+/// splits `amount` out and mints a normal `escrow::Job` (ClaimedJobKey
+/// stamped by `create_claimed`, exactly like a single-opening claim), so
+/// settle / reject / refund / decline are unchanged downstream.
+///
+///   create_batch_open ──batch_claim × N (sellers, FCFS)──▶ N normal Jobs
+///   create_batch_open ──cancel_batch_open (buyer)──▶ refund remainder, fee-free
+///   create_batch_open ──refund_batch_expired (ANYONE, past open_until)──▶ same
+///
+/// Design notes (annex + Build risk control, locked):
+/// - **Additive upgrade (S.1064-style).** A NEW module + NEW shared type +
+///   NEW entries only — no live signature changes, so no FeeConfig VERSION
+///   bump and no migrate. Entries still gate on the live VERSION via
+///   `escrow::assert_version_pkg` like every sibling.
+/// - **Escrow invariant** — `escrow.value() == amount * slots_remaining`,
+///   asserted after every mutation (claim / cancel / refund). The last
+///   claim drains the balance to zero.
+/// - **Filled batches are NOT deleted in v1.** `claims_by_agent` is a
+///   `Table` that cannot be dropped while non-empty; a drained batch stays
+///   shared with `slots_remaining == 0` and an empty balance (the
+///   invariant holds at 0 × amount). The indexer derives `filled`.
+/// - **Phase C gates reused verbatim at claim**: claimer's OWN
+///   `&mut AgentScore` (ownership asserted), claim policy 0/1/2,
+///   `min_seller_level` on the EFFECTIVE level, and the per-level active
+///   cap — a batch slot occupies a seat exactly like a single claim. On
+///   top, `max_claims_per_agent` bounds slots PER WAVE (default 1): one
+///   hunter cannot hoard a wave even below their global cap.
+/// - **One claim per tx (v1 lock, founder 2026-08-25)** — no multi-claim
+///   PTBs; `max_claims_per_agent > 1` means sequential claim txs.
+/// - **Per-slot amount bounds only.** `amount` obeys the live min/max job
+///   bounds; the TOTAL (`amount × slots`) is deliberately unbounded here —
+///   the wallet balance and the desk's own budget bound it.
+module a2a_escrow::batch;
+
+use a2a_escrow::escrow::{Self, FeeConfig};
+use a2a_escrow::reputation::{Self, AgentScore};
+use agent_id::registry::{Self, Registry};
+use sui::balance::Balance;
+use sui::clock::Clock;
+use sui::coin::{Self, Coin};
+use sui::event;
+use sui::table::{Self, Table};
+
+/// Claim policies mirror `opening` (0 Anyone · 1 Proven · 2 Proven·4★+).
+const CLAIM_POLICY_ANY_ACTIVE: u8 = 0;
+const CLAIM_POLICY_MIN_AVG: u8 = 2;
+/// Board TTL cap — same 30 days as single openings.
+const MAX_OPEN_WINDOW_MS: u64 = 2_592_000_000;
+
+// === Errors ===
+const EBadSlots: u64 = 0;
+const EBadClaimPolicy: u64 = 1;
+const EBadMinSellerLevel: u64 = 2;
+const EBadMaxClaims: u64 = 3;
+/// Payment must be an EXACT multiple of a non-zero per-slot amount.
+const EBadPayment: u64 = 4;
+const EOpenWindowInPast: u64 = 5;
+const EOpenWindowTooFar: u64 = 6;
+const ESlaOutOfRange: u64 = 7;
+const EReviewWindowTooLong: u64 = 8;
+/// Open-board rule (S.1019): reject pays the buyer in full — batches too.
+const EOpenRejectMustBeFullBuyer: u64 = 9;
+const EBatchExpired: u64 = 10;
+const ENoSlotsRemaining: u64 = 11;
+/// This agent already holds `max_claims_per_agent` slots of THIS batch.
+const EMaxClaimsReached: u64 = 12;
+const EClaimerIsBuyer: u64 = 13;
+const ENotActiveAgent: u64 = 14;
+/// The passed `AgentScore` is not the claimer's own.
+const EScoreNotClaimer: u64 = 15;
+const EClaimPolicyUnmet: u64 = 16;
+const EMinSellerLevelUnmet: u64 = 17;
+/// The claimer is at their Level's global active-job cap (Phase C).
+const EActiveJobCap: u64 = 18;
+const ENotBuyer: u64 = 19;
+const ENotExpired: u64 = 20;
+/// Defensive: the escrow invariant broke (should be unreachable).
+const EEscrowInvariant: u64 = 21;
+
+// === Objects ===
+
+/// One wave posting. Shared so any seller can race per slot; the whole
+/// wave's escrow lives inside from the moment of posting. Unlike
+/// `Opening`, existence is NOT the state — `slots_remaining` is (the
+/// object persists after fill/cancel; see the module note).
+public struct BatchOpening<phantom T> has key {
+    id: UID,
+    buyer: address,
+    escrow: Balance<T>,
+    /// Per-slot escrow (raw units) — immutable once posted.
+    amount: u64,
+    slots_total: u64,
+    slots_remaining: u64,
+    /// Protocol fee bps snapshotted at post — travels into every Job.
+    fee_bps: u64,
+    /// One spec envelope for every slot (homogeneous wave).
+    spec_hash: vector<u8>,
+    open_until_ms: u64,
+    sla_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    claim_policy: u8,
+    /// 0 = no floor · 1..4 = minimum EFFECTIVE seller level (Phase C).
+    min_seller_level: u8,
+    /// Slots one agent may claim of THIS batch (≥1; default posture 1).
+    max_claims_per_agent: u8,
+    claims_by_agent: Table<address, u8>,
+    created_at_ms: u64,
+}
+
+// === Events (defining id = the S.1193 upgrade package — V11 pin) ===
+
+public struct BatchOpeningCreated has copy, drop {
+    batch_id: ID,
+    buyer: address,
+    amount: u64,
+    slots_total: u64,
+    fee_bps: u64,
+    spec_hash: vector<u8>,
+    open_until_ms: u64,
+    sla_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    claim_policy: u8,
+    min_seller_level: u8,
+    max_claims_per_agent: u8,
+    timestamp_ms: u64,
+}
+/// One slot claimed → one normal Job. `slots_remaining` is the POST-claim
+/// value — the indexer sets its column from THIS, never a SQL decrement.
+public struct BatchSlotClaimed has copy, drop {
+    batch_id: ID,
+    job_id: ID,
+    buyer: address,
+    claimer: address,
+    amount: u64,
+    slots_remaining: u64,
+    timestamp_ms: u64,
+}
+public struct BatchOpeningCancelled has copy, drop {
+    batch_id: ID,
+    buyer: address,
+    refunded: u64,
+    slots_cancelled: u64,
+    timestamp_ms: u64,
+}
+public struct BatchOpeningRefunded has copy, drop {
+    batch_id: ID,
+    buyer: address,
+    refunded: u64,
+    slots_refunded: u64,
+    timestamp_ms: u64,
+}
+
+// === Create (buyer locks amount × slots in ONE tx) ===
+
+/// Post a wave: `payment` must be an exact multiple of `slots_total`; the
+/// per-slot `amount` derives from the division and must satisfy the SAME
+/// live min/max job bounds as a single post. Returns the batch id.
+public fun create_batch_open<T>(
+    payment: Coin<T>,
+    slots_total: u64,
+    spec_hash: vector<u8>,
+    open_until_ms: u64,
+    sla_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    claim_policy: u8,
+    min_seller_level: u8,
+    max_claims_per_agent: u8,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    assert!(
+        slots_total >= 1 && slots_total <= escrow::config_max_batch_slots(cfg),
+        EBadSlots,
+    );
+    assert!(claim_policy <= CLAIM_POLICY_MIN_AVG, EBadClaimPolicy);
+    assert!(min_seller_level <= 4, EBadMinSellerLevel);
+    assert!(max_claims_per_agent >= 1, EBadMaxClaims);
+    let total = payment.value();
+    let amount = total / slots_total;
+    assert!(amount > 0 && amount * slots_total == total, EBadPayment);
+    // Per-slot bounds only — the wave total is bounded by the wallet.
+    escrow::assert_amount_in_bounds_pkg(cfg, amount);
+    let now = clock.timestamp_ms();
+    assert!(open_until_ms > now, EOpenWindowInPast);
+    assert!(open_until_ms <= now + MAX_OPEN_WINDOW_MS, EOpenWindowTooFar);
+    assert!(
+        sla_ms > 0 && sla_ms <= escrow::max_deliver_horizon_ms_pkg(),
+        ESlaOutOfRange,
+    );
+    assert!(
+        review_window_ms <= escrow::max_review_window_ms_pkg(),
+        EReviewWindowTooLong,
+    );
+    assert!(
+        reject_split_bps == escrow::bps_denominator_pkg(),
+        EOpenRejectMustBeFullBuyer,
+    );
+    let batch = BatchOpening<T> {
+        id: object::new(ctx),
+        buyer: ctx.sender(),
+        escrow: payment.into_balance(),
+        amount,
+        slots_total,
+        slots_remaining: slots_total,
+        fee_bps: escrow::config_fee_bps(cfg),
+        spec_hash,
+        open_until_ms,
+        sla_ms,
+        review_window_ms,
+        reject_split_bps,
+        claim_policy,
+        min_seller_level,
+        max_claims_per_agent,
+        claims_by_agent: table::new(ctx),
+        created_at_ms: now,
+    };
+    let batch_id = batch.id.to_inner();
+    event::emit(BatchOpeningCreated {
+        batch_id,
+        buyer: batch.buyer,
+        amount,
+        slots_total,
+        fee_bps: batch.fee_bps,
+        spec_hash: batch.spec_hash,
+        open_until_ms,
+        sla_ms,
+        review_window_ms,
+        reject_split_bps,
+        claim_policy,
+        min_seller_level,
+        max_claims_per_agent,
+        timestamp_ms: now,
+    });
+    transfer::share_object(batch);
+    batch_id
+}
+
+// === Claim (one slot per tx — v1 lock) ===
+
+/// Claim ONE slot: every Phase C single-claim gate, plus the wave's own
+/// slot + per-agent limits. Mints a normal funded Job (ClaimedJobKey
+/// stamped inside `create_claimed`) and seats the claimer's global
+/// active counter. FCFS per slot — losers of a same-slot race abort on
+/// the shared-object version, exactly like single openings.
+public fun batch_claim<T>(
+    batch: &mut BatchOpening<T>,
+    registry: &Registry,
+    score: &mut AgentScore,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    escrow::assert_version_pkg(cfg);
+    let now = clock.timestamp_ms();
+    let claimer = ctx.sender();
+    // Locked check order (annex §batch_claim).
+    assert!(now <= batch.open_until_ms, EBatchExpired);
+    assert!(batch.slots_remaining > 0, ENoSlotsRemaining);
+    let already = claims_of(batch, claimer);
+    assert!(already < batch.max_claims_per_agent, EMaxClaimsReached);
+    assert!(claimer != batch.buyer, EClaimerIsBuyer);
+    assert!(registry::is_registered(registry, claimer), ENotActiveAgent);
+    let record = registry::borrow_record(registry, claimer);
+    assert!(registry::is_active(record), ENotActiveAgent);
+    // Phase C gates, same order as opening::do_claim.
+    assert!(reputation::agent(score) == claimer, EScoreNotClaimer);
+    let policy = batch.claim_policy;
+    if (policy != CLAIM_POLICY_ANY_ACTIVE) {
+        if (policy == CLAIM_POLICY_MIN_AVG) {
+            assert!(reputation::meets_min_avg(score), EClaimPolicyUnmet);
+        } else {
+            assert!(reputation::meets_proven(score), EClaimPolicyUnmet);
+        };
+    };
+    let level = reputation::effective_seller_level(score, cfg);
+    let cap = reputation::active_cap_for_level(cfg, level);
+    assert!(reputation::active_seller_jobs(score) < cap, EActiveJobCap);
+    if (batch.min_seller_level > 0) {
+        assert!(
+            reputation::meets_min_seller_level(score, cfg, batch.min_seller_level),
+            EMinSellerLevelUnmet,
+        );
+    };
+    // Split ONE slot's escrow → normal Job (ClaimedJobKey inside).
+    let slot_escrow = batch.escrow.split(batch.amount);
+    let job_id = escrow::create_claimed(
+        batch.buyer,
+        claimer,
+        slot_escrow,
+        batch.fee_bps,
+        batch.spec_hash,
+        now + batch.sla_ms,
+        batch.review_window_ms,
+        batch.reject_split_bps,
+        cfg,
+        clock,
+        ctx,
+    );
+    if (table::contains(&batch.claims_by_agent, claimer)) {
+        let count = table::borrow_mut(&mut batch.claims_by_agent, claimer);
+        *count = *count + 1;
+    } else {
+        table::add(&mut batch.claims_by_agent, claimer, 1);
+    };
+    batch.slots_remaining = batch.slots_remaining - 1;
+    assert_invariant(batch);
+    reputation::increment_active(score, job_id, now);
+    event::emit(BatchSlotClaimed {
+        batch_id: batch.id.to_inner(),
+        job_id,
+        buyer: batch.buyer,
+        claimer,
+        amount: batch.amount,
+        slots_remaining: batch.slots_remaining,
+        timestamp_ms: now,
+    });
+    job_id
+}
+
+// === Cancel (buyer withdraws the unclaimed remainder — fee-free) ===
+
+/// Buyer-only, any time while slots remain. Claimed slots are already
+/// normal Jobs and are untouched; the batch object persists at 0 slots.
+public fun cancel_batch_open<T>(
+    batch: &mut BatchOpening<T>,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    assert!(ctx.sender() == batch.buyer, ENotBuyer);
+    let (refunded, slots) = drain_remainder(batch, ctx);
+    event::emit(BatchOpeningCancelled {
+        batch_id: batch.id.to_inner(),
+        buyer: batch.buyer,
+        refunded,
+        slots_cancelled: slots,
+        timestamp_ms: clock.timestamp_ms(),
+    });
+}
+
+// === Refund (ANYONE, after open_until — fee-free crank) ===
+
+/// Permissionless: the remainder can only ever go back to the buyer.
+public fun refund_batch_expired<T>(
+    batch: &mut BatchOpening<T>,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    let now = clock.timestamp_ms();
+    assert!(now > batch.open_until_ms, ENotExpired);
+    let (refunded, slots) = drain_remainder(batch, ctx);
+    event::emit(BatchOpeningRefunded {
+        batch_id: batch.id.to_inner(),
+        buyer: batch.buyer,
+        refunded,
+        slots_refunded: slots,
+        timestamp_ms: now,
+    });
+}
+
+/// Return the whole unclaimed remainder to the buyer and zero the slots.
+/// Aborts when nothing remains (already filled / cancelled / refunded) so
+/// replays and double-cancels fail loudly instead of minting empty events.
+fun drain_remainder<T>(batch: &mut BatchOpening<T>, ctx: &mut TxContext): (u64, u64) {
+    let slots = batch.slots_remaining;
+    assert!(slots > 0, ENoSlotsRemaining);
+    batch.slots_remaining = 0;
+    let refunded = batch.escrow.value();
+    let payout = coin::from_balance(batch.escrow.withdraw_all(), ctx);
+    transfer::public_transfer(payout, batch.buyer);
+    assert_invariant(batch);
+    (refunded, slots)
+}
+
+/// `escrow.value() == amount * slots_remaining` — after every mutation.
+fun assert_invariant<T>(batch: &BatchOpening<T>) {
+    assert!(
+        batch.escrow.value() == batch.amount * batch.slots_remaining,
+        EEscrowInvariant,
+    );
+}
+
+fun claims_of<T>(batch: &BatchOpening<T>, agent: address): u8 {
+    if (table::contains(&batch.claims_by_agent, agent)) {
+        *table::borrow(&batch.claims_by_agent, agent)
+    } else {
+        0
+    }
+}
+
+// === Read accessors (clients, indexer, prepare preflight) ===
+public fun buyer<T>(batch: &BatchOpening<T>): address { batch.buyer }
+public fun amount<T>(batch: &BatchOpening<T>): u64 { batch.amount }
+public fun slots_total<T>(batch: &BatchOpening<T>): u64 { batch.slots_total }
+public fun slots_remaining<T>(batch: &BatchOpening<T>): u64 {
+    batch.slots_remaining
+}
+public fun fee_bps<T>(batch: &BatchOpening<T>): u64 { batch.fee_bps }
+public fun spec_hash<T>(batch: &BatchOpening<T>): vector<u8> { batch.spec_hash }
+public fun open_until_ms<T>(batch: &BatchOpening<T>): u64 { batch.open_until_ms }
+public fun sla_ms<T>(batch: &BatchOpening<T>): u64 { batch.sla_ms }
+public fun review_window_ms<T>(batch: &BatchOpening<T>): u64 {
+    batch.review_window_ms
+}
+public fun reject_split_bps<T>(batch: &BatchOpening<T>): u64 {
+    batch.reject_split_bps
+}
+public fun claim_policy<T>(batch: &BatchOpening<T>): u8 { batch.claim_policy }
+public fun min_seller_level<T>(batch: &BatchOpening<T>): u8 {
+    batch.min_seller_level
+}
+public fun max_claims_per_agent<T>(batch: &BatchOpening<T>): u8 {
+    batch.max_claims_per_agent
+}
+/// Slots `agent` already claimed of this batch (0 when never claimed).
+public fun claims_by_agent<T>(batch: &BatchOpening<T>, agent: address): u8 {
+    claims_of(batch, agent)
+}
+public fun created_at_ms<T>(batch: &BatchOpening<T>): u64 { batch.created_at_ms }
+public fun escrow_value<T>(batch: &BatchOpening<T>): u64 { batch.escrow.value() }

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -115,6 +115,14 @@ const TIER4_ACTIVE_CAP_DEFAULT: u64 = 30;
 /// `NoDeliveryRegressionFloorKey`.
 const NO_DELIVERY_REGRESSION_FLOOR_DEFAULT: u64 = 3;
 
+// === Batch openings (S.1193) — slots-per-post bounds ===
+/// Default max slots one `batch::create_batch_open` may post. Live value
+/// is AdminCap-tunable via `MaxBatchSlotsKey` (founder posts 100–200
+/// waves today, may want more tomorrow — never a frozen const alone).
+const MAX_BATCH_SLOTS_DEFAULT: u64 = 250;
+/// Hard ceiling the admin can never exceed (raising it needs an upgrade).
+const MAX_BATCH_SLOTS_CEILING: u64 = 512;
+
 // === Errors ===
 const ENotAuthorized: u64 = 0;
 const EWrongState: u64 = 1;
@@ -148,6 +156,8 @@ const EUseReleaseV2: u64 = 20;
 /// (cap 0 would freeze a level entirely), the regression floor > 0 (floor
 /// 0 would regress everyone forever).
 const EBadTierBounds: u64 = 21;
+/// S.1193: batch-slot args out of range — the live max must be 1..ceiling.
+const EBadBatchSlots: u64 = 22;
 
 // === Objects ===
 
@@ -180,6 +190,9 @@ public struct TierActiveCapKey has copy, drop, store { level: u8 }
 /// S.1192 — regression-floor override on `FeeConfig.id` (value `u64`).
 /// Missing ⇒ `NO_DELIVERY_REGRESSION_FLOOR_DEFAULT`.
 public struct NoDeliveryRegressionFloorKey has copy, drop, store {}
+/// S.1193 — max batch slots override on `FeeConfig.id` (value `u64`).
+/// Missing ⇒ `MAX_BATCH_SLOTS_DEFAULT`.
+public struct MaxBatchSlotsKey has copy, drop, store {}
 /// S.1192 — marker DF on `Job.id`, set by `create_claimed` only: this Job
 /// entered through the open board, so it counted +1 into the seller's
 /// `active_seller_jobs` and must count −1 at terminal settle
@@ -337,6 +350,16 @@ public fun config_no_delivery_regression_floor(cfg: &FeeConfig): u64 {
         *df::borrow(&cfg.id, NoDeliveryRegressionFloorKey {})
     } else {
         NO_DELIVERY_REGRESSION_FLOOR_DEFAULT
+    }
+}
+
+/// Live max slots per batch post (S.1193): the DF when set, else the
+/// package default. Read at `batch::create_batch_open`.
+public fun config_max_batch_slots(cfg: &FeeConfig): u64 {
+    if (df::exists(&cfg.id, MaxBatchSlotsKey {})) {
+        *df::borrow(&cfg.id, MaxBatchSlotsKey {})
+    } else {
+        MAX_BATCH_SLOTS_DEFAULT
     }
 }
 
@@ -807,6 +830,19 @@ public fun set_no_delivery_regression_floor(_: &AdminCap, cfg: &mut FeeConfig, n
     }
 }
 
+/// S.1193 — set (add or update) the live max batch slots. Rails: 1..
+/// package hard ceiling (a 0 max would brick batch posting; raising the
+/// ceiling itself needs a future upgrade).
+public fun set_max_batch_slots(_: &AdminCap, cfg: &mut FeeConfig, n: u64) {
+    assert_version(cfg);
+    assert!(n >= 1 && n <= MAX_BATCH_SLOTS_CEILING, EBadBatchSlots);
+    if (df::exists(&cfg.id, MaxBatchSlotsKey {})) {
+        *df::borrow_mut(&mut cfg.id, MaxBatchSlotsKey {}) = n;
+    } else {
+        df::add(&mut cfg.id, MaxBatchSlotsKey {}, n);
+    }
+}
+
 /// Version cutover after an in-place package upgrade: bumps the shared
 /// config to the new package's VERSION, which makes every entry in the OLD
 /// package abort with EWrongVersion.
@@ -891,3 +927,7 @@ public fun default_max_job_amount(): u64 { MAX_JOB_AMOUNT_DEFAULT }
 public fun min_job_amount_floor(): u64 { MIN_JOB_AMOUNT_FLOOR }
 #[test_only]
 public fun max_job_amount_ceiling(): u64 { MAX_JOB_AMOUNT_CEILING }
+#[test_only]
+public fun default_max_batch_slots(): u64 { MAX_BATCH_SLOTS_DEFAULT }
+#[test_only]
+public fun max_batch_slots_ceiling(): u64 { MAX_BATCH_SLOTS_CEILING }

--- a/contracts/a2a_escrow/tests/batch_tests.move
+++ b/contracts/a2a_escrow/tests/batch_tests.move
@@ -1,0 +1,531 @@
+#[test_only]
+module a2a_escrow::batch_tests;
+
+use a2a_escrow::batch::{Self, BatchOpening};
+use a2a_escrow::escrow::{Self, AdminCap, FeeConfig, Job};
+use a2a_escrow::reputation::{Self, AgentScore, ScoreBoard};
+use agent_id::registry::{Self, Registry};
+use sui::clock::{Self, Clock};
+use sui::coin::{Self, Coin};
+use sui::sui::SUI;
+use sui::test_scenario as ts;
+
+const ADMIN: address = @0xAD; // deployer = AdminCap holder + fee receiver
+const BUYER: address = @0xA;
+const SELLER: address = @0xB; // registered + active claimer
+const SELLER2: address = @0xE; // a second registered claimer
+const LURKER: address = @0xC; // never registered
+
+const SLOT_AMOUNT: u64 = 80_000; // $0.08 — the desk's wave unit
+const SLOTS: u64 = 10;
+const OPEN_UNTIL: u64 = 500_000; // ms
+const SLA_MS: u64 = 400_000; // ms
+const REVIEW_WINDOW: u64 = 100_000; // ms
+const SPLIT_BPS: u64 = 10_000; // open board: reject = 100% buyer
+const POLICY_ANY: u8 = 0;
+
+fun setup(): (ts::Scenario, Clock) {
+    let mut sc = ts::begin(ADMIN);
+    escrow::init_for_testing(ts::ctx(&mut sc));
+    registry::init_for_testing(ts::ctx(&mut sc));
+    let clk = clock::create_for_testing(ts::ctx(&mut sc));
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        reputation::create_score_board(&cap, &mut cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    register_agent(&mut sc, &clk, SELLER);
+    register_agent(&mut sc, &clk, SELLER2);
+    (sc, clk)
+}
+
+fun register_agent(sc: &mut ts::Scenario, clk: &Clock, who: address) {
+    ts::next_tx(sc, who);
+    let mut reg = ts::take_shared<Registry>(sc);
+    registry::register(
+        &mut reg,
+        option::none(),
+        vector[],
+        option::none(),
+        option::none(),
+        clk,
+        ts::ctx(sc),
+    );
+    ts::return_shared(reg);
+}
+
+fun ensure_score(sc: &mut ts::Scenario, clk: &Clock, who: address) {
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let mut board = ts::take_shared<ScoreBoard>(sc);
+    if (!reputation::has_score(&board, who)) {
+        reputation::create_empty_score(&mut board, who, &cfg, clk, ts::ctx(sc));
+    };
+    ts::return_shared(board);
+    ts::return_shared(cfg);
+}
+
+fun take_score(sc: &ts::Scenario, who: address): AgentScore {
+    let board = ts::take_shared<ScoreBoard>(sc);
+    let addr = reputation::score_address(&board, who);
+    ts::return_shared(board);
+    ts::take_shared_by_id<AgentScore>(sc, object::id_from_address(addr))
+}
+
+fun active_of(sc: &mut ts::Scenario, who: address): u64 {
+    ts::next_tx(sc, who);
+    let score = take_score(sc, who);
+    let n = reputation::active_seller_jobs(&score);
+    ts::return_shared(score);
+    n
+}
+
+fun post_batch(sc: &mut ts::Scenario, clk: &Clock, slots: u64, max_claims: u8): ID {
+    post_batch_with(sc, clk, SLOT_AMOUNT * slots, slots, POLICY_ANY, 0, max_claims)
+}
+
+fun post_batch_with(
+    sc: &mut ts::Scenario,
+    clk: &Clock,
+    payment: u64,
+    slots: u64,
+    claim_policy: u8,
+    min_seller_level: u8,
+    max_claims_per_agent: u8,
+): ID {
+    ts::next_tx(sc, BUYER);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let coin = coin::mint_for_testing<SUI>(payment, ts::ctx(sc));
+    let id = batch::create_batch_open<SUI>(
+        coin,
+        slots,
+        b"wave-spec-hash",
+        OPEN_UNTIL,
+        SLA_MS,
+        REVIEW_WINDOW,
+        SPLIT_BPS,
+        claim_policy,
+        min_seller_level,
+        max_claims_per_agent,
+        &cfg,
+        clk,
+        ts::ctx(sc),
+    );
+    ts::return_shared(cfg);
+    id
+}
+
+fun claim_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
+    ensure_score(sc, clk, who);
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let reg = ts::take_shared<Registry>(sc);
+    let mut score = take_score(sc, who);
+    let mut b = ts::take_shared<BatchOpening<SUI>>(sc);
+    let job_id = batch::batch_claim(&mut b, &reg, &mut score, &cfg, clk, ts::ctx(sc));
+    ts::return_shared(b);
+    ts::return_shared(score);
+    ts::return_shared(reg);
+    ts::return_shared(cfg);
+    job_id
+}
+
+fun assert_received(sc: &mut ts::Scenario, who: address, expect: u64) {
+    ts::next_tx(sc, who);
+    let received = ts::take_from_address<Coin<SUI>>(sc, who);
+    assert!(received.value() == expect, 100);
+    ts::return_to_address(who, received);
+}
+
+// === Happy path: one post, N slots, invariant holds per claim ===
+
+#[test]
+fun one_post_ten_slots_claim_decrements_and_mints_a_normal_job() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        assert!(batch::slots_total(&b) == SLOTS, 0);
+        assert!(batch::slots_remaining(&b) == SLOTS, 1);
+        assert!(batch::amount(&b) == SLOT_AMOUNT, 2);
+        assert!(batch::escrow_value(&b) == SLOT_AMOUNT * SLOTS, 3);
+        ts::return_shared(b);
+    };
+    clk.set_for_testing(10_000);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        // 10 → 9 and the escrow invariant holds after the split.
+        assert!(batch::slots_remaining(&b) == 9, 4);
+        assert!(batch::escrow_value(&b) == SLOT_AMOUNT * 9, 5);
+        assert!(batch::claims_by_agent(&b, SELLER) == 1, 6);
+        ts::return_shared(b);
+        // The slot minted a NORMAL claimed Job: right parties, right size,
+        // ClaimedJobKey stamped (the counter decrements at settle).
+        let job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        assert!(escrow::buyer(&job) == BUYER, 7);
+        assert!(escrow::seller(&job) == SELLER, 8);
+        assert!(escrow::amount(&job) == SLOT_AMOUNT, 9);
+        assert!(escrow::is_claimed_job(&job), 10);
+        assert!(escrow::deliver_by_ms(&job) == 10_000 + SLA_MS, 11);
+        ts::return_shared(job);
+    };
+    // The claim seated one job on the seller's GLOBAL active counter.
+    assert!(active_of(&mut sc, SELLER) == 1, 12);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Per-agent wave limit ===
+
+#[test]
+#[expected_failure(abort_code = batch::EMaxClaimsReached)]
+fun second_claim_same_agent_at_max_one_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+fun max_claims_two_allows_two_sequential_claims_then_other_agents() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 2);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk); // second slot, allowed at max 2
+    claim_as(&mut sc, SELLER2, &clk); // different agent unaffected
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        assert!(batch::slots_remaining(&b) == 7, 0);
+        assert!(batch::claims_by_agent(&b, SELLER) == 2, 1);
+        assert!(batch::claims_by_agent(&b, SELLER2) == 1, 2);
+        assert!(batch::escrow_value(&b) == SLOT_AMOUNT * 7, 3);
+        ts::return_shared(b);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Slots exhausted ===
+
+#[test]
+#[expected_failure(abort_code = batch::ENoSlotsRemaining)]
+fun claim_with_zero_slots_left_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, 2, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER2, &clk); // drains the batch (2 slots)
+    register_agent(&mut sc, &clk, LURKER);
+    claim_as(&mut sc, LURKER, &clk);
+    abort 0
+}
+
+#[test]
+fun filled_batch_persists_with_zero_balance() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, 2, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER2, &clk);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        // v1 lock: the drained batch is NOT deleted (Table non-empty) —
+        // it persists shared at 0 slots / 0 balance; invariant holds.
+        let b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        assert!(batch::slots_remaining(&b) == 0, 0);
+        assert!(batch::escrow_value(&b) == 0, 1);
+        ts::return_shared(b);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Cancel + expiry refund ===
+
+#[test]
+fun cancel_refunds_unclaimed_remainder_fee_free() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk); // 1 claimed, 9 remain
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::cancel_batch_open(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(batch::slots_remaining(&b) == 0, 0);
+        assert!(batch::escrow_value(&b) == 0, 1);
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    // 9 × $0.08 back, fee-free; the claimed slot's Job is untouched.
+    assert_received(&mut sc, BUYER, SLOT_AMOUNT * 9);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = batch::ENotBuyer)]
+fun cancel_by_stranger_aborts() {
+    let (mut sc, clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, LURKER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::cancel_batch_open(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+fun expiry_refund_is_permissionless_and_fee_free() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(OPEN_UNTIL + 1);
+    ts::next_tx(&mut sc, LURKER); // anyone may crank
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::refund_batch_expired(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    assert_received(&mut sc, BUYER, SLOT_AMOUNT * SLOTS);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = batch::ENotExpired)]
+fun expiry_refund_before_open_until_aborts() {
+    let (mut sc, clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, LURKER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::refund_batch_expired(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::ENoSlotsRemaining)]
+fun double_cancel_aborts() {
+    let (mut sc, clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::cancel_batch_open(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        batch::cancel_batch_open(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+// === Phase C gates stack on batch_claim ===
+
+#[test]
+#[expected_failure(abort_code = batch::EMinSellerLevelUnmet)]
+fun min_level_two_refuses_fresh_seller() {
+    let (mut sc, mut clk) = setup();
+    post_batch_with(&mut sc, &clk, SLOT_AMOUNT * SLOTS, SLOTS, POLICY_ANY, 2, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk); // empty score = Level 1 < floor 2
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EClaimPolicyUnmet)]
+fun proven_policy_refuses_unproven_claimer() {
+    let (mut sc, mut clk) = setup();
+    post_batch_with(&mut sc, &clk, SLOT_AMOUNT * SLOTS, SLOTS, 1, 0, 1);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk); // empty score: 0 distinct buyers
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EActiveJobCap)]
+fun global_active_cap_counts_batch_slots() {
+    let (mut sc, mut clk) = setup();
+    // Level 1 cap is 4 — with maxClaimsPerAgent 10 on a single wave, the
+    // 5th slot claim hits the GLOBAL cap, not the wave limit.
+    post_batch(&mut sc, &clk, SLOTS, 10);
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 4, 0);
+    claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EScoreNotClaimer)]
+fun claim_on_borrowed_score_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    ensure_score(&mut sc, &clk, SELLER);
+    ts::next_tx(&mut sc, SELLER2);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut score = take_score(&sc, SELLER); // not SELLER2's score
+        let mut b = ts::take_shared<BatchOpening<SUI>>(&sc);
+        batch::batch_claim(&mut b, &reg, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(score);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+// === A claimed slot settles like any Job (release frees the seat) ===
+
+#[test]
+fun claimed_slot_releases_via_release_v2_and_frees_the_seat() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job_id = claim_as(&mut sc, SELLER, &clk);
+    assert!(active_of(&mut sc, SELLER) == 1, 0);
+    ts::next_tx(&mut sc, SELLER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        escrow::deliver(&mut job, b"delivery", &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let mut score = take_score(&sc, SELLER);
+        reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    assert!(active_of(&mut sc, SELLER) == 0, 1);
+    // Seller got the slot minus the 2.5% test-default fee.
+    assert_received(&mut sc, SELLER, SLOT_AMOUNT - SLOT_AMOUNT * 250 / 10_000);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === Create bounds ===
+
+#[test]
+#[expected_failure(abort_code = batch::EBadPayment)]
+fun payment_not_exact_multiple_aborts() {
+    let (mut sc, clk) = setup();
+    post_batch_with(&mut sc, &clk, SLOT_AMOUNT * SLOTS + 1, SLOTS, POLICY_ANY, 0, 1);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EBadSlots)]
+fun slots_above_live_max_abort() {
+    let (mut sc, clk) = setup();
+    let slots = escrow::default_max_batch_slots() + 1;
+    post_batch_with(&mut sc, &clk, SLOT_AMOUNT * slots, slots, POLICY_ANY, 0, 1);
+    abort 0
+}
+
+#[test]
+fun admin_can_raise_live_max_batch_slots() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        assert!(escrow::config_max_batch_slots(&cfg) == escrow::default_max_batch_slots(), 0);
+        escrow::set_max_batch_slots(&cap, &mut cfg, 300);
+        assert!(escrow::config_max_batch_slots(&cfg) == 300, 1);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    // A 251-slot wave now posts (min amount default is $0.05 in tests —
+    // use it so the per-slot bound holds).
+    let slots = 251;
+    post_batch_with(&mut sc, &clk, SLOT_AMOUNT * slots, slots, POLICY_ANY, 0, 1);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = escrow::EBadBatchSlots)]
+fun admin_cannot_exceed_hard_ceiling() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, ADMIN);
+    {
+        let cap = ts::take_from_sender<AdminCap>(&sc);
+        let mut cfg = ts::take_shared<FeeConfig>(&sc);
+        escrow::set_max_batch_slots(&cap, &mut cfg, escrow::max_batch_slots_ceiling() + 1);
+        ts::return_shared(cfg);
+        ts::return_to_sender(&sc, cap);
+    };
+    clock::destroy_for_testing(clk);
+    abort 99
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EOpenRejectMustBeFullBuyer)]
+fun partial_reject_split_aborts_at_post() {
+    let (mut sc, clk) = setup();
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let coin = coin::mint_for_testing<SUI>(SLOT_AMOUNT * SLOTS, ts::ctx(&mut sc));
+        batch::create_batch_open<SUI>(
+            coin, SLOTS, b"h", OPEN_UNTIL, SLA_MS, REVIEW_WINDOW,
+            8_000, POLICY_ANY, 0, 1, &cfg, &clk, ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EBatchExpired)]
+fun claim_after_open_until_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(OPEN_UNTIL + 1);
+    claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EClaimerIsBuyer)]
+fun buyer_cannot_claim_own_batch() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    register_agent(&mut sc, &clk, BUYER);
+    claim_as(&mut sc, BUYER, &clk);
+    abort 0
+}

--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -44,9 +44,7 @@ Each Passport maintains **its own** pool — do not count other seats toward you
 
 **Ledgers (SSOT in this repo):** `AGENT-REGISTER-SETTLE-LEDGER.md` (register bounties — read the file + directory by hand; no automatic check covers it) · `SOCIAL-COMMENT-SETTLE-LEDGER.md` · `REFERRAL-SETTLE-LEDGER.md` (both deduped automatically by `t2000_job_settle` / `t2000_job_reject` from the job title + delivery — S.1188; the standalone `t2000_gtm_ledger` tool never surfaced in Connect). Connect never writes a ledger: **append the git row after each decision**.
 
-**Posting discipline:** `t2000_job_open` **one at a time**. Wait for Completed (or a hard refuse) before the next.  
-Never parallel opens — Sui locks the USDC coin (`InsufficientFundsForWithdraw`, object locked).  
-Retry a failed open **once**, then continue.
+**Posting discipline (S.1193):** pack refills are **ONE `t2000_job_batch_open` wave per pack** — the coin-lock fragility of 50 sequential opens is gone with the loop. When you do post singles (one-off smokes, appendix rows): `t2000_job_open` **one at a time**, wait for Completed before the next (Sui locks the USDC coin on parallel opens), retry a failed post **once**, then continue.
 
 **Escrow cap (per run):** lock at most **$16** USDC in **new** openings this paste (`MAX_ESCROW_RUN`) — twin full deficit is $15.59, so one run can cover both packs. Override: `MAX_ESCROW_RUN=all` or a higher number. Split across the **2×/day** runs if limits are tight.
 
@@ -98,24 +96,29 @@ Split inventory by brief tag — **do not merge v1 + v2 into one pool:**
 
 Use `t2000_job_board` filtered to your buyer address, or `t2000_jobs` role=buyer → `openings[]`. Ignore other seats.
 
-| Pool | Your live unclaimed | Action |
+| Pool | Your live unclaimed **SLOTS** | Action |
 |------|---------------------|--------|
 | v1 | **≥ TARGET_METRICS_V1 (50)** | Skip v1 posting this run |
-| v1 | **N &lt; TARGET** | Post **(TARGET − N)** v1 jobs in C1 until v1 slice hits cap or target |
+| v1 | **N &lt; TARGET** | Post ONE v1 **wave** in C1 with `slots: TARGET − N` |
 | v2 | **≥ TARGET_METRICS_V2 (50)** | Skip v2 posting this run |
-| v2 | **N &lt; TARGET** | Post **(TARGET − N)** v2 jobs in C2 until v2 slice hits cap or target |
+| v2 | **N &lt; TARGET** | Post ONE v2 **wave** in C2 with `slots: TARGET − N` |
 
-Shared **`MAX_ESCROW_RUN`** budget applies across C1 + C2 in one paste.
+**Count SLOTS, not rows (S.1193):** live inventory = Σ `slotsRemaining`
+over your batch rows matching the pack brief **+** each legacy unclaimed
+single (counts as 1 slot) while the pre-batch singles drain. Shared
+**`MAX_ESCROW_RUN`** budget applies across C1 + C2 in one paste — a
+wave's escrow is **`slots × maxUsdc`**, checked BEFORE posting.
 
 **Title discipline (both packs):** `t2000_job_open` `title` = the pack job name **exactly** — e.g. `[MCP] claim — 9`, `Board total`, `Register new Agent ID`. **Never** prefix `Metrics:` or `Metrics: ` (wrong: `Metrics: Board total`). Campaign routing is the **`PACK: protocol-metrics`** / **`PACK: protocol-metrics-v2`** footer in the brief, not the title. If you already posted with `Metrics:` this run, stop — do not post more until the founder confirms.
 
-### C1 — v1 `t2000_job_open` (sequential)
+### C1 — v1 `t2000_job_batch_open` (ONE wave, not 50 opens — S.1193)
 
-Open `PROMPT-50-PROTOCOL-METRICS.md` — **exact title** (no `Metrics:` prefix), **maxUsdc, slaHours**, `openHours: 168`, claim policy **Anyone**, brief = job brief + EXCLUSIVITY (`PACK: protocol-metrics`; jobs **12–39** carry ANTI-SELF-DEAL). **Rotate** within v1: never repost a v1 title while your unclaimed v1 copy of that title is still live. Per-job limit ≥ **0.50** for v1 register rows.
+Open `PROMPT-50-PROTOCOL-METRICS.md`. Post **ONE wave** per deficit:
+`t2000_job_batch_open { title, brief, maxUsdc, slots: TARGET − N, openHours: 168, claimPolicy: 0, maxClaimsPerAgent: 1 }` — **exact title** (no `Metrics:` prefix; ONE title per wave card, rotate titles ACROSS waves, never within), brief = job brief + EXCLUSIVITY (`PACK: protocol-metrics`; jobs **12–39** carry ANTI-SELF-DEAL). `maxUsdc` is PER SLOT. `maxClaimsPerAgent: 1` is the wave-level anti-hoard — keep it. Per-job limit ≥ **0.50** for v1 register rows. Sequential 50× `t2000_job_open` is **deprecated** for packs — singles stay for one-off smokes only.
 
-### C2 — v2 `t2000_job_open` (sequential)
+### C2 — v2 `t2000_job_batch_open` (ONE wave)
 
-Open `PROMPT-50-PROTOCOL-METRICS-V2.md` — same discipline; **exact title** (no `Metrics:` prefix); EXCLUSIVITY uses `PACK: protocol-metrics-v2`; jobs **8–43** carry ANTI-SELF-DEAL. **Rotate** within v2 only. Per-job limit ≥ **1.00** for v2 register rows.
+Open `PROMPT-50-PROTOCOL-METRICS-V2.md` — same wave discipline; EXCLUSIVITY uses `PACK: protocol-metrics-v2`; jobs **8–43** carry ANTI-SELF-DEAL. Per-job limit ≥ **1.00** for v2 register rows.
 
 **Claim gate (S.1182 → S.1190 → S.1192):** jobs **5–7** (register) and **39–43** (review after hire) → `claimPolicy: 2` + `minSellerLevel: 2` on `t2000_job_open` (**Proven · 4★+** — ≥3 distinct buyer reviews AND a 4.0★ average — with a Level 2 floor). All other v2 jobs → **Anyone**, no Level floor (omit `claimPolicy`/`minSellerLevel` or send 0). The old `proven: true` boolean is deprecated (maps to policy 1 only) — always send `claimPolicy`. Sellers also carry per-Level active caps (4/10/20/30) — a hunter at cap is refused at claim until they settle in-flight work; that is the S.1192 anti-hoard gate working, not an outage.
 

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -1,0 +1,239 @@
+// Batch (wave) verbs of `t2 job` (S.1193 — Phase D). ONE post = N
+// homogeneous slots with a SINGLE escrow of slots × per-slot budget; each
+// claimed slot mints a normal Job (deliver/settle with the ordinary job
+// verbs). One claim per tx (v1 lock) — a wave allowing more claims per
+// agent means running batch-claim again. Sequential 50× `t2 job open`
+// is the thing this replaces; singles stay for one-offs.
+//
+//   batch-open    post a wave — ESCROWS slots × budget NOW    (buyer)
+//   batch-claim   claim ONE slot → funded Job, work starts    (seller)
+//   batch-cancel  withdraw the unclaimed remainder, fee-free  (buyer)
+
+import {
+  assertSpendAllowed,
+  recordSpendIfLanded,
+} from '../lib/spend-gate.js';
+import type { Command } from 'commander';
+import {
+  A2A_SCORE_BOARD_ID,
+  BATCH_OPENING_TYPE_MARKER,
+  cancelBatchOpenJob,
+  claimBatchOpenJob,
+  claimPolicyLabel,
+  claimPolicyRequirement,
+  getAgentScore,
+  getBatchClaimsByAgent,
+  getBatchOpening,
+  getSuiClient,
+  MAX_BATCH_SLOTS_DEFAULT,
+  MAX_JOB_USDC,
+  OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  postBatchOpenJob,
+  preflightBatchClaim,
+  resolveCreatedObjectId,
+  sellerLevelLabel,
+} from '@t2000/sdk';
+import { parseDuration } from './job.js';
+import {
+  resolveBrief,
+  resolveClaimPolicyFlags,
+  resolveMinSellerLevelFlag,
+} from './open.js';
+import { withAgent } from '../lib/with-agent.js';
+import {
+  handleError,
+  isJsonMode,
+  printBlank,
+  printInfo,
+  printJson,
+  printKeyValue,
+  printSuccess,
+} from '../output.js';
+
+const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
+
+/** Adds the batch verbs onto the `t2 job` group. */
+export function registerBatchVerbs(group: Command) {
+  group
+    .command('batch-open')
+    .description('Batch — post ONE wave of N identical slots (buyer); ESCROWS slots × budget on-chain now. Each claimed slot becomes a normal Job; the unclaimed remainder refunds fee-free (cancel any time, or the crank after the window).')
+    .requiredOption('--title <text>', "The wave's public name (up to 80 chars)")
+    .requiredOption('--brief <file-or-text>', 'What every slot delivers — PUBLIC, one brief for the whole wave')
+    .requiredOption('--max <usdc>', `PER-SLOT budget (max ${MAX_JOB_USDC}); total escrow = slots × this`)
+    .requiredOption('--slots <n>', `Slots in the wave (1–${MAX_BATCH_SLOTS_DEFAULT}; the live max is AdminCap-tunable)`)
+    .option('--max-claims-per-agent <n>', 'Slots one agent may claim of THIS wave (default 1)', '1')
+    .option('--sla <duration>', 'Delivery window per slot once claimed (e.g. 30m, 24h, 7d)', '24h')
+    .option('--open-for <duration>', 'How long the wave stays claimable before it refunds', '24h')
+    .option(
+      '--claim-policy <policy>',
+      'Who may claim: 0 Anyone (default) · 1 Proven · 2 Proven · 4★+; claiming stays instant and $0',
+    )
+    .option(
+      '--min-seller-level <level>',
+      'Minimum seller Level to claim: 1–4 (default none) — independent of --claim-policy',
+    )
+    .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
+    .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
+    .action(
+      async (opts: {
+        title: string;
+        brief: string;
+        max: string;
+        slots: string;
+        maxClaimsPerAgent: string;
+        sla: string;
+        openFor: string;
+        claimPolicy?: string;
+        minSellerLevel?: string;
+        key?: string;
+        api?: string;
+      }) => {
+        try {
+          const base = opts.api ?? DEFAULT_API_BASE;
+          const maxUsdc = Number(opts.max);
+          if (!Number.isFinite(maxUsdc) || maxUsdc <= 0 || maxUsdc > MAX_JOB_USDC) {
+            throw new Error(`--max is the PER-SLOT budget: between 0.01 and ${MAX_JOB_USDC} USDC.`);
+          }
+          const slots = Number(opts.slots);
+          if (!Number.isInteger(slots) || slots < 1 || slots > MAX_BATCH_SLOTS_DEFAULT) {
+            throw new Error(`--slots must be an integer 1–${MAX_BATCH_SLOTS_DEFAULT}.`);
+          }
+          const maxClaims = Number(opts.maxClaimsPerAgent);
+          if (!Number.isInteger(maxClaims) || maxClaims < 1 || maxClaims > slots) {
+            throw new Error('--max-claims-per-agent must be an integer ≥1 and ≤ --slots.');
+          }
+          const claimPolicy = resolveClaimPolicyFlags(opts);
+          const minSellerLevel = resolveMinSellerLevelFlag(opts.minSellerLevel);
+          const brief = await resolveBrief(opts.brief);
+          // The WHOLE wave escrows at post — the spend gate sees the total.
+          const totalUsdc = maxUsdc * slots;
+          assertSpendAllowed(totalUsdc);
+          const agent = await withAgent({ keyPath: opts.key });
+          const digest = await postBatchOpenJob(base, agent.signer, {
+            title: opts.title.trim(),
+            brief,
+            maxUsdc,
+            slots,
+            slaMinutes: Math.round(parseDuration(opts.sla) / 60_000),
+            openHours: parseDuration(opts.openFor) / 3_600_000,
+            claimPolicy,
+            ...(minSellerLevel > 0 ? { minSellerLevel } : {}),
+            maxClaimsPerAgent: maxClaims,
+          });
+          recordSpendIfLanded(totalUsdc, digest);
+          const batchId = await resolveCreatedObjectId(
+            getSuiClient(),
+            digest,
+            BATCH_OPENING_TYPE_MARKER,
+          );
+          if (isJsonMode()) {
+            printJson({ digest, batchId, slots, totalUsdc });
+            return;
+          }
+          printBlank();
+          printSuccess(
+            `Wave posted — ${slots} slot${slots === 1 ? '' : 's'} × $${maxUsdc.toFixed(2)} = $${totalUsdc.toFixed(2)} USDC escrowed in ONE tx.`,
+          );
+          if (claimPolicy !== OPENING_CLAIM_POLICY_ANY_ACTIVE) {
+            printInfo(
+              `${claimPolicyLabel(claimPolicy)} gate on: ${claimPolicyRequirement(claimPolicy)}`,
+            );
+          }
+          if (minSellerLevel > 0) {
+            printInfo(`${sellerLevelLabel(minSellerLevel)}+ floor on.`);
+          }
+          if (maxClaims === 1) {
+            printInfo('One slot per agent — a hunter cannot hoard this wave.');
+          } else {
+            printInfo(`Up to ${maxClaims} slots per agent (sequential claims).`);
+          }
+          printBlank();
+          if (batchId) printKeyValue('Batch', batchId);
+          printKeyValue('Tx', digest);
+          printBlank();
+          printInfo(
+            `Each claim starts a normal job immediately. Unclaimed slots refund in ${opts.openFor}` +
+              (batchId ? ` (or now: t2 job batch-cancel ${batchId})` : '.'),
+          );
+          printBlank();
+        } catch (error) {
+          handleError(error);
+        }
+      },
+    );
+
+  group
+    .command('batch-claim')
+    .argument('<batchId>', 'The batch object id (0x…, from t2 job board)')
+    .description('Claim ONE slot of a wave (seller) — $0, first-come; the funded Job starts immediately. Claim again for another slot when the wave allows more than one per agent.')
+    .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
+    .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
+    .action(async (batchId: string, opts: { key?: string; api?: string }) => {
+      try {
+        const base = opts.api ?? DEFAULT_API_BASE;
+        const agent = await withAgent({ keyPath: opts.key });
+        // English preflight (best-effort, same shape as t2 job claim):
+        // slots, per-agent wave limit, then the Phase C policy/cap/floor
+        // stack — a read hiccup falls through to the server's own checks.
+        const live = await getBatchOpening(getSuiClient(), batchId.trim()).catch(() => null);
+        if (live && A2A_SCORE_BOARD_ID) {
+          const [score, myClaims] = await Promise.all([
+            getAgentScore(getSuiClient(), agent.address()).catch(() => null),
+            getBatchClaimsByAgent(getSuiClient(), live, agent.address()).catch(() => 0),
+          ]);
+          const pf = preflightBatchClaim(score, live, myClaims);
+          if (!pf.valid) {
+            throw new Error(`${pf.error} Find claimable work: t2 job board`);
+          }
+        }
+        const digest = await claimBatchOpenJob(base, agent.signer, batchId.trim());
+        const jobId = await resolveCreatedObjectId(
+          getSuiClient(),
+          digest,
+          '::escrow::Job<',
+        );
+        if (isJsonMode()) {
+          printJson({ digest, jobId });
+          return;
+        }
+        printBlank();
+        printSuccess('Slot claimed — a normal funded Job minted. Work starts NOW.');
+        printBlank();
+        if (jobId) printKeyValue('Job', jobId);
+        printKeyValue('Tx', digest);
+        printBlank();
+        printInfo(
+          jobId
+            ? `Deliver before the deadline: t2 job deliver ${jobId} <file>`
+            : 'Deliver before the deadline — find it: t2 job watch --mine',
+        );
+        printBlank();
+      } catch (error) {
+        handleError(error);
+      }
+    });
+
+  group
+    .command('batch-cancel')
+    .argument('<batchId>', 'Your batch object id (0x…)')
+    .description("Withdraw a wave's UNCLAIMED remainder (buyer) — fee-free, any time; claimed slots are running Jobs and are untouched")
+    .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
+    .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
+    .action(async (batchId: string, opts: { key?: string; api?: string }) => {
+      try {
+        const base = opts.api ?? DEFAULT_API_BASE;
+        const agent = await withAgent({ keyPath: opts.key });
+        const digest = await cancelBatchOpenJob(base, agent.signer, batchId.trim());
+        if (isJsonMode()) {
+          printJson({ digest, cancelled: true });
+          return;
+        }
+        printBlank();
+        printSuccess('Cancelled — the unclaimed remainder is back in your wallet, fee-free.');
+        printKeyValue('Tx', digest);
+        printBlank();
+      } catch (error) {
+        handleError(error);
+      }
+    });
+}

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -47,6 +47,7 @@ import {
   type Job,
 } from '@t2000/sdk';
 import { runSponsoredTx } from '../lib/agent-register.js';
+import { registerBatchVerbs } from './batch.js';
 import { registerOpenVerbs } from './open.js';
 import {
   assertBuyerRequirements,
@@ -1456,4 +1457,5 @@ no fund step; unclaimed openings refund fee-free):
 
   // The OPEN door — board verbs live flat on this same group (one noun).
   registerOpenVerbs(group);
+  registerBatchVerbs(group);
 }

--- a/packages/cli/src/lib/tx-guard.test.ts
+++ b/packages/cli/src/lib/tx-guard.test.ts
@@ -277,6 +277,24 @@ describe('B — the map matches the SDK builders, verb for verb', () => {
       'open-cancel',
       `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::cancel_open`,
     ],
+    // S.1193: the batch (wave) family — new module, same package.
+    [
+      'batch-open-create',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::batch::create_batch_open`,
+    ],
+    ['batch-open-claim', `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::batch::batch_claim`],
+    [
+      'batch-open-claim',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::reputation::create_empty_score`,
+    ],
+    [
+      'batch-open-cancel',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::batch::cancel_batch_open`,
+    ],
+    [
+      'batch-open-refund',
+      `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::batch::refund_batch_expired`,
+    ],
     [
       'open-refund',
       `${MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID}::opening::refund_unclaimed`,

--- a/packages/cli/src/lib/tx-guard.ts
+++ b/packages/cli/src/lib/tx-guard.ts
@@ -141,6 +141,29 @@ const ACTION_TARGETS: Record<
     module: 'opening',
     functions: ['refund_unclaimed'],
   },
+  // Batch (wave) openings — S.1193, `a2a_escrow::batch`. One claim per
+  // tx (v1 lock); the scoreless-claimer precursor rides cross-module
+  // exactly like open-claim's.
+  'batch-open-create': {
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'batch',
+    functions: ['create_batch_open'],
+  },
+  'batch-open-claim': {
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'batch',
+    functions: ['batch_claim', 'reputation::create_empty_score'],
+  },
+  'batch-open-cancel': {
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'batch',
+    functions: ['cancel_batch_open'],
+  },
+  'batch-open-refund': {
+    pkgs: [MAINNET_A2A_ESCROW_OPENING_PACKAGE_ID],
+    module: 'batch',
+    functions: ['refund_batch_expired'],
+  },
   // On-chain review stars (S.1054) — `a2a_escrow::reputation`. Two entries:
   // the seller's first-ever review lazily creates their AgentScore.
   'job-review': {

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -160,6 +160,22 @@ export {
 } from './wallet/reputation.js';
 export type { AgentScore, SellerLevel } from './wallet/reputation.js';
 
+// S.1193 — batch (wave) openings: browser-safe builders + preflights.
+export {
+  MAX_BATCH_SLOTS_DEFAULT,
+  BATCH_OPENING_TYPE_MARKER,
+  buildBatchClaimTx,
+  buildCancelBatchOpeningTx,
+  buildCreateBatchOpeningTx,
+  buildRefundBatchExpiredTx,
+  getBatchClaimsByAgent,
+  getBatchOpening,
+  preflightBatchClaim,
+  preflightCreateBatchOpening,
+} from './wallet/batch.js';
+export type { BatchOpening, BatchOpeningTerms } from './wallet/batch.js';
+
+
 // Commerce API client (agent services + content-addressed job specs) —
 // browser-safe (WebCrypto hashing, fetch only). Console surfaces share the
 // tamper-verify.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -167,6 +167,7 @@ export {
   A2A_ESCROW_PACKAGE_V7_ID,
   A2A_ESCROW_PACKAGE_V8_ID,
   A2A_ESCROW_PACKAGE_V10_ID,
+  A2A_ESCROW_PACKAGE_V11_ID,
   MAX_OPEN_WINDOW_MS,
   OPENING_CLAIM_POLICY_ANY_ACTIVE,
   OPENING_CLAIM_POLICY_PROVEN,
@@ -180,6 +181,20 @@ export {
   preflightCreateOpening,
 } from './wallet/opening.js';
 export type { Opening, OpeningTerms } from './wallet/opening.js';
+export {
+  MAX_BATCH_SLOTS_DEFAULT,
+  BATCH_OPENING_TYPE_MARKER,
+  buildBatchClaimTx,
+  buildCancelBatchOpeningTx,
+  buildCreateBatchOpeningTx,
+  buildRefundBatchExpiredTx,
+  getBatchClaimsByAgent,
+  getBatchOpening,
+  preflightBatchClaim,
+  preflightCreateBatchOpening,
+} from './wallet/batch.js';
+export type { BatchOpening, BatchOpeningTerms } from './wallet/batch.js';
+
 export {
   A2A_SCORE_BOARD_ID,
   MAINNET_A2A_SCORE_BOARD_ID,
@@ -235,6 +250,10 @@ export {
   type SponsoredTxGuard,
   refundOpenJob,
   submitJobReview,
+  cancelBatchOpenJob,
+  claimBatchOpenJob,
+  postBatchOpenJob,
+  refundBatchOpenJob,
 } from './open-jobs.js';
 export type { OpenJobFilter, OpenJobRow, OpenJobsPage } from './open-jobs.js';
 // Seller onboarding, headless (S.1158 — SPEC_HEADLESS_SELL_STACK §3): the

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -76,6 +76,16 @@ export interface OpenJobRow {
   /** S.1192 — minimum EFFECTIVE seller level to claim (render with
    *  `sellerLevelLabel`). Absent on pre-S.1192 rows = 0 (no floor). */
   minSellerLevel?: number;
+  /** S.1193 — row kind: absent or "single" = one Opening; "batch" = a
+   *  wave (ONE row for the whole batch — never N duplicate rows). */
+  kind?: 'single' | 'batch';
+  /** S.1193 — wave size (batch rows only). */
+  slotsTotal?: number;
+  /** S.1193 — unclaimed slots left (batch rows only; a batch row is
+   *  claimable while status is open AND slotsRemaining > 0). */
+  slotsRemaining?: number;
+  /** S.1193 — slots one agent may claim of this wave (batch rows only). */
+  maxClaimsPerAgent?: number;
   createdAtMs: number;
   updatedAtMs: number;
 }
@@ -161,7 +171,17 @@ export async function getOpenJob(
 async function sponsoredOpeningVerb(
   base: string,
   signer: TransactionSigner,
-  action: 'open-create' | 'open-claim' | 'open-cancel' | 'open-refund' | 'job-review',
+  action:
+    | 'open-create'
+    | 'open-claim'
+    | 'open-cancel'
+    | 'open-refund'
+    | 'job-review'
+    // S.1193 — batch (wave) verbs, mirroring the open-* family.
+    | 'batch-open-create'
+    | 'batch-open-claim'
+    | 'batch-open-cancel'
+    | 'batch-open-refund',
   params: Record<string, unknown>,
 ): Promise<string> {
   const address = signer.getAddress();
@@ -274,5 +294,66 @@ export function refundOpenJob(
 ): Promise<string> {
   return sponsoredOpeningVerb(base, signer, 'open-refund', {
     openingId: openingId.trim(),
+  });
+}
+
+/** S.1193 — post a WAVE: N homogeneous slots, one tx, one escrow of
+ *  `slots × maxUsdc`. Each claimed slot becomes a normal Job. `maxUsdc`
+ *  is PER SLOT (the live job bounds apply per slot); the wave total is
+ *  bounded by your wallet, not the protocol. */
+export function postBatchOpenJob(
+  base: string,
+  signer: TransactionSigner,
+  input: {
+    title: string;
+    brief: string;
+    /** PER-SLOT budget in USDC. */
+    maxUsdc: number;
+    /** Slots in the wave (1..live max, default max 250). */
+    slots: number;
+    slaMinutes?: number;
+    openHours?: number;
+    claimPolicy?: number;
+    minSellerLevel?: number;
+    /** Slots one agent may claim of this wave (default 1). */
+    maxClaimsPerAgent?: number;
+  },
+): Promise<string> {
+  return sponsoredOpeningVerb(base, signer, 'batch-open-create', input);
+}
+
+/** S.1193 — claim ONE slot of a wave (v1 lock: one claim per tx; a
+ *  `maxClaimsPerAgent > 1` wave means calling this again). Same $0 FCFS
+ *  and the same Phase C gates as a single claim. */
+export function claimBatchOpenJob(
+  base: string,
+  signer: TransactionSigner,
+  batchId: string,
+): Promise<string> {
+  return sponsoredOpeningVerb(base, signer, 'batch-open-claim', {
+    batchId: batchId.trim(),
+  });
+}
+
+/** S.1193 — withdraw a wave's UNCLAIMED remainder — fee-free, any time.
+ *  Already-claimed slots are normal Jobs and are untouched. */
+export function cancelBatchOpenJob(
+  base: string,
+  signer: TransactionSigner,
+  batchId: string,
+): Promise<string> {
+  return sponsoredOpeningVerb(base, signer, 'batch-open-cancel', {
+    batchId: batchId.trim(),
+  });
+}
+
+/** S.1193 — permissionless remainder refund once the wave expires. */
+export function refundBatchOpenJob(
+  base: string,
+  signer: TransactionSigner,
+  batchId: string,
+): Promise<string> {
+  return sponsoredOpeningVerb(base, signer, 'batch-open-refund', {
+    batchId: batchId.trim(),
   });
 }

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -62,7 +62,9 @@ export interface OpenJobRow {
   briefPreview?: string | null;
   maxUsdc: number;
   slaMinutes: number;
-  status: 'open' | 'claimed' | 'cancelled' | 'refunded' | 'expired';
+  /** S.1193 adds `filled` — a batch row whose every slot is claimed
+   *  (terminal; the escrow moved onto the slot Jobs, never refunded). */
+  status: 'open' | 'claimed' | 'cancelled' | 'refunded' | 'expired' | 'filled';
   openUntilMs: number;
   seller: string | null;
   sellerAgent: { agentId: number; name: string } | null;

--- a/packages/sdk/src/wallet/batch.test.ts
+++ b/packages/sdk/src/wallet/batch.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBatchClaimTx,
+  buildCancelBatchOpeningTx,
+  buildRefundBatchExpiredTx,
+  MAX_BATCH_SLOTS_DEFAULT,
+  preflightBatchClaim,
+  preflightCreateBatchOpening,
+  type BatchOpeningTerms,
+} from './batch.js';
+import type { AgentScore } from './reputation.js';
+
+// S.1193 — the batch surface mirrors the single-opening rules per slot,
+// adds the wave bounds, and targets only the new `batch` module entries.
+
+const BATCH_ID = `0x${'1'.repeat(64)}`;
+const REGISTRY_ID = `0x${'2'.repeat(64)}`;
+const SCORE_ID = `0x${'3'.repeat(64)}`;
+
+function terms(overrides: Partial<BatchOpeningTerms> = {}): BatchOpeningTerms {
+  return {
+    amountUsdc: 0.08,
+    slots: 50,
+    specHash: `0x${'a'.repeat(64)}`,
+    openUntilMs: Date.now() + 3_600_000,
+    slaMs: 86_400_000,
+    reviewWindowMs: 600_000,
+    rejectSplitBps: 10_000,
+    ...overrides,
+  };
+}
+
+function score(overrides: Partial<AgentScore> = {}): AgentScore {
+  return {
+    id: SCORE_ID,
+    agent: `0x${'4'.repeat(64)}`,
+    reviewCount: 0,
+    starsSum: 0,
+    averageStars: 0,
+    distinctBuyers: 0,
+    rejectedAfterDelivery: 0,
+    noDelivery: 0,
+    asBuyerRejected: 0,
+    activeSellerJobs: 0,
+    ...overrides,
+  };
+}
+
+describe('preflightCreateBatchOpening (S.1193)', () => {
+  it('accepts the desk wave shape (50 × $0.08, max 1 per agent default)', () => {
+    expect(preflightCreateBatchOpening(terms()).valid).toBe(true);
+    expect(preflightCreateBatchOpening(terms({ maxClaimsPerAgent: 1 })).valid).toBe(true);
+  });
+
+  it('reuses the single-opening rules per slot (cap, split, policy)', () => {
+    expect(preflightCreateBatchOpening(terms({ amountUsdc: 101 })).valid).toBe(false);
+    expect(preflightCreateBatchOpening(terms({ rejectSplitBps: 8000 })).valid).toBe(false);
+    expect(preflightCreateBatchOpening(terms({ claimPolicy: 3 })).valid).toBe(false);
+    expect(preflightCreateBatchOpening(terms({ minSellerLevel: 5 })).valid).toBe(false);
+  });
+
+  it('bounds slots 1..default max and maxClaimsPerAgent 1..slots', () => {
+    expect(preflightCreateBatchOpening(terms({ slots: 0 })).valid).toBe(false);
+    expect(preflightCreateBatchOpening(terms({ slots: 1.5 })).valid).toBe(false);
+    expect(
+      preflightCreateBatchOpening(terms({ slots: MAX_BATCH_SLOTS_DEFAULT + 1 })).valid,
+    ).toBe(false);
+    expect(preflightCreateBatchOpening(terms({ maxClaimsPerAgent: 0 })).valid).toBe(false);
+    expect(
+      preflightCreateBatchOpening(terms({ slots: 5, maxClaimsPerAgent: 6 })).valid,
+    ).toBe(false);
+    expect(
+      preflightCreateBatchOpening(terms({ slots: 5, maxClaimsPerAgent: 5 })).valid,
+    ).toBe(true);
+  });
+});
+
+describe('batch builders target only the batch module', () => {
+  function onlyCall(tx: ReturnType<typeof buildCancelBatchOpeningTx>) {
+    const calls = tx
+      .getData()
+      .commands.filter((c) => 'MoveCall' in (c as Record<string, unknown>)) as Array<{
+      MoveCall: { module: string; function: string };
+    }>;
+    expect(calls).toHaveLength(1);
+    return `${calls[0].MoveCall.module}::${calls[0].MoveCall.function}`;
+  }
+
+  it('claim / cancel / refund hit batch::*', () => {
+    expect(
+      onlyCall(
+        buildBatchClaimTx({ batchId: BATCH_ID, registryId: REGISTRY_ID, scoreId: SCORE_ID }),
+      ),
+    ).toBe('batch::batch_claim');
+    expect(onlyCall(buildCancelBatchOpeningTx(BATCH_ID))).toBe('batch::cancel_batch_open');
+    expect(onlyCall(buildRefundBatchExpiredTx(BATCH_ID))).toBe('batch::refund_batch_expired');
+  });
+
+  it('claim refuses a missing scoreId in English', () => {
+    expect(() =>
+      buildBatchClaimTx({ batchId: BATCH_ID, registryId: REGISTRY_ID, scoreId: '' }),
+    ).toThrow(/AgentScore/);
+  });
+});
+
+describe('preflightBatchClaim — wave gates first, then the single stack', () => {
+  const wave = {
+    claimPolicy: 0,
+    slotsRemaining: 47,
+    maxClaimsPerAgent: 1,
+  };
+
+  it('fresh seller on an open Anyone wave passes', () => {
+    expect(preflightBatchClaim(score(), wave, 0).valid).toBe(true);
+    expect(preflightBatchClaim(null, wave, 0).valid).toBe(true);
+  });
+
+  it('zero slots left refuses before anything else', () => {
+    const pf = preflightBatchClaim(score(), { ...wave, slotsRemaining: 0 }, 0);
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/No slots left/);
+  });
+
+  it('per-agent wave limit refuses with the counts', () => {
+    const pf = preflightBatchClaim(score(), wave, 1);
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/1 slot per agent/);
+    expect(
+      preflightBatchClaim(score(), { ...wave, maxClaimsPerAgent: 3 }, 2).valid,
+    ).toBe(true);
+  });
+
+  it('the Phase C stack still applies (active cap + level floor + policy)', () => {
+    const capped = score({ activeSellerJobs: 4 });
+    const pf = preflightBatchClaim(capped, wave, 0);
+    expect(pf.valid).toBe(false);
+    expect(pf.error).toMatch(/Active: 4\/4/);
+    const floored = preflightBatchClaim(score(), { ...wave, minSellerLevel: 2 }, 0);
+    expect(floored.valid).toBe(false);
+    expect(floored.error).toMatch(/Level 2\+/);
+    const proven = preflightBatchClaim(null, { ...wave, claimPolicy: 1 }, 0);
+    expect(proven.valid).toBe(false);
+    expect(proven.error).toMatch(/distinct buyers/);
+  });
+});

--- a/packages/sdk/src/wallet/batch.ts
+++ b/packages/sdk/src/wallet/batch.ts
@@ -1,0 +1,313 @@
+import { Transaction } from '@mysten/sui/transactions';
+import { bcs } from '@mysten/sui/bcs';
+import { deriveDynamicFieldID } from '@mysten/sui/utils';
+import { T2000Error } from '../errors.js';
+import { USDC_DECIMALS } from '../constants.js';
+import { USDC_TYPE } from '../token-registry.js';
+import { validateAddress } from '../utils/sui.js';
+import { selectAndSplitCoin } from './coinSelection.js';
+import type { SuiCoreClient } from '../utils/sui.js';
+import {
+  A2A_ESCROW_OPENING_PACKAGE_ID,
+  feeConfigArg,
+  OPENING_CLAIM_POLICY_ANY_ACTIVE,
+  preflightCreateOpening,
+  type OpeningTerms,
+} from './opening.js';
+import {
+  type AgentScore,
+  preflightClaimOpening,
+} from './reputation.js';
+
+/**
+ * Batch openings — client for `a2a_escrow::batch` (S.1193, Phase D wave
+ * post). ONE post = N homogeneous slots backed by a single escrow of
+ * `amount × slots`; each claimed slot mints a normal `escrow::Job`
+ * (ClaimedJobKey stamped — settles with the ordinary job verbs and frees
+ * the claimer's global active seat). One `batch_claim` per tx (v1 lock);
+ * `maxClaimsPerAgent > 1` means sequential claim txs.
+ *
+ * Amount bounds are PER SLOT (same live min/max as a single post). The
+ * wave TOTAL (`slots × amountUsdc`) is deliberately unbounded on-chain —
+ * the wallet balance and the desk's own budget bound it.
+ */
+
+const MODULE = 'batch';
+const CLOCK_ID = '0x6';
+
+/** Mirror of the Move package default for slots per wave. The LIVE value
+ *  is an AdminCap FeeConfig DF (`config_max_batch_slots`) — the chain is
+ *  the SSOT and may be retuned between npm releases (same class as
+ *  `MAX_JOB_USDC`); this mirror feeds the preflight's English only. */
+export const MAX_BATCH_SLOTS_DEFAULT = 250;
+
+/** Object-type marker for `resolveCreatedObjectId` digest walks. */
+export const BATCH_OPENING_TYPE_MARKER = '::batch::BatchOpening<' as const;
+
+export interface BatchOpeningTerms extends OpeningTerms {
+  /** Slots in the wave (1..live max; default live max 250). `amountUsdc`
+   *  is PER SLOT — total escrow = `slots × amountUsdc`. */
+  slots: number;
+  /** Slots one agent may claim of THIS wave (≥1; default 1). */
+  maxClaimsPerAgent?: number;
+}
+
+/** Client-side preflight — the single-opening rules on the PER-SLOT terms
+ *  plus the wave bounds. */
+export function preflightCreateBatchOpening(terms: BatchOpeningTerms): {
+  valid: boolean;
+  code?: 'INVALID_AMOUNT' | 'INVALID_INPUT';
+  error?: string;
+} {
+  const single = preflightCreateOpening(terms);
+  if (!single.valid) return single;
+  if (
+    !Number.isInteger(terms.slots) ||
+    terms.slots < 1 ||
+    terms.slots > MAX_BATCH_SLOTS_DEFAULT
+  ) {
+    return {
+      valid: false,
+      code: 'INVALID_INPUT',
+      error: `slots must be an integer 1–${MAX_BATCH_SLOTS_DEFAULT} (the live max is AdminCap-tunable on-chain).`,
+    };
+  }
+  const maxClaims = terms.maxClaimsPerAgent ?? 1;
+  if (!Number.isInteger(maxClaims) || maxClaims < 1 || maxClaims > terms.slots) {
+    return {
+      valid: false,
+      code: 'INVALID_INPUT',
+      error: 'maxClaimsPerAgent must be an integer ≥1 and ≤ slots.',
+    };
+  }
+  return { valid: true };
+}
+
+/** Build the wave post: split `slots × amount` USDC → `create_batch_open`. */
+export async function buildCreateBatchOpeningTx({
+  client,
+  buyer,
+  terms,
+}: {
+  client: SuiCoreClient;
+  buyer: string;
+  terms: BatchOpeningTerms;
+}): Promise<Transaction> {
+  const pf = preflightCreateBatchOpening(terms);
+  if (!pf.valid) throw new T2000Error(pf.code ?? 'INVALID_INPUT', pf.error ?? 'Invalid batch.');
+  const perSlotRaw = BigInt(Math.floor(terms.amountUsdc * 10 ** USDC_DECIMALS));
+  const totalRaw = perSlotRaw * BigInt(terms.slots);
+  const tx = new Transaction();
+  const { coin } = await selectAndSplitCoin(
+    tx,
+    client,
+    validateAddress(buyer),
+    USDC_TYPE,
+    totalRaw,
+    { allowSwapAll: false },
+  );
+  tx.moveCall({
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::create_batch_open`,
+    typeArguments: [USDC_TYPE],
+    arguments: [
+      coin,
+      tx.pure.u64(terms.slots),
+      tx.pure.vector('u8', hexToBytes(terms.specHash)),
+      tx.pure.u64(terms.openUntilMs),
+      tx.pure.u64(terms.slaMs),
+      tx.pure.u64(terms.reviewWindowMs),
+      tx.pure.u64(terms.rejectSplitBps),
+      tx.pure.u8(terms.claimPolicy ?? OPENING_CLAIM_POLICY_ANY_ACTIVE),
+      tx.pure.u8(terms.minSellerLevel ?? 0),
+      tx.pure.u8(terms.maxClaimsPerAgent ?? 1),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
+  });
+  return tx;
+}
+
+/** Claim ONE slot — same score plumbing as `buildClaimOpeningTx`
+ *  (claimer's own AgentScore always; `create_empty_score` precursor when
+ *  it doesn't exist yet). Unlike singles there is no policy-based entry
+ *  split: `batch_claim` handles every policy internally. */
+export function buildBatchClaimTx({
+  batchId,
+  registryId,
+  scoreId,
+}: {
+  batchId: string;
+  registryId: string;
+  scoreId: string;
+}): Transaction {
+  if (!scoreId) {
+    throw new T2000Error(
+      'INVALID_INPUT',
+      "Claiming needs the claimer's own AgentScore id (derive with " +
+        'deriveAgentScoreId; create it first with buildCreateEmptyScoreTx when missing).',
+    );
+  }
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::batch_claim`,
+    typeArguments: [USDC_TYPE],
+    arguments: [
+      tx.object(batchId),
+      tx.object(registryId),
+      tx.object(scoreId),
+      feeConfigArg(tx),
+      tx.object(CLOCK_ID),
+    ],
+  });
+  return tx;
+}
+
+function batchCall(batchId: string, fn: 'cancel_batch_open' | 'refund_batch_expired'): Transaction {
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${A2A_ESCROW_OPENING_PACKAGE_ID}::${MODULE}::${fn}`,
+    typeArguments: [USDC_TYPE],
+    arguments: [tx.object(batchId), feeConfigArg(tx), tx.object(CLOCK_ID)],
+  });
+  return tx;
+}
+
+/** Buyer withdraws the unclaimed remainder — fee-free, any time. */
+export function buildCancelBatchOpeningTx(batchId: string): Transaction {
+  return batchCall(batchId, 'cancel_batch_open');
+}
+
+/** Permissionless remainder refund once `open_until` lapses. */
+export function buildRefundBatchExpiredTx(batchId: string): Transaction {
+  return batchCall(batchId, 'refund_batch_expired');
+}
+
+/** On-chain view of one BatchOpening. */
+export interface BatchOpening {
+  id: string;
+  buyer: string;
+  /** PER-SLOT escrow in display USDC. */
+  amountUsdc: number;
+  slotsTotal: number;
+  slotsRemaining: number;
+  feeBps: number;
+  specHash: string;
+  openUntilMs: number;
+  slaMs: number;
+  reviewWindowMs: number;
+  rejectSplitBps: number;
+  claimPolicy: number;
+  minSellerLevel: number;
+  maxClaimsPerAgent: number;
+  /** Object id of the on-chain `claims_by_agent` Table (per-agent counts
+   *  live as its dynamic fields — see `getBatchClaimsByAgent`). */
+  claimsTableId: string | null;
+  createdAtMs: number;
+}
+
+function bytesToHex(bytes: number[] | Uint8Array): string {
+  return `0x${Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+function hexToBytes(hex: string): number[] {
+  const clean = hex.replace(/^0x/, '');
+  const bytes: number[] = [];
+  for (let i = 0; i < clean.length; i += 2) {
+    bytes.push(Number.parseInt(clean.slice(i, i + 2), 16));
+  }
+  return bytes;
+}
+
+/** Read one BatchOpening by object id (null = not a batch / gone). A
+ *  drained or cancelled batch still resolves (`slotsRemaining: 0`) — the
+ *  object persists in v1; existence is NOT the state. */
+export async function getBatchOpening(
+  client: SuiCoreClient,
+  batchId: string,
+): Promise<BatchOpening | null> {
+  const resp = await client.core
+    .getObject({ objectId: batchId, include: { json: true } })
+    .catch(() => null);
+  const objType = resp?.object?.type ?? '';
+  const json = resp?.object?.json as Record<string, unknown> | null | undefined;
+  if (!json || !objType.includes(BATCH_OPENING_TYPE_MARKER)) {
+    return null;
+  }
+  const table = json.claims_by_agent as { id?: unknown } | null | undefined;
+  return {
+    id: batchId,
+    buyer: String(json.buyer),
+    amountUsdc: Number(json.amount) / 10 ** USDC_DECIMALS,
+    slotsTotal: Number(json.slots_total),
+    slotsRemaining: Number(json.slots_remaining),
+    feeBps: Number(json.fee_bps ?? 0),
+    specHash: bytesToHex((json.spec_hash ?? []) as number[] | Uint8Array),
+    openUntilMs: Number(json.open_until_ms),
+    slaMs: Number(json.sla_ms),
+    reviewWindowMs: Number(json.review_window_ms),
+    rejectSplitBps: Number(json.reject_split_bps),
+    claimPolicy: Number(json.claim_policy ?? 0),
+    minSellerLevel: Number(json.min_seller_level ?? 0),
+    maxClaimsPerAgent: Number(json.max_claims_per_agent ?? 1),
+    claimsTableId: table?.id ? String(table.id) : null,
+    createdAtMs: Number(json.created_at_ms ?? 0),
+  };
+}
+
+/** Slots `agent` already claimed of this batch — best-effort read of the
+ *  on-chain Table entry (0 on miss/hiccup; Move enforces the real limit). */
+export async function getBatchClaimsByAgent(
+  client: SuiCoreClient,
+  batch: BatchOpening,
+  agent: string,
+): Promise<number> {
+  if (!batch.claimsTableId) return 0;
+  try {
+    const fieldId = deriveDynamicFieldID(
+      batch.claimsTableId,
+      'address',
+      bcs.Address.serialize(validateAddress(agent)).toBytes(),
+    );
+    const resp = await client.core.getObject({
+      objectId: fieldId,
+      include: { json: true },
+    });
+    const json = resp?.object?.json as { value?: unknown } | null | undefined;
+    return Number(json?.value ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
+/** English preflight for a batch claim — the wave gates first (slots,
+ *  per-agent limit), then the exact single-claim stack (policy → active
+ *  cap → level floor via `preflightClaimOpening`). */
+export function preflightBatchClaim(
+  score: AgentScore | null,
+  batch: {
+    claimPolicy: number;
+    minSellerLevel?: number;
+    slotsRemaining: number;
+    maxClaimsPerAgent: number;
+  },
+  myClaims: number,
+): { valid: boolean; error?: string } {
+  if (batch.slotsRemaining <= 0) {
+    return {
+      valid: false,
+      error:
+        'No slots left on this batch — every slot is claimed. Find open waves on the board.',
+    };
+  }
+  if (myClaims >= batch.maxClaimsPerAgent) {
+    return {
+      valid: false,
+      error:
+        `This wave allows ${batch.maxClaimsPerAgent} slot${batch.maxClaimsPerAgent === 1 ? '' : 's'} per agent and this wallet already holds ${myClaims}. ` +
+        'Deliver what you claimed; other waves on the board are open.',
+    };
+  }
+  return preflightClaimOpening(score, batch);
+}

--- a/packages/sdk/src/wallet/opening.ts
+++ b/packages/sdk/src/wallet/opening.ts
@@ -103,6 +103,15 @@ export const A2A_ESCROW_PACKAGE_V8_ID =
 export const A2A_ESCROW_PACKAGE_V10_ID =
   process.env.A2A_ESCROW_PACKAGE_V10_ID ??
   '0x5c90ec07da01bf885a4e65247ce98b75ab8a042cd965d30d7213856d579c4afa';
+/** v11 (S.1193) — defining id for the batch surface: the
+ *  BatchOpeningCreated/BatchSlotClaimed/BatchOpeningCancelled/
+ *  BatchOpeningRefunded events and the BatchOpening object type.
+ *  ⚠️ PLACEHOLDER '' until the founder upgrade broadcasts
+ *  (RUNBOOK_S1193 §2 pins the real id in the cutover commit, BEFORE the
+ *  npm release) — while empty, batch event walks are a no-op, which is
+ *  the honest pre-cutover value. Never moves again after pinning. */
+export const A2A_ESCROW_PACKAGE_V11_ID =
+  process.env.A2A_ESCROW_PACKAGE_V11_ID ?? '';
 
 const CLOCK_ID = '0x6';
 const MODULE = 'opening';

--- a/t2000-skills/skills/t2000-earn/SKILL.md
+++ b/t2000-skills/skills/t2000-earn/SKILL.md
@@ -35,6 +35,7 @@ Read the playbook first: `https://t2000.ai/llms.txt`.
 ```bash
 t2 job board                  # open work, budgets, SLAs — $0 to claim
 t2 job claim <openingId>      # first claim wins; the funded Job starts now
+t2 job batch-claim <batchId>  # wave rows ("N/M slots"): claim ONE slot — Connect: t2000_job_batch_claim
 t2 job spec <jobId>           # the work order (hash-verified) — read before working
 t2 job deliver <jobId> out.md # the file's text IS the delivery (UTF-8 ≤16 KiB)
 t2 job watch --mine           # your inbox + the next verb per job

--- a/t2000-skills/skills/t2000-job/SKILL.md
+++ b/t2000-skills/skills/t2000-job/SKILL.md
@@ -159,6 +159,27 @@ t2 job refund 0xJOB
 Do nothing after a delivery and the review window lapses → anyone can release
 to the seller, so review deliveries promptly.
 
+## Buyer flow — Batch (ONE post = N identical slots; S.1193)
+
+```bash
+# 1. Post a wave: escrows slots × per-slot budget in ONE tx; one board
+#    row with a live slot count. --max is PER SLOT. Default
+#    --max-claims-per-agent 1 = no hunter can hoard your wave.
+t2 job batch-open --title "Board check" --brief brief.md --max 0.08 --slots 50
+# Connect: t2000_job_batch_open { title, brief, maxUsdc, slots, maxClaimsPerAgent }
+
+# 2. Sellers claim ONE slot per tx ($0, first-come; same claim-policy /
+#    min-seller-level / active-cap gates as singles):
+t2 job batch-claim <batchId>            # Connect: t2000_job_batch_claim { batchId }
+
+# 3. Each claimed slot is a NORMAL Job — deliver / settle / reject /
+#    refund exactly as below. Unclaimed remainder refunds fee-free:
+t2 job batch-cancel <batchId>           # buyer, any time (or auto after --open-for)
+```
+
+Waves replace posting the same job 50 times. Singles (`t2 job open`)
+stay for one-offs.
+
 ## Buyer flow — Open (no seller picked; escrow at post, first claim wins)
 
 Post the job to the public board — title + brief + budget + SLA. **The


### PR DESCRIPTION
## S.1193 — Batch openings (Phase D, t2000 half)

Spec: master § Phase D + `SPEC_MARKETPLACE_BATCH_OPENINGS.md` (LOCKED) + the 2026-08-25 Think addendum / Build risk control. Runbook (PENDING, written pre-broadcast): t2000-internal `RUNBOOK_S1193_BATCH_OPENINGS.md` (`057b897`). Companion audric PR follows. **Design Wave 1/2 deferred after live — functional slots chrome only.**

### 1. Additive vs VERSION bump — decision

**Additive (S.1064-style): NO FeeConfig VERSION bump, NO migrate.** v11 only adds module `a2a_escrow::batch` (new shared `BatchOpening<T>` — full struct fields legal, no live instances) + on `escrow` the AdminCap tunable `set_max_job_amount`-pattern trio for max slots (`MaxBatchSlotsKey` DF, default **250**, hard ceiling **512**, `EBadBatchSlots`). Zero live public signatures change; `batch_claim` reuses the Phase C helpers (`effective_seller_level`, `active_cap_for_level`, `meets_min_seller_level`, package-visible `increment_active`/`create_claimed`) read-only or by call — never by signature edit. Singles (`create_open_v2`/`claim_v2`) untouched; v10 bytecode keeps working.

### 2. v11 package id — PLACEHOLDER

`A2A_ESCROW_PACKAGE_V11_ID` ships as `''` (batch event walks no-op — the honest pre-cutover value). The founder cutover commit fills it + moves LATEST → v11 (runbook §2), before the npm minor.

### 3. Escrow invariant + ClaimedJobKey

`escrow.value() == amount × slots_remaining` **asserted after every mutation** (claim split / cancel / expiry refund — `EEscrowInvariant` is the defensive backstop). Every claimed slot goes through `create_claimed`, so it carries **ClaimedJobKey**: batch slots seat the GLOBAL active counter at claim and free it at settle exactly like single claims — the dust-hire counter-reset immunity from S.1192 holds unchanged. Per-slot `amount` obeys the live min/max job bounds; the wave TOTAL is deliberately unbounded on-chain (wallet + desk budget bound it). Payment must be an exact multiple (`EBadPayment`). **Filled/cancelled batches persist** (non-droppable Table — v1 lock); double cancel/refund aborts. Locked claim-check order implemented verbatim: expiry → slots → per-agent (`max_claims_per_agent` ≥1, default 1) → active agent ≠ buyer → policy → cap + floor → split/mint/count. **One claim per tx** (v1 founder lock).

**Move tests: 151/151** (22 new: slot decrement + invariant per claim, per-agent limit, slots-exhausted, filled-batch persistence, cancel/expiry refund + double-cancel abort, Phase C gate stacking incl. the global-cap-across-one-wave case, borrowed-score refusal, exact-multiple + live-max-slots + AdminCap rails + ceiling, split lock, expiry, buyer-self-claim).

### SDK / CLI

- SDK `wallet/batch.ts`: `BatchOpeningTerms` (extends `OpeningTerms` + `slots`/`maxClaimsPerAgent`), `preflightCreateBatchOpening` (reuses the single-opening preflight per slot), builders for all four verbs (post splits `slots × amount` via `selectAndSplitCoin`), `getBatchOpening` + `getBatchClaimsByAgent` (on-chain Table entry read for the per-agent English), `preflightBatchClaim` (slots → per-agent → the exact single-claim stack), `MAX_BATCH_SLOTS_DEFAULT = 250` mirror (chain is SSOT — AdminCap may retune between releases, same class as `MAX_JOB_USDC`), `BATCH_OPENING_TYPE_MARKER`. Sponsored actions `batch-open-{create,claim,cancel,refund}` + high-level `postBatchOpenJob`/`claimBatchOpenJob`/`cancelBatchOpenJob`/`refundBatchOpenJob`; `OpenJobRow` gains `kind`/`slotsTotal`/`slotsRemaining`/`maxClaimsPerAgent`. **SDK 633 tests.**
- CLI: `t2 job batch-open` (`--slots`, `--max-claims-per-agent`, per-slot `--max`, same gate flags as `open`; **spend gate sees the wave TOTAL**), `batch-claim` (chain-read English preflight incl. per-agent count), `batch-cancel`; tx-guard allowlists the four `batch::` targets (+ the cross-module `reputation::create_empty_score` precursor). **CLI 320 tests.**

### Docs / skills / ops (surface ship-gate walked)

open-job.mdx "Post a wave" section · cli-reference batch rows (+ retired a stale `--proven` blurb found in passing) · **on-chain.mdx stale v9 LATEST row → v10** (v11 at cutover) · `t2000-job` skill batch flow + `t2000-earn` one-liner (`validate.ts`: 15 skills, 0 errors) · ARCHITECTURE.md paragraph · **GTM desk**: §A counts SLOTS (Σ `slotsRemaining` + legacy singles while they drain), C1/C2 = ONE `t2000_job_batch_open` wave per deficit (`slots: TARGET − N`, one title per wave card, rotate across waves), wave escrow = `slots × maxUsdc` against `MAX_ESCROW_RUN`, posting-discipline coin-lock note scoped to the singles that remain. Annex `&mut AgentScore` fix + master baseline v10/VERSION 6 landed in t2000-internal (`cec75b0`). **llms.txt lives in audric — updated in the companion PR.**

### Founder path (runbook — NOT executed)

Merge → `sui client upgrade` (expect Published.toml **v11**; **no migrate**) → fill V11 pin + LATEST → npm **minor** → audric bump/merge → dogfood: 10-slot × $0.01 wave (live min is at the floor — runbook preflight prints it), one claim from a second seat, same-seat second claim refused, cancel remainder ($0.09 back), settle the claimed slot, singles regression.

**Do not merge / broadcast without founder approval. Design Wave 1/2 after live.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)