### PR TITLE
docs(ops): Dune pack — v11 batch + v10 events, slot-aware queries (S.1200f)

### DIFF
--- a/ops/dune/DASHBOARD.md
+++ b/ops/dune/DASHBOARD.md
@@ -16,7 +16,14 @@ Sui event types are frozen at the package that **first defined** the struct. Aft
 | Reputation (v6) | `0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618` | `ReviewSubmitted` `ScoreCreated` |
 | Distinct buyers (v7) | `0x4249f0b242c47c7baf0c37304365bc4bbe769bcedf11f3525e84682d59a3b23e` | `ReviewSubmittedV2` |
 | Outcomes (v8) | `0x1595b80bc05a03607f3908702c866ca63cf961025b4263b5ecbe419e07f8ff31` | `OutcomeRecorded` |
+| Open v10 (levels, S.1192) | `0x5c90ec07da01bf885a4e65247ce98b75ab8a042cd965d30d7213856d579c4afa` | `OpeningCreatedV2` (min_seller_level sibling of every post) · `ActiveSellerJobsChanged` (seller active counter — optional probe) |
+| Batch openings (v11, S.1193) | `0x2a928916c859a159e6d6f4841073a31397d01336c1ea689ce74344e456463c8d` | `BatchOpeningCreated` `BatchSlotClaimed` `BatchOpeningCancelled` `BatchOpeningRefunded` |
 | Agent ID (original) | `0x7669be207f9ac28a34d2cbd45dcfdade11e6fd503ad24e687c180931be9a45e9` | `AgentRegistered` `AgentUpdated` `AgentActiveSet` |
+
+Ids SSOT: `packages/sdk/src/wallet/opening.ts` (`A2A_ESCROW_PACKAGE_V10_ID`,
+`A2A_ESCROW_PACKAGE_V11_ID`) — never hand-copy from memory. The legacy v2
+`OpeningCreated` row stays: singles still emit it; batch waves emit ONLY the
+v11 family (one `BatchOpeningCreated` per wave, `amount` is PER SLOT).
 
 USDC amounts are **raw / 1e6**. Fee on settle is on-chain (`fee_amount` on `JobReleased`).
 
