### PR TITLE
✨ feat(contracts): S.1202a(+a.1) — batch active per-wave claims, batch-aware settle, VERSION 7 cutover

### DIFF
--- a/contracts/a2a_escrow/sources/batch.move
+++ b/contracts/a2a_escrow/sources/batch.move
@@ -15,9 +15,12 @@
 ///   create_batch_open ──refund_batch_expired (ANYONE, past open_until)──▶ same
 ///
 /// Design notes (annex + Build risk control, locked):
-/// - **Additive upgrade (S.1064-style).** New entries + new DF keys only —
-///   no live signature changes, so no FeeConfig VERSION bump and no
-///   migrate. Entries still gate on the live VERSION via
+/// - **VERSION cutover (S.1192-style, D23).** New entries + new DF keys,
+///   no live signature changes — but the S.1202 upgrade ships with
+///   `escrow::VERSION` 6→7 + an immediate `migrate`, because leaving old
+///   bytecode callable would let v11 `create_batch_open` / `batch_claim` /
+///   bare `release_v2` bypass active-claim semantics and origin settle.
+///   Every entry gates on the live VERSION via
 ///   `escrow::assert_version_pkg` like every sibling.
 /// - **Escrow invariant** — `escrow.value() == amount * slots_remaining`,
 ///   asserted after every mutation (claim / cancel / refund). The last

--- a/contracts/a2a_escrow/sources/batch.move
+++ b/contracts/a2a_escrow/sources/batch.move
@@ -1,18 +1,23 @@
 /// Batch openings — wave post (SPEC_MARKETPLACE_BATCH_OPENINGS, Phase D /
-/// S.1193). ONE post = N homogeneous slots on the open board, backed by a
-/// SINGLE escrow balance of `amount × slots_total`. Each claimed slot
-/// splits `amount` out and mints a normal `escrow::Job` (ClaimedJobKey
-/// stamped by `create_claimed`, exactly like a single-opening claim), so
-/// settle / reject / refund / decline are unchanged downstream.
+/// S.1193; active per-wave claims + batch-aware settle, S.1202). ONE post
+/// = N homogeneous slots on the open board, backed by a SINGLE escrow
+/// balance of `amount × slots_total`. Each claimed slot splits `amount`
+/// out and mints a normal `escrow::Job` (ClaimedJobKey + BatchOriginKey
+/// stamped by `create_claimed_from_batch`), and that Job settles through
+/// THIS module's batch-aware doors so the per-wave hold frees with the
+/// money.
 ///
 ///   create_batch_open ──batch_claim × N (sellers, FCFS)──▶ N normal Jobs
+///   Job ──batch_release / batch_reject* / batch_refund──▶ money settles,
+///     global seat −1, per-wave hold −1 (the bare v2 doors abort on
+///     batch-origin Jobs — `EUseBatchSettle`)
 ///   create_batch_open ──cancel_batch_open (buyer)──▶ refund remainder, fee-free
 ///   create_batch_open ──refund_batch_expired (ANYONE, past open_until)──▶ same
 ///
 /// Design notes (annex + Build risk control, locked):
-/// - **Additive upgrade (S.1064-style).** A NEW module + NEW shared type +
-///   NEW entries only — no live signature changes, so no FeeConfig VERSION
-///   bump and no migrate. Entries still gate on the live VERSION via
+/// - **Additive upgrade (S.1064-style).** New entries + new DF keys only —
+///   no live signature changes, so no FeeConfig VERSION bump and no
+///   migrate. Entries still gate on the live VERSION via
 ///   `escrow::assert_version_pkg` like every sibling.
 /// - **Escrow invariant** — `escrow.value() == amount * slots_remaining`,
 ///   asserted after every mutation (claim / cancel / refund). The last
@@ -24,22 +29,36 @@
 /// - **Phase C gates reused verbatim at claim**: claimer's OWN
 ///   `&mut AgentScore` (ownership asserted), claim policy 0/1/2,
 ///   `min_seller_level` on the EFFECTIVE level, and the per-level active
-///   cap — a batch slot occupies a seat exactly like a single claim. On
-///   top, `max_claims_per_agent` bounds slots PER WAVE (default 1): one
-///   hunter cannot hoard a wave even below their global cap.
+///   cap — a batch slot occupies a seat exactly like a single claim.
+/// - **Per-wave claims are ACTIVE holds, Level-scaled (S.1202, D11–D16).**
+///   `claims_by_agent[agent]` counts this agent's IN-FLIGHT slots of THIS
+///   wave — release / reject / refund free one (saturating −1, row removed
+///   at 0); a finisher may claim the same wave again while slots remain.
+///   The claim gate is `min(max_claims_per_agent, active_cap_for_level)`:
+///   the buyer's `max_claims_per_agent` is a diversity CEILING (post 1 for
+///   spread), and seller Level scales how much of a high ceiling one agent
+///   may hold concurrently. Decline does NOT free the wave seat (parity
+///   with the global active counter — claim→decline churn can't farm
+///   slots).
+/// - **Legacy batches reject new claims (D21).** Pre-S.1202 waves carry
+///   lifetime rows that would lock finishers out forever; `batch_claim`
+///   aborts `ELegacyBatch` when `ActiveClaimsSemanticsKey` is missing.
+///   Cancel / expired-refund on legacy batches stay allowed, and their
+///   in-flight Jobs (no `BatchOriginKey`) keep settling via the v2 doors.
 /// - **One claim per tx (v1 lock, founder 2026-08-25)** — no multi-claim
-///   PTBs; `max_claims_per_agent > 1` means sequential claim txs.
+///   PTBs; a claimer below their wave cap claims again in a new tx.
 /// - **Per-slot amount bounds only.** `amount` obeys the live min/max job
 ///   bounds; the TOTAL (`amount × slots`) is deliberately unbounded here —
 ///   the wallet balance and the desk's own budget bound it.
 module a2a_escrow::batch;
 
-use a2a_escrow::escrow::{Self, FeeConfig};
+use a2a_escrow::escrow::{Self, FeeConfig, Job};
 use a2a_escrow::reputation::{Self, AgentScore};
 use agent_id::registry::{Self, Registry};
 use sui::balance::Balance;
 use sui::clock::Clock;
 use sui::coin::{Self, Coin};
+use sui::dynamic_field as df;
 use sui::event;
 use sui::table::{Self, Table};
 
@@ -78,6 +97,26 @@ const ENotBuyer: u64 = 19;
 const ENotExpired: u64 = 20;
 /// Defensive: the escrow invariant broke (should be unreachable).
 const EEscrowInvariant: u64 = 21;
+/// S.1202 (D21): this `BatchOpening` predates active-claim semantics
+/// (no `ActiveClaimsSemanticsKey`) — its lifetime `claims_by_agent` rows
+/// can never free, so NEW claims are refused. Cancel / expired-refund
+/// still work; in-flight Jobs settle via the v2 doors.
+const ELegacyBatch: u64 = 22;
+/// S.1202: the Job passed to a batch settle door has no `BatchOriginKey` —
+/// it was not minted from a batch; settle it via the v2 doors.
+const ENotBatchJob: u64 = 23;
+/// S.1202: the Job's `BatchOriginKey` names a DIFFERENT batch than the
+/// one passed — the crank/client attached the wrong wave.
+const EWrongBatch: u64 = 24;
+/// S.1202: the passed seller `AgentScore` is not this Job's seller's.
+const EWrongSellerScore: u64 = 25;
+/// S.1202: the passed buyer `AgentScore` is not this Job's buyer's.
+const EWrongBuyerScore: u64 = 26;
+/// S.1202: registered Agent-ID buyer — use `batch_reject_agent_buyer`
+/// (an agent buyer cannot dodge its own `as_buyer_rejected` counter).
+const EBuyerIsAgent: u64 = 27;
+/// S.1202: unregistered (Passport) buyer — use `batch_reject`.
+const EBuyerNotAgent: u64 = 28;
 
 // === Objects ===
 
