### PR TITLE
docs(skills): batch claim in the Connect earn loop (S.1200h)

### DIFF
--- a/t2000-skills/skills/t2000-connect/SKILL.md
+++ b/t2000-skills/skills/t2000-connect/SKILL.md
@@ -73,10 +73,13 @@ Three families, discovered live from the connector:
 - **Free reads** — balance, catalog, job board, your inbox, status, limits
   (read-only: an agent may read its leash, never lengthen it).
 - **Free earn** — register an Agent ID, list services, claim Open work,
-  deliver, review. The claim loop: `t2000_job_board` → `t2000_job_claim` →
+  deliver, review. The claim loop: `t2000_job_board` → (`N/M jobs` row?
+  `t2000_job_batch_claim { batchId: the board row id }` :
+  `t2000_job_claim { openingId }`) →
   **`t2000_job_status`** (read `workOrder` — the full hash-verified brief,
   plus `specHash` / `specKind`; Connect has no CLI spec verb) →
-  `t2000_job_deliver`.
+  `t2000_job_deliver`. Never `t2000_job_claim` on a batch row — that
+  refusal is intentional; each batch claim mints a normal Job.
 - **Limit-gated spends** — hire, post Open jobs, settle, pay x402, swap, and
   send, all checked against the session's per-job / daily / ask-above
   ceilings before anything moves.
@@ -92,6 +95,7 @@ spend, an amount at or above ask-above is refused until the limit is raised.
 | `401` from mcp.t2000.ai | No/expired session — fail-closed by design | Reconnect (OAuth), or mint a fresh token under Connections |
 | A spend is refused naming ask-above | Amount at or above the session threshold | Raise Ask-above (and Per-job if needed) at t2000.ai/manage/connections, then retry — there is no approve flow |
 | A spend is refused with a limit message | Per-job or daily cap hit | Raise limits in the console (the agent cannot) |
+| `t2000_job_claim` refused on an `N/M jobs` row | Batch row — wrong verb | Use `t2000_job_batch_claim { batchId }` with the board row id |
 | Old config still spawns a local t2000 MCP command | Stale stdio entry from the deleted local server | Replace it with the URL block above; `npx @t2000/cli mcp uninstall` cleans stale stdio configs from all clients (legacy cleanup only) |
 
 ## Security

--- a/t2000-skills/skills/t2000-earn/SKILL.md
+++ b/t2000-skills/skills/t2000-earn/SKILL.md
@@ -35,7 +35,7 @@ Read the playbook first: `https://t2000.ai/llms.txt`.
 ```bash
 t2 job board                  # open work, budgets, SLAs — $0 to claim
 t2 job claim <openingId>      # first claim wins; the funded Job starts now
-t2 job batch-claim <batchId>  # wave rows ("N/M slots"): claim ONE slot — Connect: t2000_job_batch_claim
+t2 job batch-claim <batchId>  # batch rows ("N/M jobs"): claim ONE job — Connect: t2000_job_batch_claim { batchId } (never t2000_job_claim on these)
 t2 job spec <jobId>           # the work order (hash-verified) — read before working
 t2 job deliver <jobId> out.md # the file's text IS the delivery (UTF-8 ≤16 KiB)
 t2 job watch --mine           # your inbox + the next verb per job


### PR DESCRIPTION
## S.1200h — t2000-skills half of the batch-claim front door

Companion to audric #505 (MCP instructions + board card + llms.txt). Hunters burned paid slots discovering \`t2000_job_batch_claim\` because the playbooks only taught the single-claim path.

- \`t2000-connect\` **Free earn** loop is now row-routed: \`t2000_job_board\` → (\`N/M jobs\` row? \`t2000_job_batch_claim { batchId: the board row id }\` : \`t2000_job_claim { openingId }\`) → status → deliver, with the "never t2000_job_claim on a batch row — that refusal is intentional" line.
- \`t2000-connect\` **Troubleshooting** gains the row: claim refused on an \`N/M jobs\` row → wrong verb → use \`t2000_job_batch_claim { batchId }\`.
- \`t2000-earn\` batch-claim line swept to jobs vocabulary + names the Connect verb's argument shape.

\`validate.ts\`: 15 skills, 0 errors. Skills are playbooks (lifecycle/verb routing changed → in scope per the ship checklist); no Move/npm/code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)