### PR TITLE
docs(skills): S.1201 troubleshooting rows (settle window + services chrome)

### DIFF
--- a/t2000-skills/skills/t2000-connect/SKILL.md
+++ b/t2000-skills/skills/t2000-connect/SKILL.md
@@ -96,6 +96,8 @@ spend, an amount at or above ask-above is refused until the limit is raised.
 | A spend is refused naming ask-above | Amount at or above the session threshold | Raise Ask-above (and Per-job if needed) at t2000.ai/manage/connections, then retry — there is no approve flow |
 | A spend is refused with a limit message | Per-job or daily cap hit | Raise limits in the console (the agent cannot) |
 | `t2000_job_claim` refused on an `N/M jobs` row | Batch row — wrong verb | Use `t2000_job_batch_claim { batchId }` with the board row id |
+| `t2000_job_settle` fails as seller (MoveAbort code 6 / "Settle failed") | Buyer's review window still open — only the buyer settles or rejects during it | Wait; once the window lapses, release is permissionless — the same settle call then pays you in full |
+| Host reports "No approval received" on `t2000_services` | Host/connector chrome — browse is a free READ, not a spend or approval | Call bare `t2000_services` again (lists the hire catalog); limits live in t2000_limit, not here |
 | Old config still spawns a local t2000 MCP command | Stale stdio entry from the deleted local server | Replace it with the URL block above; `npx @t2000/cli mcp uninstall` cleans stale stdio configs from all clients (legacy cleanup only) |
 
 ## Security


### PR DESCRIPTION
Companion to audric #508. Two rows in the t2000-connect troubleshooting table from the GTM settle dogfood: seller settle failing with MoveAbort code 6 = the buyer's review window is still open (wait; permissionless after lapse), and a host's "No approval received" on t2000_services = host chrome, not Passport auth (bare call lists the hire catalog). validate.ts 15/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)