@@ -33,11 +40,14 @@ USDC amounts are **raw / 1e6**. Fee on settle is on-chain (`fee_amount` on `JobR
 | 1 | Counter | Jobs released |
 | 1 | Counter | Protocol fees (USDC) |
 | 1 | Counter | Agents registered |
-| 2 | Counter | Open jobs posted |
+| 2 | Counter | Open jobs posted (rows — legacy Q5) |
+| 2 | Counter | **Open slots posted** (batch-aware — Q5b) |
+| 2 | Counter | **Batch slot claims** (Q6b) |
 | 2 | Counter | Open jobs claimed |
 | 2 | Counter | Reviews |
 | 3 | Area / bar (daily) | Settled volume over time |
 | 4 | Bar (daily) | Job funnel: created / delivered / released / rejected |
+| 4 | Bar (daily) | Batch board by day (Q10b — beside or combined with Q10) |
 | 5 | Table | Recent settlements |
 | 6 | Table | Top sellers by settled USDC |
 
@@ -60,6 +70,10 @@ WHERE event_type LIKE '0x358a819c1c016e2cc84ef5fbea81cba90c31f7f8a62bf45cb5e5276
    OR event_type LIKE '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b::%'
    OR event_type LIKE '0x7669be207f9ac28a34d2cbd45dcfdade11e6fd503ad24e687c180931be9a45e9::%'
    OR event_type LIKE '0xb065033b6f72c4899055a0b3afac28f09dc7b0b7b491eada793157de20000618::%'
+   -- v10 (S.1192): OpeningCreatedV2 + ActiveSellerJobsChanged
+   OR event_type LIKE '0x5c90ec07da01bf885a4e65247ce98b75ab8a042cd965d30d7213856d579c4afa::%'
+   -- v11 (S.1193): the four BatchOpening* events — verify after a wave post
+   OR event_type LIKE '0x2a928916c859a159e6d6f4841073a31397d01336c1ea689ce74344e456463c8d::%'
 GROUP BY 1, 2
 ORDER BY 1 DESC, 3 DESC
 LIMIT 200
@@ -111,12 +125,49 @@ FROM sui.events
 WHERE event_type = '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b::opening::OpeningCreated'
 ```
 
+### Q5b Open **slots** posted (batch-aware — the slot truth)
+
+Q5 counts ROWS; one S.1193 wave row is N identical jobs. This is the
+counter a pitch should lead with.
+
+```sql
+-- Singles (v2 OpeningCreated) + batch slot totals (v11)
+SELECT
+  COALESCE(singles.c, 0) + COALESCE(batches.slots, 0) AS open_slots_posted,
+  COALESCE(singles.c, 0) AS single_openings,
+  COALESCE(batches.waves, 0) AS batch_waves,
+  COALESCE(batches.slots, 0) AS batch_slots
+FROM (
+  SELECT COUNT(*) AS c
+  FROM sui.events
+  WHERE event_type = '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b::opening::OpeningCreated'
+) singles,
+(
+  SELECT
+    COUNT(*) AS waves,
+    COALESCE(SUM(CAST(json_extract_scalar(event_json, '$.slots_total') AS DOUBLE)), 0) AS slots
+  FROM sui.events
+  WHERE event_type = '0x2a928916c859a159e6d6f4841073a31397d01336c1ea689ce74344e456463c8d::batch::BatchOpeningCreated'
+) batches
+```
+
 ### Q6 Open jobs claimed
 
 ```sql
 SELECT COUNT(*) AS openings_claimed
 FROM sui.events
 WHERE event_type = '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b::opening::OpeningClaimed'
+```
+
+### Q6b Batch slots claimed
+
+Each one minted a normal escrow `Job` (so it ALSO appears in Q9's
+`JobCreated` funnel — do not add the two as if independent).
+
+```sql
+SELECT COUNT(*) AS batch_slot_claims
+FROM sui.events
+WHERE event_type = '0x2a928916c859a159e6d6f4841073a31397d01336c1ea689ce74344e456463c8d::batch::BatchSlotClaimed'
 ```
 
 ### Q7 Reviews submitted
@@ -185,6 +236,42 @@ SELECT
   ) AS posted_usdc
 FROM sui.events
 WHERE event_type LIKE '0x860288d789dc617f6474a0a6801d6011e53bf30d5fb801cdad47b9bc6adb098b::opening::%'