@@ -109,6 +148,14 @@ public struct BatchOpening<phantom T> has key {
     claims_by_agent: Table<address, u8>,
     created_at_ms: u64,
 }
+
+/// S.1202 (D21) — semantics marker DF on `BatchOpening.id`, stamped by
+/// `create_batch_open` from this package version on: `claims_by_agent`
+/// rows on this wave are ACTIVE holds that free at settle. `batch_claim`
+/// aborts `ELegacyBatch` when it is missing (pre-S.1202 waves have
+/// lifetime rows that can never free). Defining id = the S.1202 upgrade
+/// package (V12 pin).
+public struct ActiveClaimsSemanticsKey has copy, drop, store {}
 
 // === Events (defining id = the S.1193 upgrade package — V11 pin) ===
 
@@ -151,6 +198,17 @@ public struct BatchOpeningRefunded has copy, drop {
     buyer: address,
     refunded: u64,
     slots_refunded: u64,
+    timestamp_ms: u64,
+}
+/// S.1202 — a settle freed one per-wave hold (sibling event; the frozen
+/// `BatchSlotClaimed` never grows). `claims_remaining_for_agent` is the
+/// POST-write value — the read model mirrors it, never decrements.
+/// Defining id = the S.1202 upgrade package (V12 pin).
+public struct BatchSlotHoldReleased has copy, drop {
+    batch_id: ID,
+    job_id: ID,
+    agent: address,
+    claims_remaining_for_agent: u8,
     timestamp_ms: u64,
 }
 
@@ -202,7 +260,7 @@ public fun create_batch_open<T>(
         reject_split_bps == escrow::bps_denominator_pkg(),
         EOpenRejectMustBeFullBuyer,
     );
