### PR TITLE
📝 docs(skills): t2000-connect advanced MCP verbs · product-first Grok copy

### DIFF
--- a/ops/distro/GROK-MARKETPLACE-PR.md
+++ b/ops/distro/GROK-MARKETPLACE-PR.md
@@ -31,7 +31,7 @@
 ```json
 {
   "name": "t2000",
-  "description": "Hire agents and earn USDC on the t2000 marketplace (Sui). Hosted Passport Connect MCP for hire, post Open jobs, claim work, and pay x402 APIs — plus Agent Wallet and Marketplace skills for terminal agents.",
+  "description": "Hire agents and earn USDC on t2000. Passport Connect MCP — post Open jobs, claim work, settle escrow, pay x402 APIs. Agent Wallet and Marketplace skills for terminal agents.",
   "category": "development",
   "source": {
     "source": "url",
@@ -52,7 +52,7 @@
 ```markdown
 ## What this PR does
 
-Adds the **t2000** plugin — agent marketplace on Sui (hire · work · earn in USDC).
+Adds the **t2000** plugin — hire agents, work, earn in USDC.
 
 - Plugin name: `t2000`
 - Type: remote source

--- a/t2000-skills/.grok-plugin/plugin.json
+++ b/t2000-skills/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "t2000",
   "version": "1.0.0",
-  "description": "Agent marketplace on Sui — hire, claim Open jobs, deliver, settle in USDC. Passport Connect MCP plus Agent Wallet and Agent Marketplace skills.",
+  "description": "Hire agents and earn USDC on t2000. Passport Connect MCP plus Agent Wallet and Agent Marketplace skills.",
   "author": { "name": "t2000", "url": "https://t2000.ai" },
   "homepage": "https://t2000.ai",
   "repository": "https://github.com/mission69b/t2000-skills",

--- a/t2000-skills/skills/t2000-connect/SKILL.md
+++ b/t2000-skills/skills/t2000-connect/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: MIT
 metadata:
   author: t2000
-  version: "5.0"
+  version: "5.1"
   requires: nothing local — a Google account becomes the Passport
 ---
 
@@ -86,6 +86,17 @@ Three families, discovered live from the connector:
 
 External `send` runs on Connect under those same session limits — like every
 spend, an amount at or above ask-above is refused until the limit is raised.
+
+### Advanced MCP verbs
+
+These tools exist in `tools/list` but sit outside the default earn/hire loop.
+Use them when the task calls for reposting, trust checks, or public job counts.
+
+| Tool | When | Notes |
+|------|------|-------|
+| `t2000_job_repost` | Buyer re-posts a **single** Open job that ended without delivery (seller declined, deadline refund, or your own never-claimed cancel) | **Spends** — locks a NEW escrow with the same terms pulled from the original posting. Pass `jobId` (preferred) or your `openingId`. **Not** for batch rows — repost waves with `t2000_job_batch_open`. Hires and settled work need a fresh `t2000_job_open` / `t2000_job_hire`. |
+| `t2000_reviews` | Read the full public review list + 1–5★ histogram for a seller | FREE read. Pass `seller` (agent ref) or omit for this Passport's own reviews. Buyer-side stars are on-chain; text is off-chain. **Write:** `t2000_job_review` after a job with an on-chain delivery settles (RELEASED or REJECTED). |
+| `t2000_jobs_lookup` | "How many jobs did agent X complete?" or audit any seller's public job history | FREE read. Pass `agent` (0x, #id, @handle). Returns `releasedCount` + job rows — counts **jobs**, not reviews (`t2000_reviews`) and not your inbox (`t2000_jobs`). Optional `state` filter; depth on any row: `t2000_job_status`. |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Adds **Advanced MCP verbs** subsection to `t2000-connect` (repost, reviews, jobs_lookup)
- Product-first Grok copy: drops leading "Sui" from plugin.json + marketplace runbook template

## Test plan

- [x] `npx tsx t2000-skills/validate.ts` — 10/10 green


Made with [Cursor](https://cursor.com)