+GROUP BY 1
+ORDER BY 1
+```
+
+### Q10b Batch board by day (v11)
+
+`amount` on `BatchOpeningCreated` is PER SLOT — USDC locked at post is
+`amount × slots_total / 1e6`. `refunded` on cancel/refund is the raw
+USDC actually returned (unclaimed remainder only).
+
+```sql
+SELECT
+  date,
+  SUM(CASE WHEN event_type LIKE '%::BatchOpeningCreated' THEN 1 ELSE 0 END) AS waves_posted,
+  SUM(
+    CASE WHEN event_type LIKE '%::BatchOpeningCreated'
+      THEN CAST(json_extract_scalar(event_json, '$.slots_total') AS DOUBLE)
+      ELSE 0 END
+  ) AS slots_posted,
+  SUM(CASE WHEN event_type LIKE '%::BatchSlotClaimed' THEN 1 ELSE 0 END) AS slots_claimed,
+  SUM(CASE WHEN event_type LIKE '%::BatchOpeningCancelled' THEN 1 ELSE 0 END) AS waves_cancelled,
+  SUM(CASE WHEN event_type LIKE '%::BatchOpeningRefunded' THEN 1 ELSE 0 END) AS waves_refunded,
+  SUM(
+    CASE WHEN event_type LIKE '%::BatchOpeningCreated'
+      THEN CAST(json_extract_scalar(event_json, '$.amount') AS DOUBLE)
+         * CAST(json_extract_scalar(event_json, '$.slots_total') AS DOUBLE) / 1e6
+      ELSE 0 END
+  ) AS posted_usdc,
+  SUM(
+    CASE WHEN event_type LIKE '%::BatchOpeningCancelled'
+        OR event_type LIKE '%::BatchOpeningRefunded'
+      THEN CAST(json_extract_scalar(event_json, '$.refunded') AS DOUBLE) / 1e6
+      ELSE 0 END
+  ) AS refunded_usdc
+FROM sui.events
+WHERE event_type LIKE '0x2a928916c859a159e6d6f4841073a31397d01336c1ea689ce74344e456463c8d::batch::%'
 GROUP BY 1
 ORDER BY 1
 ```
@@ -274,7 +361,10 @@ LIMIT 50
 
 - Metrics are **on-chain receipts only** (escrow + Agent ID). x402 API volume is not in these events unless you add a separate indexer later.  
 - `amount` on `JobReleased` is the escrowed job size; seller net ≈ `amount − fee_amount`.  
-- Open “live inventory” is not a single event — use posted − claimed − cancelled − refunded as a proxy, or read live openings from the product API.  
+- **Jobs released / settled USDC (Q1–Q3) stay correct post-S.1193** — every claimed batch slot mints a normal `Job`, so the escrow funnel already counts them.  
+- **Q5 is a ROW count** — one wave row ≠ N jobs; lead with Q5b for slot truth. Q6b's claims also appear in Q9's `JobCreated` — never add the two as independent.  
+- Open “live inventory” is not a single event — use posted − claimed − cancelled − refunded as a proxy (Q5b/Q6b/Q10b for the batch legs), or read live openings from the product API.  
+- **Seller Level / active caps** live on-chain in `AgentScore`; this pack does not yet chart the Level distribution (future query over v10 `ActiveSellerJobsChanged` if wanted).  
 - If Q0 is empty: Dune may lag a few hours after first txs, or `event_json` key casing may differ — open one row and adjust paths (`$.amount` vs nested).
 
 ## Optional: decode probe if JSON keys look wrong


### PR DESCRIPTION
## S.1200f — Dune dashboard catches up with S.1192/S.1193

Docs-only (\`ops/dune/DASHBOARD.md\`); the founder applies in the Dune UI. The live pack predated batch openings, so pitch counters under-counted waves (1 row ≠ N jobs) and missed batch USDC locked at post.

- **Defining-package table** gains v10 (\`OpeningCreatedV2\` + \`ActiveSellerJobsChanged\`) and v11 (the four \`BatchOpening*\` events), with the ids-SSOT pointer to \`opening.ts\` and the note that legacy v2 \`OpeningCreated\` stays (singles still emit it; waves emit only v11, \`amount\` per slot). All event field names verified against \`batch.move\`/\`opening.move\`/\`reputation.move\` structs, and every 0x id in the doc cross-checked against the SDK pins.
- **Q0 smoke** extended with the v10 + v11 LIKE lines.
- **Q5b** — open SLOTS posted (singles + Σ \`slots_total\`), the counter a pitch should lead with; **Q6b** — batch slot claims (with the double-count warning: each also mints a \`JobCreated\`); **Q10b** — batch board by day (waves/slots posted, claims, cancels/refunds, \`amount × slots_total / 1e6\` posted USDC, \`refunded\` USDC).
- **Layout** rows updated (Q5b/Q6b counters, Q10b beside Q10); **honesty notes** extended: Q1–Q3 stay correct post-batch, Q5 is a row count, live-inventory proxy formula gets its batch legs, Level distribution named as a future query.
- Old queries untouched for backward compatibility. No code outside \`ops/dune/\`; no audric, no npm.

Founder verify: run Q0 after the next desk wave — the v11 event family should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)