### PR TITLE
🎨 style(cli): jobs vocabulary + USDC-first taglines + t2 help refresh

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @t2000/cli
 
-The terminal Agent Wallet for AI agents on Sui — the A2A Marketplace (hire, sell, escrowed jobs), gasless USDC + USDsui sends, Cetus swaps, and x402 pay. Scriptable from any shell.
+The terminal Agent Wallet for AI agents on Sui — the A2A Marketplace (hire, sell, escrowed jobs), gasless USDC sends, Cetus swaps, and x402 pay. Scriptable from any shell.
 
 [![npm @t2000/cli](https://img.shields.io/npm/v/@t2000/cli?label=%40t2000%2Fcli)](https://www.npmjs.com/package/@t2000/cli)
 [![docs](https://img.shields.io/badge/docs-docs.t2000.ai-00D395)](https://docs.t2000.ai/agent-wallet)

--- a/packages/cli/src/commands/balance.ts
+++ b/packages/cli/src/commands/balance.ts
@@ -24,7 +24,7 @@ export interface BalanceOptions {
 export function registerBalance(program: Command) {
   program
     .command('balance')
-    .description('Show all wallet holdings — USDC / USDsui / SUI (USD-priced) + any other tokens (amount-only)')
+    .description('Show all wallet holdings — USDC first (stables + SUI USD-priced) + any other tokens (amount-only)')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .action(async (opts: BalanceOptions) => {
       try {

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -1,13 +1,14 @@
-// Batch (wave) verbs of `t2 job` (S.1193 — Phase D). ONE post = N
-// homogeneous slots with a SINGLE escrow of slots × per-slot budget; each
-// claimed slot mints a normal Job (deliver/settle with the ordinary job
-// verbs). One claim per tx (v1 lock) — a wave allowing more claims per
-// agent means running batch-claim again. Sequential 50× `t2 job open`
-// is the thing this replaces; singles stay for one-offs.
+// Batch verbs of `t2 job` (S.1193/S.1202). ONE post = N identical jobs
+// with a SINGLE escrow of jobs × per-job budget ("N/M jobs" on the
+// board); each claim mints a normal Job (deliver/settle with the
+// ordinary job verbs). One claim per tx — the per-agent limit counts
+// ACTIVE holds, so a finisher claims again after settling. Sequential
+// 50× `t2 job open` is the thing this replaces; singles stay for
+// one-offs. Human copy says "jobs"; the machine ids stay batchId/--slots.
 //
-//   batch-open    post a wave — ESCROWS slots × budget NOW    (buyer)
-//   batch-claim   claim ONE slot → funded Job, work starts    (seller)
-//   batch-cancel  withdraw the unclaimed remainder, fee-free  (buyer)
+//   batch-open    post N jobs at once — ESCROWS jobs × budget NOW (buyer)
+//   batch-claim   claim ONE job → funded Job, work starts        (seller)
+//   batch-cancel  withdraw the unclaimed jobs, fee-free          (buyer)
 
 import {
   assertSpendAllowed,
@@ -56,14 +57,14 @@ const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 export function registerBatchVerbs(group: Command) {
   group
     .command('batch-open')
-    .description('Batch — post ONE wave of N identical slots (buyer); ESCROWS slots × budget on-chain now. Each claimed slot becomes a normal Job; the unclaimed remainder refunds fee-free (cancel any time, or the crank after the window).')
-    .requiredOption('--title <text>', "The wave's public name (up to 80 chars)")
-    .requiredOption('--brief <file-or-text>', 'What every slot delivers — PUBLIC, one brief for the whole wave')
-    .requiredOption('--max <usdc>', `PER-SLOT budget (max ${MAX_JOB_USDC}); total escrow = slots × this`)
-    .requiredOption('--slots <n>', `Slots in the wave (1–${MAX_BATCH_SLOTS_DEFAULT}; the live max is AdminCap-tunable)`)
-    .option('--max-claims-per-agent <n>', 'Slots one agent may claim of THIS wave (default 1)', '1')
-    .option('--sla <duration>', 'Delivery window per slot once claimed (e.g. 30m, 24h, 7d)', '24h')
-    .option('--open-for <duration>', 'How long the wave stays claimable before it refunds', '24h')
+    .description('Post N identical jobs in ONE tx (buyer); ESCROWS jobs × budget on-chain now — one board row with a live "N/M jobs" count. Each claim becomes a normal Job; unclaimed jobs refund fee-free (cancel any time, or the crank after the window).')
+    .requiredOption('--title <text>', "The posting's public name (up to 80 chars)")
+    .requiredOption('--brief <file-or-text>', 'What every job delivers — PUBLIC, one brief for the whole posting')
+    .requiredOption('--max <usdc>', `PER-JOB budget (max ${MAX_JOB_USDC}); total escrow = jobs × this`)
+    .requiredOption('--slots <n>', `Jobs in the posting (1–${MAX_BATCH_SLOTS_DEFAULT}; the live max is AdminCap-tunable)`)
+    .option('--max-claims-per-agent <n>', 'Jobs one agent may hold IN FLIGHT on this posting (default 1) — a settled job frees the seat; seller Level scales the effective cap', '1')
+    .option('--sla <duration>', 'Delivery window per job once claimed (e.g. 30m, 24h, 7d)', '24h')
+    .option('--open-for <duration>', 'How long the posting stays claimable before it refunds', '24h')
     .option(
       '--claim-policy <policy>',
       'Who may claim: 0 Anyone (default) · 1 Proven · 2 Proven · 4★+; claiming stays instant and $0',
@@ -92,7 +93,7 @@ export function registerBatchVerbs(group: Command) {
           const base = opts.api ?? DEFAULT_API_BASE;
           const maxUsdc = Number(opts.max);
           if (!Number.isFinite(maxUsdc) || maxUsdc <= 0 || maxUsdc > MAX_JOB_USDC) {
-            throw new Error(`--max is the PER-SLOT budget: between 0.01 and ${MAX_JOB_USDC} USDC.`);
+            throw new Error(`--max is the PER-JOB budget: between 0.01 and ${MAX_JOB_USDC} USDC.`);
           }
           const slots = Number(opts.slots);
           if (!Number.isInteger(slots) || slots < 1 || slots > MAX_BATCH_SLOTS_DEFAULT) {
@@ -105,7 +106,7 @@ export function registerBatchVerbs(group: Command) {
           const claimPolicy = resolveClaimPolicyFlags(opts);
           const minSellerLevel = resolveMinSellerLevelFlag(opts.minSellerLevel);
           const brief = await resolveBrief(opts.brief);
-          // The WHOLE wave escrows at post — the spend gate sees the total.
+          // The WHOLE posting escrows at post — the spend gate sees the total.
           const totalUsdc = maxUsdc * slots;
           assertSpendAllowed(totalUsdc);
           const agent = await withAgent({ keyPath: opts.key });
@@ -132,7 +133,7 @@ export function registerBatchVerbs(group: Command) {
           }
           printBlank();
           printSuccess(
-            `Wave posted — ${slots} slot${slots === 1 ? '' : 's'} × $${maxUsdc.toFixed(2)} = $${totalUsdc.toFixed(2)} USDC escrowed in ONE tx.`,
+            `Posted — ${slots} job${slots === 1 ? '' : 's'} × $${maxUsdc.toFixed(2)} = $${totalUsdc.toFixed(2)} USDC escrowed in ONE tx.`,
           );
           if (claimPolicy !== OPENING_CLAIM_POLICY_ANY_ACTIVE) {
             printInfo(
@@ -143,16 +144,20 @@ export function registerBatchVerbs(group: Command) {
             printInfo(`${sellerLevelLabel(minSellerLevel)}+ floor on.`);
           }
           if (maxClaims === 1) {
-            printInfo('One slot per agent — a hunter cannot hoard this wave.');
+            printInfo(
+              'One job in flight per agent — a finisher can claim again once their job settles.',
+            );
           } else {
-            printInfo(`Up to ${maxClaims} slots per agent (sequential claims).`);
+            printInfo(
+              `Up to ${maxClaims} jobs in flight per agent on this posting (sequential claims; seller Level scales the effective cap).`,
+            );
           }
           printBlank();
-          if (batchId) printKeyValue('Batch', batchId);
+          if (batchId) printKeyValue('Posting', batchId);
           printKeyValue('Tx', digest);
           printBlank();
           printInfo(
-            `Each claim starts a normal job immediately. Unclaimed slots refund in ${opts.openFor}` +
+            `Each claim starts a normal job immediately. Unclaimed jobs refund in ${opts.openFor}` +
               (batchId ? ` (or now: t2 job batch-cancel ${batchId})` : '.'),
           );
           printBlank();
@@ -164,8 +169,8 @@ export function registerBatchVerbs(group: Command) {
 
   group
     .command('batch-claim')
-    .argument('<batchId>', 'The batch object id (0x…, from t2 job board)')
-    .description('Claim ONE slot of a wave (seller) — $0, first-come; the funded Job starts immediately. Claim again for another slot when the wave allows more than one per agent.')
+    .argument('<batchId>', 'The board row id (0x…, from t2 job board — rows showing "N/M jobs")')
+    .description("Claim ONE job from a batch posting (seller) — $0, first-come; the funded Job starts immediately. The per-agent limit counts jobs IN FLIGHT: settle one and you can claim this posting again.")
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(async (batchId: string, opts: { key?: string; api?: string }) => {
@@ -173,8 +178,9 @@ export function registerBatchVerbs(group: Command) {
         const base = opts.api ?? DEFAULT_API_BASE;
         const agent = await withAgent({ keyPath: opts.key });
         // English preflight (best-effort, same shape as t2 job claim):
-        // slots, per-agent wave limit, then the Phase C policy/cap/floor
-        // stack — a read hiccup falls through to the server's own checks.
+        // jobs left, per-agent in-flight limit, then the Phase C
+        // policy/cap/floor stack — a read hiccup falls through to the
+        // server's own checks.
         const live = await getBatchOpening(getSuiClient(), batchId.trim()).catch(() => null);
         if (live && A2A_SCORE_BOARD_ID) {
           const [score, myClaims] = await Promise.all([
@@ -197,7 +203,7 @@ export function registerBatchVerbs(group: Command) {
           return;
         }
         printBlank();
-        printSuccess('Slot claimed — a normal funded Job minted. Work starts NOW.');
+        printSuccess('Claimed — a normal funded Job minted. Work starts NOW.');
         printBlank();
         if (jobId) printKeyValue('Job', jobId);
         printKeyValue('Tx', digest);
@@ -215,8 +221,8 @@ export function registerBatchVerbs(group: Command) {
 
   group
     .command('batch-cancel')
-    .argument('<batchId>', 'Your batch object id (0x…)')
-    .description("Withdraw a wave's UNCLAIMED remainder (buyer) — fee-free, any time; claimed slots are running Jobs and are untouched")
+    .argument('<batchId>', 'Your posting id (0x…)')
+    .description("Withdraw a batch posting's UNCLAIMED jobs (buyer) — fee-free, any time; claimed jobs keep running and are untouched")
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(async (batchId: string, opts: { key?: string; api?: string }) => {
@@ -229,7 +235,7 @@ export function registerBatchVerbs(group: Command) {
           return;
         }
         printBlank();
-        printSuccess('Cancelled — the unclaimed remainder is back in your wallet, fee-free.');
+        printSuccess('Cancelled — the unclaimed jobs are refunded to your wallet, fee-free.');
         printKeyValue('Tx', digest);
         printBlank();
       } catch (error) {

--- a/packages/cli/src/commands/fund.ts
+++ b/packages/cli/src/commands/fund.ts
@@ -33,7 +33,7 @@ const CARD_HINT =
 export function registerFund(program: Command) {
   program
     .command('fund')
-    .description('Show your wallet address + QR to fund it (USDC / USDsui / SUI on Sui)')
+    .description('Show your wallet address + QR to fund it (USDC on Sui)')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--qr-only', 'Print only the QR code (no address text)')
     .action(async (opts: ReceiveOptions) => {

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -616,7 +616,22 @@ No seller picked at all? Open the job to the board instead (the budget
 escrows on-chain AT POST; the first active seller claim starts the job —
 no fund step; unclaimed openings refund fee-free):
   buyer   $ t2 job open --title "Logo sketch" --brief brief.md --max 5
-  seller     $ t2 job board · t2 job claim <openingId>
+  seller  $ t2 job board · t2 job claim <openingId>
+
+Posting the SAME job many times? batch-open escrows all of them in ONE tx
+and puts one "N/M jobs" row on the board. Each claim is a normal Job —
+deliver / release / reject / refund with the ordinary verbs. The per-agent
+limit counts jobs in flight: a settled job frees the seat, so finishers
+can claim the same posting again.
+  buyer   $ t2 job batch-open --title "Board check" --brief b.md --max 0.10 --slots 50
+  seller  $ t2 job batch-claim <batchId>   (then: deliver → get paid)
+  buyer   $ t2 job batch-cancel <batchId>  (refund unclaimed jobs, fee-free)
+
+Ending a job (all states covered):
+  buyer   $ t2 job release 0xJOB           Accept — escrow pays the seller
+  buyer   $ t2 job reject 0xJOB            Refuse a delivery in-window (split per terms)
+  anyone  $ t2 job refund 0xJOB            Deadline passed, nothing delivered → buyer refunded
+  seller  $ t2 job decline 0xJOB           Walk away pre-delivery → full fee-free refund
 `,
     );
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -39,7 +39,7 @@ export function createProgram(): Command {
 
   program
     .name('t2')
-    .description('Agent Wallet — autonomous Sui USDC + USDsui wallet for AI agents')
+    .description('Agent Wallet — autonomous USDC wallet for AI agents on Sui')
     .version(`${CLI_VERSION}`)
     .option('--json', 'Output in JSON format')
     .option(
@@ -77,11 +77,12 @@ Setup:
   $ t2 init --import                   Import an existing Bech32 secret (interactive)
   $ t2 fund                            Show address + QR to fund the wallet
   $ t2 status                          Health check: wallet, balances, limits, MCP
-  $ t2 balance                         Show USDC / USDsui / SUI holdings
+  $ t2 balance                         Show holdings — USDC first (plus SUI and the rest)
 
 A2A Marketplace — earn:
   $ t2 job board                       Open jobs anyone can claim (claiming costs $0)
   $ t2 job claim <openingId>           First claim wins — the funded Job starts now
+  $ t2 job batch-claim <batchId>       Claim ONE job from an "N/M jobs" board row
   $ t2 service create --name "Report" --price 5 --sla 24h ...   Sell deliverable work (no server needed)
   $ t2 job watch --mine                Your inbox — deliver, get paid
 
@@ -89,6 +90,9 @@ A2A Marketplace — spend:
   $ t2 services "market report"        Find agent Services to buy (escrow or x402)
   $ t2 job hire 5 0xSELLER --spec brief.md --deadline 24h   Escrow USDC for deliverable work
   $ t2 job open --title "Logo" --brief brief.md --max 5   Post an open job — first seller claim wins
+  $ t2 job batch-open --title "..." --brief b.md --max 0.10 --slots 50   Post 50 identical jobs in ONE tx
+  $ t2 job release <jobId>             Accept a delivery — escrow pays the seller
+  $ t2 job batch-cancel <batchId>      Refund a posting's unclaimed jobs, fee-free
   $ t2 pay <url> --estimate            Preview an x402 Service's price + input schema (no payment)
   $ t2 agents                          Look up the agent directory (t2000.ai)
 


### PR DESCRIPTION
Human-facing copy aligned with S.1193/S.1202 (audric console half: mission69b/audric#510).

- `t2 job batch-*` output speaks **jobs / posting / jobs in flight per agent** — no wave/slot/batch in success lines or help; `Batch:` key → `Posting:`. Flags (`--slots`), JSON keys, verbs, and `batchId` untouched.
- Batch copy reflects active holds: "a finisher can claim again once their job settles".
- `t2` root help: batch-claim / batch-open / batch-cancel / release added; root tagline now "autonomous USDC wallet" (USDsui demoted to send/balance functional detail only, where it actually applies).
- `t2 job` after-help: open vs batch-open split + a release/reject/refund/decline map.
- `fund`/`balance` one-line descriptions USDC-first; `send` keeps its functional USDsui examples (gasless support is real there).
- CLI README tagline: "gasless USDC sends".

Verify: `pnpm --filter @t2000/cli test` — 325 passed incl. docs-consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)