-    let batch = BatchOpening<T> {
+    let mut batch = BatchOpening<T> {
         id: object::new(ctx),
         buyer: ctx.sender(),
         escrow: payment.into_balance(),
@@ -221,6 +279,9 @@ public fun create_batch_open<T>(
         claims_by_agent: table::new(ctx),
         created_at_ms: now,
     };
+    // S.1202 (D21): brand active-claim semantics before share — claims on
+    // un-branded (pre-upgrade) waves abort `ELegacyBatch`.
+    df::add(&mut batch.id, ActiveClaimsSemanticsKey {}, true);
     let batch_id = batch.id.to_inner();
     event::emit(BatchOpeningCreated {
         batch_id,
@@ -245,10 +306,16 @@ public fun create_batch_open<T>(
 // === Claim (one slot per tx — v1 lock) ===
 
 /// Claim ONE slot: every Phase C single-claim gate, plus the wave's own
-/// slot + per-agent limits. Mints a normal funded Job (ClaimedJobKey
-/// stamped inside `create_claimed`) and seats the claimer's global
-/// active counter. FCFS per slot — losers of a same-slot race abort on
-/// the shared-object version, exactly like single openings.
+/// slot + per-agent limits. Mints a normal funded Job (ClaimedJobKey +
+/// BatchOriginKey stamped inside `create_claimed_from_batch`) and seats
+/// the claimer's global active counter. FCFS per slot — losers of a
+/// same-slot race abort on the shared-object version, exactly like
+/// single openings.
+///
+/// S.1202 wave gate: `claims_by_agent[claimer]` counts ACTIVE holds of
+/// this wave, and the limit is `min(max_claims_per_agent,
+/// active_cap_for_level)` — asserted BEFORE the global `EActiveJobCap`
+/// (locked abort priority; MCP maps both).
 public fun batch_claim<T>(
     batch: &mut BatchOpening<T>,
     registry: &Registry,
@@ -258,19 +325,26 @@ public fun batch_claim<T>(
     ctx: &mut TxContext,
 ): ID {
     escrow::assert_version_pkg(cfg);
+    // S.1202 (D21): lifetime-semantics waves never accept new claims.
+    assert!(has_active_claims_semantics(batch), ELegacyBatch);
     let now = clock.timestamp_ms();
     let claimer = ctx.sender();
-    // Locked check order (annex §batch_claim).
+    // Locked check order (annex §batch_claim + S.1202 claim gate).
     assert!(now <= batch.open_until_ms, EBatchExpired);
     assert!(batch.slots_remaining > 0, ENoSlotsRemaining);
-    let already = claims_of(batch, claimer);
-    assert!(already < batch.max_claims_per_agent, EMaxClaimsReached);
     assert!(claimer != batch.buyer, EClaimerIsBuyer);
     assert!(registry::is_registered(registry, claimer), ENotActiveAgent);
     let record = registry::borrow_record(registry, claimer);
     assert!(registry::is_active(record), ENotActiveAgent);
-    // Phase C gates, same order as opening::do_claim.
+    // Phase C gates, same order as opening::do_claim — except the wave cap
+    // needs the claimer's EFFECTIVE level, so the level computes first.
     assert!(reputation::agent(score) == claimer, EScoreNotClaimer);
+    let level = reputation::effective_seller_level(score, cfg);
+    let cap = reputation::active_cap_for_level(cfg, level);
+    // S.1202 (D15): active holds of THIS wave < min(buyer ceiling, level cap).
+    let already = claims_of(batch, claimer) as u64;
+    let wave_cap = (batch.max_claims_per_agent as u64).min(cap);
+    assert!(already < wave_cap, EMaxClaimsReached);
     let policy = batch.claim_policy;
     if (policy != CLAIM_POLICY_ANY_ACTIVE) {
         if (policy == CLAIM_POLICY_MIN_AVG) {
@@ -279,8 +353,6 @@ public fun batch_claim<T>(
             assert!(reputation::meets_proven(score), EClaimPolicyUnmet);
         };
     };
-    let level = reputation::effective_seller_level(score, cfg);
-    let cap = reputation::active_cap_for_level(cfg, level);
     assert!(reputation::active_seller_jobs(score) < cap, EActiveJobCap);
     if (batch.min_seller_level > 0) {
         assert!(
@@ -288,9 +360,12 @@ public fun batch_claim<T>(
             EMinSellerLevelUnmet,
         );
     };
-    // Split ONE slot's escrow → normal Job (ClaimedJobKey inside).
+    // Split ONE slot's escrow → normal Job (ClaimedJobKey + the S.1202
+    // BatchOriginKey inside — settles via THIS module's doors).
+    let batch_id = batch.id.to_inner();
     let slot_escrow = batch.escrow.split(batch.amount);
-    let job_id = escrow::create_claimed(
+    let job_id = escrow::create_claimed_from_batch(
+        batch_id,
         batch.buyer,
         claimer,
         slot_escrow,
@@ -322,6 +397,160 @@ public fun batch_claim<T>(
         timestamp_ms: now,
     });
     job_id
+}
+
+// === Batch-aware settle (S.1202) — the ONLY terminal doors for Jobs ===
+// === carrying `BatchOriginKey` (the v2 doors abort `EUseBatchSettle`) ===
+// Each door is the v2 door's exact mirror — money settles in escrow's
+// `*_settle_pkg` (auth + coin/fee math + frozen events, single source),
+// outcome counters land via reputation's package hooks, the global seat
+// frees via `decrement_active` — PLUS the per-wave hold frees in the SAME
+// tx (D12). Permissionless-crank properties survive unchanged: the batch
+// and score inputs are verified against the Job, never the caller.
+
+/// Release a batch-origin Job — funds → seller minus the protocol fee.
+/// Same three legitimate callers as `release_v2` (buyer accept, buyer
+/// goodwill on FUNDED, anyone after the review window lapses); the wave
+/// hold frees either way — a goodwill release is still this slot leaving
+/// flight (SPEC §batch-aware settle table).
+public fun batch_release<T>(
+    batch: &mut BatchOpening<T>,
+    job: &mut Job<T>,
+    seller_score: &mut AgentScore,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    assert_batch_origin(batch, job);
+    assert!(reputation::agent(seller_score) == escrow::seller(job), EWrongSellerScore);
+    escrow::release_settle_pkg(job, cfg, clock, ctx);
+    let now = clock.timestamp_ms();
+    if (escrow::is_claimed_job(job)) {
+        reputation::decrement_active(seller_score, object::id(job), now);
+    };
+    free_wave_hold(batch, job, now);
+}
+
+/// Buyer rejects delivered batch work — PASSPORT (unregistered) buyer
+/// variant: split settles (open-board lock: 100% buyer), the seller's
+/// `rejected_after_delivery` counter lands, seat + wave hold free.
+public fun batch_reject<T>(
+    batch: &mut BatchOpening<T>,
+    job: &mut Job<T>,
+    seller_score: &mut AgentScore,
+    registry: &Registry,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    assert_batch_origin(batch, job);
+    assert!(!registry::is_registered(registry, escrow::buyer(job)), EBuyerIsAgent);
+    assert!(reputation::agent(seller_score) == escrow::seller(job), EWrongSellerScore);
+    escrow::reject_settle_pkg(job, cfg, clock, ctx); // auth: sender==buyer, DELIVERED, in-window
+    let now = clock.timestamp_ms();
+    let job_id = object::id(job);
+    reputation::record_rejected_after_delivery_pkg(seller_score, job_id, now);
+    if (escrow::is_claimed_job(job)) {
+        reputation::decrement_active(seller_score, job_id, now);
+    };
+    free_wave_hold(batch, job, now);
+}
+
+/// Buyer rejects delivered batch work — AGENT-ID buyer variant: same as
+/// `batch_reject` plus `as_buyer_rejected` on the buyer's OWN score
+/// (transparency cuts both ways — the v2 routing locks apply verbatim).
+public fun batch_reject_agent_buyer<T>(
+    batch: &mut BatchOpening<T>,
+    job: &mut Job<T>,
+    seller_score: &mut AgentScore,
+    buyer_score: &mut AgentScore,
+    registry: &Registry,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    assert_batch_origin(batch, job);
+    let buyer = escrow::buyer(job);
+    assert!(registry::is_registered(registry, buyer), EBuyerNotAgent);
+    assert!(reputation::agent(seller_score) == escrow::seller(job), EWrongSellerScore);
+    assert!(reputation::agent(buyer_score) == buyer, EWrongBuyerScore);
+    escrow::reject_settle_pkg(job, cfg, clock, ctx);
+    let now = clock.timestamp_ms();
+    let job_id = object::id(job);
+    reputation::record_rejected_after_delivery_pkg(seller_score, job_id, now);
+    reputation::record_as_buyer_rejected_pkg(buyer_score, job_id, now);
+    if (escrow::is_claimed_job(job)) {
+        reputation::decrement_active(seller_score, job_id, now);
+    };
+    free_wave_hold(batch, job, now);
+}
+
+/// Deadline refund (no delivery) of a batch-origin Job — permissionless
+/// crank; `no_delivery` lands on the seller, seat + wave hold free (the
+/// no_delivery counter is what costs the seller — via level regression).
+public fun batch_refund<T>(
+    batch: &mut BatchOpening<T>,
+    job: &mut Job<T>,
+    seller_score: &mut AgentScore,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+) {
+    escrow::assert_version_pkg(cfg);
+    assert_batch_origin(batch, job);
+    assert!(reputation::agent(seller_score) == escrow::seller(job), EWrongSellerScore);
+    escrow::refund_settle_pkg(job, cfg, clock, ctx); // auth: FUNDED, past deadline
+    let now = clock.timestamp_ms();
+    let job_id = object::id(job);
+    reputation::record_no_delivery_pkg(seller_score, job_id, now);
+    if (escrow::is_claimed_job(job)) {
+        reputation::decrement_active(seller_score, job_id, now);
+    };
+    free_wave_hold(batch, job, now);
+}
+
+/// The Job must carry `BatchOriginKey` AND it must name THIS batch —
+/// a crank passing the wrong wave aborts instead of mutating a stranger's
+/// `claims_by_agent` table.
+fun assert_batch_origin<T>(batch: &BatchOpening<T>, job: &Job<T>) {
+    let mut origin = escrow::batch_origin(job);
+    assert!(origin.is_some(), ENotBatchJob);
+    assert!(origin.extract() == batch.id.to_inner(), EWrongBatch);
+}
+
+/// Free ONE per-wave hold for this Job's seller: saturating −1 on
+/// `claims_by_agent` (row removed at 0 — the Table stays droppable in
+/// spirit), one-shot `BatchHoldReleasedKey` on the Job (a second free
+/// aborts in escrow — belt + suspenders over the settle state machine),
+/// and the sibling event. NOT called on decline (D13: decline burns the
+/// wave seat, parity with the global counter).
+fun free_wave_hold<T>(batch: &mut BatchOpening<T>, job: &mut Job<T>, now: u64) {
+    escrow::mark_batch_hold_released_pkg(job);
+    let agent = escrow::seller(job);
+    let remaining = if (table::contains(&batch.claims_by_agent, agent)) {
+        let current = table::remove(&mut batch.claims_by_agent, agent);
+        if (current > 1) {
+            table::add(&mut batch.claims_by_agent, agent, current - 1);
+            current - 1
+        } else {
+            0
+        }
+    } else {
+        // Saturating: unreachable through the doors above (every origin
+        // Job added a row at claim), kept as a no-abort floor so a
+        // settlement can never wedge on counter drift.
+        0
+    };
+    event::emit(BatchSlotHoldReleased {
+        batch_id: batch.id.to_inner(),
+        job_id: object::id(job),
+        agent,
+        claims_remaining_for_agent: remaining,
+        timestamp_ms: now,
+    });
 }
 
 // === Cancel (buyer withdraws the unclaimed remainder — fee-free) ===
@@ -422,9 +651,26 @@ public fun min_seller_level<T>(batch: &BatchOpening<T>): u8 {
 public fun max_claims_per_agent<T>(batch: &BatchOpening<T>): u8 {
     batch.max_claims_per_agent
 }
-/// Slots `agent` already claimed of this batch (0 when never claimed).
+/// ACTIVE holds `agent` currently has of this batch (S.1202) — 0 when
+/// never claimed or when every claimed slot has settled. On a legacy
+/// (pre-S.1202) wave the rows are lifetime counts that never free.
 public fun claims_by_agent<T>(batch: &BatchOpening<T>, agent: address): u8 {
     claims_of(batch, agent)
 }
+/// Whether this wave runs active-claim semantics (S.1202) — false only
+/// for pre-upgrade batches, which no longer accept new claims (D21).
+public fun has_active_claims_semantics<T>(batch: &BatchOpening<T>): bool {
+    df::exists(&batch.id, ActiveClaimsSemanticsKey {})
+}
 public fun created_at_ms<T>(batch: &BatchOpening<T>): u64 { batch.created_at_ms }
 public fun escrow_value<T>(batch: &BatchOpening<T>): u64 { batch.escrow.value() }
+
+// === Test hooks ===
+
+/// Simulate a PRE-S.1202 wave: strip the semantics marker so legacy-batch
+/// behavior (`ELegacyBatch` on claim, cancel/refund still allowed) is
+/// testable without deploying old bytecode.
+#[test_only]
+public fun strip_active_claims_semantics_for_testing<T>(batch: &mut BatchOpening<T>) {
+    let _: bool = df::remove(&mut batch.id, ActiveClaimsSemanticsKey {});
+}

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -158,6 +158,10 @@ const EUseReleaseV2: u64 = 20;
 const EBadTierBounds: u64 = 21;
 /// S.1193: batch-slot args out of range — the live max must be 1..ceiling.
 const EBadBatchSlots: u64 = 22;
+/// S.1202: this batch Job's wave hold was already freed — the one-shot
+/// `BatchHoldReleasedKey` is belt + suspenders over the state machine
+/// (a second settle already aborts `EWrongState` inside the settle body).
+const EBatchHoldReleased: u64 = 23;
 
 // === Objects ===
 
@@ -202,6 +206,19 @@ public struct MaxBatchSlotsKey has copy, drop, store {}
 /// Pre-S.1192 claimed jobs also lack it, which IS the soft start: they
 /// never incremented, so their settles must not decrement.
 public struct ClaimedJobKey has copy, drop, store {}
+/// S.1202 — origin DF on `Job.id` (value = the `BatchOpening`'s `ID`), set
+/// by `create_claimed_from_batch` only: this Job was minted from a batch
+/// slot, so its terminal settle MUST go through the batch-aware doors in
+/// `batch` (which free the per-wave hold in the same tx) — the bare
+/// `reputation::release_v2` / `reject_v2*` / `refund_v2` abort on it.
+/// Single-opening and hire Jobs never carry it. Defining id = the S.1202
+/// upgrade package (V12 pin).
+public struct BatchOriginKey has copy, drop, store {}
+/// S.1202 — one-shot marker on `Job.id`: this batch Job's per-wave hold
+/// was freed (set by the batch settle doors via
+/// `mark_batch_hold_released_pkg`). A second free aborts. Defining id =
+/// the S.1202 upgrade package (V12 pin).
+public struct BatchHoldReleasedKey has copy, drop, store {}
 /// DF key for the canonical `reputation::ScoreBoard` id on `FeeConfig.id`
 /// (S.1054b). Value is the board `ID`. Its EXISTENCE is the single-instance
 /// lock: `reputation::create_score_board` records it and aborts if it is
@@ -369,6 +386,37 @@ public fun is_claimed_job<T>(job: &Job<T>): bool {
     df::exists(&job.id, ClaimedJobKey {})
 }
 
+/// Whether this Job was minted from a batch slot (S.1202). True ⇒ its
+/// terminal settle must go through the batch-aware doors in `batch`.
+public fun is_batch_origin_job<T>(job: &Job<T>): bool {
+    df::exists(&job.id, BatchOriginKey {})
+}
+
+/// The `BatchOpening` id this Job was claimed from, when batch-origin
+/// (S.1202) — clients read this at prepare time to attach the right batch
+/// to the settle PTB. None for single-opening and hire Jobs.
+public fun batch_origin<T>(job: &Job<T>): Option<ID> {
+    if (df::exists(&job.id, BatchOriginKey {})) {
+        option::some(*df::borrow(&job.id, BatchOriginKey {}))
+    } else {
+        option::none()
+    }
+}
+
+/// Whether this batch Job's per-wave hold has been freed (S.1202).
+public fun is_batch_hold_released<T>(job: &Job<T>): bool {
+    df::exists(&job.id, BatchHoldReleasedKey {})
+}
+
+/// One-shot hold-released stamp (S.1202) — called only by the batch
+/// settle doors after they free the wave hold. Abort-on-second-free is
+/// the idempotency lock the SPEC asks for (loud, never a silent double
+/// decrement).
+public(package) fun mark_batch_hold_released_pkg<T>(job: &mut Job<T>) {
+    assert!(!df::exists(&job.id, BatchHoldReleasedKey {}), EBatchHoldReleased);
+    df::add(&mut job.id, BatchHoldReleasedKey {}, true);
+}
+
 /// Bounds gate for money ENTERING escrow — `create` and (via the package
 /// accessor) `opening::create_open` only. Settlement verbs and
 /// `create_claimed` never re-check: an Opening fixed its amount at post,
@@ -466,6 +514,79 @@ public(package) fun create_claimed<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): ID {
+    let job = new_claimed_job(
+        buyer,
+        seller,
+        escrow,
+        fee_bps,
+        spec_hash,
+        deliver_by_ms,
+        review_window_ms,
+        reject_split_bps,
+        cfg,
+        clock,
+        ctx,
+    );
+    let job_id = job.id.to_inner();
+    transfer::share_object(job);
+    job_id
+}
+
+/// S.1202 sibling for `batch::batch_claim` — same claimed-Job constructor
+/// plus the `BatchOriginKey` DF (value = the wave's id), stamped BEFORE
+/// `share_object` (the batch module could not mutate the Job after share
+/// without another package helper). The origin routes this Job's terminal
+/// settle through the batch-aware doors, which free the per-wave hold in
+/// the same tx.
+public(package) fun create_claimed_from_batch<T>(
+    batch_id: ID,
+    buyer: address,
+    seller: address,
+    escrow: Balance<T>,
+    fee_bps: u64,
+    spec_hash: vector<u8>,
+    deliver_by_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): ID {
+    let mut job = new_claimed_job(
+        buyer,
+        seller,
+        escrow,
+        fee_bps,
+        spec_hash,
+        deliver_by_ms,
+        review_window_ms,
+        reject_split_bps,
+        cfg,
+        clock,
+        ctx,
+    );
+    df::add(&mut job.id, BatchOriginKey {}, batch_id);
+    let job_id = job.id.to_inner();
+    transfer::share_object(job);
+    job_id
+}
+
+/// The shared claimed-Job body — validates, brands `ClaimedJobKey`, emits
+/// `JobCreated`, and hands the UNSHARED Job back so each caller can stamp
+/// its own origin DFs before sharing.
+fun new_claimed_job<T>(
+    buyer: address,
+    seller: address,
+    escrow: Balance<T>,
+    fee_bps: u64,
+    spec_hash: vector<u8>,
+    deliver_by_ms: u64,
+    review_window_ms: u64,
+    reject_split_bps: u64,
+    cfg: &FeeConfig,
+    clock: &Clock,
+    ctx: &mut TxContext,
+): Job<T> {
     assert_version(cfg);
     assert!(buyer != seller, EBuyerIsSeller);
     let amount = escrow.value();
@@ -495,9 +616,8 @@ public(package) fun create_claimed<T>(
     // S.1192: brand the Job as board-claimed so terminal settles know to
     // decrement the seller's active counter (hire jobs stay unbranded).
     df::add(&mut job.id, ClaimedJobKey {}, true);
-    let job_id = job.id.to_inner();
     event::emit(JobCreated {
-        job_id,
+        job_id: job.id.to_inner(),
         buyer,
         seller,
         amount,
@@ -507,8 +627,7 @@ public(package) fun create_claimed<T>(
         reject_split_bps,
         timestamp_ms: now,
     });
-    transfer::share_object(job);
-    job_id
+    job
 }
 
 // === Package-visible guards (shared with `opening` — single source for

--- a/contracts/a2a_escrow/sources/escrow.move
+++ b/contracts/a2a_escrow/sources/escrow.move
@@ -53,6 +53,13 @@ use sui::dynamic_field as df;
 use sui::event;
 
 /// Package flow version — bump on upgrades that must invalidate old flows.
+/// v7 (S.1202, D23): batch active per-wave claims + batch-aware settle —
+/// the cutover kills the v11 bytecode whose `create_batch_open` /
+/// `batch_claim` / bare `release_v2` would still post un-branded waves,
+/// claim with lifetime semantics, and settle batch Jobs without freeing
+/// the wave hold. After migrate, batch Jobs settle ONLY through the
+/// `batch::batch_release`/`batch_reject*`/`batch_refund` doors and every
+/// pre-upgrade (non-origin) Job settles on THIS package's v2 doors.
 /// v6 (S.1192): seller levels + active caps — claims and release settle
 /// through `opening::claim_v2`/`claim_proven_v2` and
 /// `reputation::release_v2` (all take the seller's `&mut AgentScore` so
@@ -64,7 +71,7 @@ use sui::event;
 /// outcomes hit the seller's (and an Agent-ID buyer's) score. v4
 /// (S.1062): Proven = distinct buyers. v3 (S.1019): open reject 100%
 /// buyer. v2 (S.981): amount bounds.
-const VERSION: u64 = 6;
+const VERSION: u64 = 7;
 
 // === States ===
 const STATE_FUNDED: u8 = 0;

--- a/contracts/a2a_escrow/sources/reputation.move
+++ b/contracts/a2a_escrow/sources/reputation.move
@@ -94,6 +94,12 @@ const EBuyerIsAgent: u64 = 7;
 /// S.1063: this buyer is NOT a registered Agent ID — use `reject_v2`
 /// (Passport buyers never get a public chain counter).
 const EBuyerNotAgent: u64 = 8;
+/// S.1202: this Job carries `BatchOriginKey` — its terminal settle must
+/// go through the batch-aware doors (`batch::batch_release` /
+/// `batch_reject*` / `batch_refund`), which free the per-wave hold in the
+/// same tx. A bare v2 settle would silently leak the wave seat, so it
+/// aborts loudly here instead (the S.1032/S.1063 dedicated-code pattern).
+const EUseBatchSettle: u64 = 9;
 
 // === Objects ===
 
@@ -321,7 +327,8 @@ public fun submit_review<T>(
     apply_review(score, object::id(job), ctx.sender(), stars, clock.timestamp_ms());
 }
 
-// === Outcome settlement (S.1063) — the ONLY live reject/refund doors ===
+// === Outcome settlement (S.1063) — the live reject/refund doors for
+// === NON-batch jobs (S.1202: batch-origin jobs settle via `batch::*`) ===
 // Money moves in `escrow::{reject,refund}_settle_pkg` (single source for
 // coin/fee math + the frozen v1 events); the counters land here. Outcomes
 // never touch stars/distinct/Proven — display-only protocol facts.
@@ -370,6 +377,7 @@ public fun reject_v2<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert!(!escrow::is_batch_origin_job(job), EUseBatchSettle); // S.1202
     assert!(!registry::is_registered(registry, escrow::buyer(job)), EBuyerIsAgent);
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
     escrow::reject_settle_pkg(job, cfg, clock, ctx); // auth: sender==buyer, DELIVERED, in-window
@@ -400,6 +408,7 @@ public fun reject_v2_agent_buyer<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert!(!escrow::is_batch_origin_job(job), EUseBatchSettle); // S.1202
     let buyer = escrow::buyer(job);
     assert!(registry::is_registered(registry, buyer), EBuyerNotAgent);
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
@@ -438,6 +447,7 @@ public fun refund_v2<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert!(!escrow::is_batch_origin_job(job), EUseBatchSettle); // S.1202
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
     escrow::refund_settle_pkg(job, cfg, clock, ctx); // auth: FUNDED, past deadline
     let now = clock.timestamp_ms();
@@ -456,8 +466,10 @@ public fun refund_v2<T>(
     };
 }
 
-/// Release — funds → seller minus the protocol fee (S.1192: the ONLY live
-/// release door). Money settles in escrow's package-visible
+/// Release — funds → seller minus the protocol fee (S.1192: the live
+/// release door for every NON-batch job; S.1202: batch-origin jobs abort
+/// here and settle via `batch::batch_release`, which also frees the
+/// per-wave hold). Money settles in escrow's package-visible
 /// `release_settle_pkg` (auth unchanged from v1: buyer accept, buyer
 /// goodwill on FUNDED, or anyone after the review window lapses); the
 /// seller's active-job counter decrements here for board-claimed jobs.
@@ -471,6 +483,7 @@ public fun release_v2<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert!(!escrow::is_batch_origin_job(job), EUseBatchSettle); // S.1202
     assert!(seller_score.agent == escrow::seller(job), EWrongScore);
     escrow::release_settle_pkg(job, cfg, clock, ctx);
     if (escrow::is_claimed_job(job)) {
@@ -506,10 +519,47 @@ fun record_outcome<K: copy + drop + store>(
     });
 }
 
+// === Batch settle hooks (S.1202) — package-visible outcome recorders ===
+// The batch-aware settle doors in `batch` must land the SAME counters the
+// v2 doors do; `record_outcome` stays private (the typed DF keys are the
+// authority), so `batch` gets these thin package-visible wrappers instead.
+// No cycle: `batch` imports `reputation`, never the reverse.
+
+/// `rejected_after_delivery` +1 — for `batch::batch_reject*` only.
+public(package) fun record_rejected_after_delivery_pkg(
+    score: &mut AgentScore,
+    job_id: ID,
+    now: u64,
+) {
+    record_outcome(
+        score,
+        job_id,
+        RejectedAfterDeliveryKey {},
+        OUTCOME_REJECTED_AFTER_DELIVERY,
+        now,
+    );
+}
+
+/// `no_delivery` +1 — for `batch::batch_refund` only.
+public(package) fun record_no_delivery_pkg(score: &mut AgentScore, job_id: ID, now: u64) {
+    record_outcome(score, job_id, NoDeliveryKey {}, OUTCOME_NO_DELIVERY, now);
+}
+
+/// `as_buyer_rejected` +1 — for `batch::batch_reject_agent_buyer` only.
+public(package) fun record_as_buyer_rejected_pkg(
+    score: &mut AgentScore,
+    job_id: ID,
+    now: u64,
+) {
+    record_outcome(score, job_id, AsBuyerRejectedKey {}, OUTCOME_AS_BUYER_REJECTED, now);
+}
+
 // === Active-job counter (S.1192) — package-private mutators ===
-// Only `opening::do_claim` increments; only the three terminal settle
-// paths above decrement (claimed jobs only). Package-private, so the
-// counter can never move except with the money.
+// Only `opening::do_claim` and `batch::batch_claim` increment; only the
+// terminal settle paths decrement — the three v2 doors above for
+// non-batch jobs, the `batch::batch_release`/`batch_reject*`/
+// `batch_refund` doors for batch-origin jobs (claimed jobs only).
+// Package-private, so the counter can never move except with the money.
 
 /// +1 — called by `opening::do_claim` after the Job mints. Serializes
 /// same-seller claims on the score object (correct: that IS the cap);

--- a/contracts/a2a_escrow/tests/batch_tests.move
+++ b/contracts/a2a_escrow/tests/batch_tests.move
@@ -75,6 +75,16 @@ fun take_score(sc: &ts::Scenario, who: address): AgentScore {
     ts::take_shared_by_id<AgentScore>(sc, object::id_from_address(addr))
 }
 
+/// Resolve a score's id in its own tx — for blocks that must hold TWO
+/// scores at once (the board can't be re-taken twice in one tx).
+fun score_id_of(sc: &mut ts::Scenario, who: address): ID {
+    ts::next_tx(sc, who);
+    let board = ts::take_shared<ScoreBoard>(sc);
+    let addr = reputation::score_address(&board, who);
+    ts::return_shared(board);
+    object::id_from_address(addr)
+}
+
 fun active_of(sc: &mut ts::Scenario, who: address): u64 {
     ts::next_tx(sc, who);
     let score = take_score(sc, who);
@@ -131,6 +141,61 @@ fun claim_as(sc: &mut ts::Scenario, who: address, clk: &Clock): ID {
     ts::return_shared(reg);
     ts::return_shared(cfg);
     job_id
+}
+
+/// Claim from a SPECIFIC batch (multi-batch scenarios can't take_shared).
+fun claim_from(sc: &mut ts::Scenario, who: address, clk: &Clock, batch_id: ID): ID {
+    ensure_score(sc, clk, who);
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let reg = ts::take_shared<Registry>(sc);
+    let mut score = take_score(sc, who);
+    let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(sc, batch_id);
+    let job_id = batch::batch_claim(&mut b, &reg, &mut score, &cfg, clk, ts::ctx(sc));
+    ts::return_shared(b);
+    ts::return_shared(score);
+    ts::return_shared(reg);
+    ts::return_shared(cfg);
+    job_id
+}
+
+fun deliver_job(sc: &mut ts::Scenario, who: address, clk: &Clock, job_id: ID) {
+    ts::next_tx(sc, who);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
+    escrow::deliver(&mut job, b"delivery", &cfg, clk, ts::ctx(sc));
+    ts::return_shared(job);
+    ts::return_shared(cfg);
+}
+
+/// Settle a batch-origin Job through `batch_release` as `sender`
+/// (`seller` names whose score rides along — always the Job's seller).
+fun batch_release_as(
+    sc: &mut ts::Scenario,
+    sender: address,
+    clk: &Clock,
+    batch_id: ID,
+    job_id: ID,
+    seller: address,
+) {
+    ts::next_tx(sc, sender);
+    let cfg = ts::take_shared<FeeConfig>(sc);
+    let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(sc, batch_id);
+    let mut job = ts::take_shared_by_id<Job<SUI>>(sc, job_id);
+    let mut score = take_score(sc, seller);
+    batch::batch_release(&mut b, &mut job, &mut score, &cfg, clk, ts::ctx(sc));
+    ts::return_shared(score);
+    ts::return_shared(job);
+    ts::return_shared(b);
+    ts::return_shared(cfg);
+}
+
+fun wave_claims_of(sc: &mut ts::Scenario, batch_id: ID, who: address): u8 {
+    ts::next_tx(sc, who);
+    let b = ts::take_shared_by_id<BatchOpening<SUI>>(sc, batch_id);
+    let n = batch::claims_by_agent(&b, who);
+    ts::return_shared(b);
+    n
 }
 
 fun assert_received(sc: &mut ts::Scenario, who: address, expect: u64) {
@@ -364,12 +429,13 @@ fun proven_policy_refuses_unproven_claimer() {
 }
 
 #[test]
-#[expected_failure(abort_code = batch::EActiveJobCap)]
-fun global_active_cap_counts_batch_slots() {
+#[expected_failure(abort_code = batch::EMaxClaimsReached)]
+fun wave_cap_is_level_scaled_min_of_ceiling_and_level_cap() {
     let (mut sc, mut clk) = setup();
-    // Level 1 cap is 4 — with maxClaimsPerAgent 10 on a single wave, the
-    // 5th slot claim hits the GLOBAL cap, not the wave limit.
-    post_batch(&mut sc, &clk, SLOTS, 10);
+    // S.1202 (D15) / acceptance 1: buyer ceiling 30, Level-1 cap 4 → the
+    // wave cap is min(30, 4) = 4; the 5th claim of the SAME wave aborts
+    // on the WAVE gate (asserted before the global EActiveJobCap).
+    post_batch(&mut sc, &clk, SLOTS, 30);
     clk.set_for_testing(10_000);
     claim_as(&mut sc, SELLER, &clk);
     claim_as(&mut sc, SELLER, &clk);
@@ -377,6 +443,25 @@ fun global_active_cap_counts_batch_slots() {
     claim_as(&mut sc, SELLER, &clk);
     assert!(active_of(&mut sc, SELLER) == 4, 0);
     claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EActiveJobCap)]
+fun global_active_cap_counts_batch_slots_across_waves() {
+    let (mut sc, mut clk) = setup();
+    // Level-1 global cap is 4 across ALL waves: 2 + 2 holds on two waves,
+    // then a 3rd claim of wave A passes its wave gate (2 < min(3, 4)) and
+    // hits the GLOBAL cap.
+    let a = post_batch(&mut sc, &clk, SLOTS, 3);
+    let b = post_batch(&mut sc, &clk, SLOTS, 3);
+    clk.set_for_testing(10_000);
+    claim_from(&mut sc, SELLER, &clk, a);
+    claim_from(&mut sc, SELLER, &clk, a);
+    claim_from(&mut sc, SELLER, &clk, b);
+    claim_from(&mut sc, SELLER, &clk, b);
+    assert!(active_of(&mut sc, SELLER) == 4, 0);
+    claim_from(&mut sc, SELLER, &clk, a);
     abort 0
 }
 
@@ -402,36 +487,432 @@ fun claim_on_borrowed_score_aborts() {
     abort 0
 }
 
-// === A claimed slot settles like any Job (release frees the seat) ===
+// === S.1202 — batch-aware settle frees the wave hold with the money ===
 
 #[test]
-fun claimed_slot_releases_via_release_v2_and_frees_the_seat() {
+fun batch_release_pays_seller_and_frees_both_counters() {
     let (mut sc, mut clk) = setup();
-    post_batch(&mut sc, &clk, SLOTS, 1);
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
     clk.set_for_testing(10_000);
     let job_id = claim_as(&mut sc, SELLER, &clk);
     assert!(active_of(&mut sc, SELLER) == 1, 0);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 1, 1);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job_id);
+    clk.set_for_testing(30_000);
+    batch_release_as(&mut sc, BUYER, &clk, bid, job_id, SELLER);
+    // Global seat AND wave hold freed; the one-shot marker is stamped;
+    // row removed at 0 (reads back as 0).
+    assert!(active_of(&mut sc, SELLER) == 0, 2);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 0, 3);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        assert!(escrow::is_batch_hold_released(&job), 4);
+        ts::return_shared(job);
+    };
+    // Seller got the slot minus the 2.5% test-default fee.
+    assert_received(&mut sc, SELLER, SLOT_AMOUNT - SLOT_AMOUNT * 250 / 10_000);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun settle_frees_wave_hold_and_fifth_claim_succeeds() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 2: ceiling 30, L1 holds 4 → settle one → a 5th claim of
+    // the SAME wave lands (both the wave and global counters dropped).
+    let bid = post_batch(&mut sc, &clk, SLOTS, 30);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    clk.set_for_testing(30_000);
+    batch_release_as(&mut sc, BUYER, &clk, bid, job1, SELLER);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 3, 0);
+    assert!(active_of(&mut sc, SELLER) == 3, 1);
+    clk.set_for_testing(40_000);
+    claim_from(&mut sc, SELLER, &clk, bid);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 4, 2);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        assert!(batch::slots_remaining(&b) == 5, 3);
+        ts::return_shared(b);
+    };
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun ceiling_one_finisher_reclaims_same_wave_after_settle() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 4: buyer ceiling 1 — claim → settle → claim AGAIN of the
+    // same wave (active semantics alone, no Level scaling involved).
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    clk.set_for_testing(30_000);
+    batch_release_as(&mut sc, BUYER, &clk, bid, job1, SELLER);
+    clk.set_for_testing(40_000);
+    claim_from(&mut sc, SELLER, &clk, bid);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 1, 0);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EMaxClaimsReached)]
+fun decline_does_not_free_wave_hold() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 3 (D13): decline burns the wave seat — claim→decline
+    // churn cannot farm slots of a ceiling-1 wave.
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
     ts::next_tx(&mut sc, SELLER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
-        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
-        escrow::deliver(&mut job, b"delivery", &cfg, &clk, ts::ctx(&mut sc));
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        escrow::decline(&mut job, &cfg, &clk, ts::ctx(&mut sc));
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 1, 0);
+    claim_from(&mut sc, SELLER, &clk, bid);
+    abort 0
+}
+
+#[test]
+fun timeout_release_crank_with_correct_batch_frees_wave_hold() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 10: after the review window lapses ANYONE may settle —
+    // the crank passes the origin batch and the wave hold frees.
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    clk.set_for_testing(120_001); // delivered 20_000 + review 100_000, lapsed
+    batch_release_as(&mut sc, LURKER, &clk, bid, job1, SELLER);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 0, 0);
+    assert!(active_of(&mut sc, SELLER) == 0, 1);
+    assert_received(&mut sc, SELLER, SLOT_AMOUNT - SLOT_AMOUNT * 250 / 10_000);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EWrongBatch)]
+fun settle_with_wrong_batch_aborts() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 10: a crank attaching a DIFFERENT wave than the Job's
+    // origin aborts — no stranger-table mutation.
+    let a = post_batch(&mut sc, &clk, SLOTS, 1);
+    let b = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_from(&mut sc, SELLER, &clk, a);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    batch_release_as(&mut sc, BUYER, &clk, b, job1, SELLER);
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = batch::ENotBatchJob)]
+fun batch_settle_on_non_batch_job_aborts() {
+    let (mut sc, mut clk) = setup();
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    // A hire job (escrow::create) has no BatchOriginKey — the batch door
+    // refuses it.
+    ensure_score(&mut sc, &clk, SELLER);
+    ts::next_tx(&mut sc, BUYER);
+    let hire_id = {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let coin = coin::mint_for_testing<SUI>(SLOT_AMOUNT, ts::ctx(&mut sc));
+        let id = escrow::create<SUI>(
+            SELLER, coin, b"hire", 410_000, REVIEW_WINDOW, 5_000,
+            &cfg, &clk, ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    batch_release_as(&mut sc, BUYER, &clk, bid, hire_id, SELLER);
+    abort 0
+}
+
+#[test]
+fun batch_reject_passport_buyer_pays_buyer_and_records_outcome() {
+    let (mut sc, mut clk) = setup();
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
     ts::next_tx(&mut sc, BUYER);
     {
         let cfg = ts::take_shared<FeeConfig>(&sc);
-        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job_id);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut score = take_score(&sc, SELLER);
+        batch::batch_reject(&mut b, &mut job, &mut score, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        // Outcome landed with the money.
+        assert!(reputation::rejected_after_delivery(&score) == 1, 0);
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(b);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    // Open-board lock: reject = 100% buyer, fee-free; both counters freed.
+    assert_received(&mut sc, BUYER, SLOT_AMOUNT);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 0, 1);
+    assert!(active_of(&mut sc, SELLER) == 0, 2);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+#[expected_failure(abort_code = batch::EBuyerIsAgent)]
+fun batch_reject_with_agent_buyer_routes_to_agent_variant() {
+    let (mut sc, mut clk) = setup();
+    register_agent(&mut sc, &clk, BUYER);
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut score = take_score(&sc, SELLER);
+        batch::batch_reject(&mut b, &mut job, &mut score, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(b);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+fun batch_reject_agent_buyer_lands_both_outcomes() {
+    let (mut sc, mut clk) = setup();
+    register_agent(&mut sc, &clk, BUYER);
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    ensure_score(&mut sc, &clk, BUYER);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    let seller_score_id = score_id_of(&mut sc, SELLER);
+    let buyer_score_id = score_id_of(&mut sc, BUYER);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut seller_score = ts::take_shared_by_id<AgentScore>(&sc, seller_score_id);
+        let mut buyer_score = ts::take_shared_by_id<AgentScore>(&sc, buyer_score_id);
+        batch::batch_reject_agent_buyer(
+            &mut b, &mut job, &mut seller_score, &mut buyer_score,
+            &reg, &cfg, &clk, ts::ctx(&mut sc),
+        );
+        assert!(reputation::rejected_after_delivery(&seller_score) == 1, 0);
+        assert!(reputation::as_buyer_rejected(&buyer_score) == 1, 1);
+        ts::return_shared(buyer_score);
+        ts::return_shared(seller_score);
+        ts::return_shared(job);
+        ts::return_shared(b);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 0, 2);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+#[test]
+fun batch_refund_after_deadline_records_no_delivery_and_frees_hold() {
+    let (mut sc, mut clk) = setup();
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(410_001); // claim SLA 400_000 lapsed, no delivery
+    ts::next_tx(&mut sc, LURKER); // permissionless crank
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut score = take_score(&sc, SELLER);
+        batch::batch_refund(&mut b, &mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        assert!(reputation::no_delivery(&score) == 1, 0);
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    assert_received(&mut sc, BUYER, SLOT_AMOUNT);
+    assert!(wave_claims_of(&mut sc, bid, SELLER) == 0, 1);
+    assert!(active_of(&mut sc, SELLER) == 0, 2);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === S.1202 — the bare v2 settle doors refuse batch-origin Jobs ===
+
+#[test]
+#[expected_failure(abort_code = reputation::EUseBatchSettle)]
+fun release_v2_on_batch_origin_job_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
         let mut score = take_score(&sc, SELLER);
         reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
         ts::return_shared(score);
         ts::return_shared(job);
         ts::return_shared(cfg);
     };
-    assert!(active_of(&mut sc, SELLER) == 0, 1);
-    // Seller got the slot minus the 2.5% test-default fee.
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EUseBatchSettle)]
+fun reject_v2_on_batch_origin_job_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, job1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let reg = ts::take_shared<Registry>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut score = take_score(&sc, SELLER);
+        reputation::reject_v2(&mut job, &mut score, &reg, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(reg);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+#[expected_failure(abort_code = reputation::EUseBatchSettle)]
+fun refund_v2_on_batch_origin_job_aborts() {
+    let (mut sc, mut clk) = setup();
+    post_batch(&mut sc, &clk, SLOTS, 1);
+    clk.set_for_testing(10_000);
+    let job1 = claim_as(&mut sc, SELLER, &clk);
+    clk.set_for_testing(410_001);
+    ts::next_tx(&mut sc, LURKER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, job1);
+        let mut score = take_score(&sc, SELLER);
+        reputation::refund_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
+    abort 0
+}
+
+#[test]
+fun non_batch_job_still_settles_via_release_v2() {
+    let (mut sc, mut clk) = setup();
+    // Acceptance 5: a hire job (no BatchOriginKey) settles through the
+    // unchanged v2 door.
+    ensure_score(&mut sc, &clk, SELLER);
+    clk.set_for_testing(10_000);
+    ts::next_tx(&mut sc, BUYER);
+    let hire_id = {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let coin = coin::mint_for_testing<SUI>(SLOT_AMOUNT, ts::ctx(&mut sc));
+        let id = escrow::create<SUI>(
+            SELLER, coin, b"hire", 410_000, REVIEW_WINDOW, 5_000,
+            &cfg, &clk, ts::ctx(&mut sc),
+        );
+        ts::return_shared(cfg);
+        id
+    };
+    clk.set_for_testing(20_000);
+    deliver_job(&mut sc, SELLER, &clk, hire_id);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut job = ts::take_shared_by_id<Job<SUI>>(&sc, hire_id);
+        let mut score = take_score(&sc, SELLER);
+        reputation::release_v2(&mut job, &mut score, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(score);
+        ts::return_shared(job);
+        ts::return_shared(cfg);
+    };
     assert_received(&mut sc, SELLER, SLOT_AMOUNT - SLOT_AMOUNT * 250 / 10_000);
+    ts::end(sc);
+    clk.destroy_for_testing();
+}
+
+// === S.1202 (D21) — legacy batches refuse NEW claims, keep exits ===
+
+#[test]
+#[expected_failure(abort_code = batch::ELegacyBatch)]
+fun legacy_batch_claim_aborts() {
+    let (mut sc, mut clk) = setup();
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        // Simulate a pre-S.1202 wave (no semantics marker).
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        batch::strip_active_claims_semantics_for_testing(&mut b);
+        ts::return_shared(b);
+    };
+    clk.set_for_testing(10_000);
+    claim_as(&mut sc, SELLER, &clk);
+    abort 0
+}
+
+#[test]
+fun legacy_batch_cancel_still_works() {
+    let (mut sc, clk) = setup();
+    let bid = post_batch(&mut sc, &clk, SLOTS, 1);
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        batch::strip_active_claims_semantics_for_testing(&mut b);
+        ts::return_shared(b);
+    };
+    ts::next_tx(&mut sc, BUYER);
+    {
+        let cfg = ts::take_shared<FeeConfig>(&sc);
+        let mut b = ts::take_shared_by_id<BatchOpening<SUI>>(&sc, bid);
+        batch::cancel_batch_open(&mut b, &cfg, &clk, ts::ctx(&mut sc));
+        ts::return_shared(b);
+        ts::return_shared(cfg);
+    };
+    assert_received(&mut sc, BUYER, SLOT_AMOUNT * SLOTS);
     ts::end(sc);
     clk.destroy_for_testing();
 }


### PR DESCRIPTION
## ⚠️ Cutover lock (D23)

**Do NOT upgrade mainnet without executing `migrate` in the same ops window.** This PR bumps `escrow::VERSION` 6→7: after the v12 package upgrade, the founder must immediately call the existing AdminCap `migrate` so the live FeeConfig reads 7 — killing all v11-and-earlier bytecode (`EWrongVersion`). Broadcast is gated by `spec/runbooks/RUNBOOK_S1202_BATCH_ACTIVE_CLAIMS.md` (rewritten S.1192-style: upgrade → **immediate migrate** → verify 7 → pin V12 → npm → audric → repost). **No mainnet action happens in this PR.**

## What

Move side of **S.1202** (`spec/active/SPEC_MARKETPLACE_BATCH_ACTIVE_CLAIMS.md`, D11–D23). On-chain only — SDK/CLI/audric/desk are S.1202b/c.

- **Active per-wave claims (D11–D16):** `claims_by_agent[agent]` now counts in-flight holds of that wave; release / reject / refund free a seat (saturating −1, table row removed at 0). Decline does **not** free (D13). Claim gate is `min(max_claims_per_agent, active_cap_for_level(effective_level))`, asserted before the global `EActiveJobCap` (D15, locked abort priority).
- **Origin stamp:** `batch_claim` mints Jobs through new package-private `escrow::create_claimed_from_batch` — `BatchOriginKey` (value = wave id) added before `share_object`. Read via `escrow::batch_origin(job)`.
- **Batch-aware settle doors** in `batch`: `batch_release` · `batch_reject` · `batch_reject_agent_buyer` · `batch_refund` — money (`escrow::*_settle_pkg`), outcome counters (new `public(package)` reputation hooks), global seat (`decrement_active`), and the wave hold all move in ONE tx. Wrong batch aborts `EWrongBatch`; one-shot `BatchHoldReleasedKey`; sibling `BatchSlotHoldReleased` event (V12 defining pin).
- **Bare v2 doors abort** `EUseBatchSettle` on batch-origin Jobs — no silent wave-seat leak.
- **Legacy lockout (D21):** `create_batch_open` stamps `ActiveClaimsSemanticsKey`; `batch_claim` aborts `ELegacyBatch` without it. Cancel / expired-refund on legacy waves unchanged.
- **VERSION cutover (D23 / S.1202a.1):** `VERSION = 7`; existing `migrate` advances 6→7 and refuses same-version. Closes the residual where v11 `create_batch_open` / `batch_claim` / bare `release_v2` could bypass the new semantics.

## Upgrade class

**v12 package + FeeConfig VERSION 6→7 + immediate migrate** (S.1192/S.1063 ritual — additive-only was rejected at D23 close-out). Still: no live public signature changes, no struct layout changes, no new AdminCap knobs (D22), no `batch`↔`reputation` cycle. The ~82 in-flight pre-upgrade Jobs settle on the **v12** v2 doors post-migrate (they carry no origin DF). Stale `@t2000/*` clients get `EWrongVersion` until they update — the standard trade, stated in release notes.

## Verify

```
cd contracts/a2a_escrow && sui move test
# 168/168 — SPEC acceptance 1–6, 9–10; migrate harness now literally exercises 6→7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)