### PR TITLE
📝 docs(ops): settle default role:buyer — ghost needsActionTotal fix

### DIFF
--- a/ops/open-jobs/PROMPT-GTM-DESK.md
+++ b/ops/open-jobs/PROMPT-GTM-DESK.md
@@ -99,7 +99,7 @@ Report in §D: `cancelled (openingIds / batchIds) | USDC returned estimate`.
 
 ## B — Inbox first (settle / reject)
 
-`t2000_jobs` with `needsOnly: true` and **no** `role` — buyer deliveries on openings **you** funded **plus** any seller clocks on this Passport. You **cannot** settle openings another Passport posted. **Do this 3×/day** even when you are not posting (`PROMPT-GTM-SETTLE.md` is the settle-only paste).
+`t2000_jobs` with **`needsOnly: true`** · **`role: "buyer"`** — buyer deliveries on openings **you** funded. Optional seller pass: `role: "seller"`. You **cannot** settle openings another Passport posted. **Do this 3×/day** even when you are not posting (`PROMPT-GTM-SETTLE.md` is the settle-only paste).
 
 **JobId only (S.1188 / S.1197):** settle/reject/deliver always take the **job** object id — never a batchId / openingId. If a batch claim returns `jobIdPending`, wait/resolve before deliver.
 
@@ -142,6 +142,8 @@ Referral titles still start with **`Refer a new agent`** (ledger regex unchanged
 Shared **`MAX_ESCROW_RUN`** applies across all C* posts in one paste — a posting's escrow is **`slots × maxUsdc`**, checked BEFORE posting.
 
 ### C1 — Activity waves (briefs inline — do not invent)
+
+**Top-up priority (dogfood 2026-08-26):** when **Wave C** (`Honest friction`) has the fewest `slotsRemaining` but the highest-signal deliveries, post Wave C deficit **before** A/B in the same paste.
 
 One `t2000_job_batch_open` per deficit band. Anyone · **`maxClaimsPerAgent: 3`** on **Wave A only** (anti-farm); **B/C use `1`** · `openHours: 168` · `slaHours: 48`.
 

--- a/ops/open-jobs/PROMPT-GTM-SETTLE.md
+++ b/ops/open-jobs/PROMPT-GTM-SETTLE.md
@@ -11,7 +11,7 @@ Do not ask what to do with the text. Pre-flight → **load queue** → **route e
 
 **Batch / jobId (S.1193 / S.1197):** every settle/reject/deliver/review takes a **job** object id. Never pass a batchId. Batch-claimed jobs are normal Jobs — settle them like any other Open. If claim returned `jobIdPending`, resolve before acting.
 
-**NEVER bare inbox:** Do **not** call `t2000_jobs` without `needsOnly: true` (and without narrowing `role`) on seats with history — Connect loads up to **500 job rows** and blows the context window (dogfood 2026-08-26: 500 of 634 on funkii@). Settle **always** uses `needsOnly: true`. Posting inventory uses `role: "buyer"` → `openings[]` only (`PROMPT-GTM-DESK.md` §A).
+**NEVER bare inbox:** On mature seats, do **not** call `t2000_jobs` without **`needsOnly: true` AND `role: "buyer"`** for settle work — a no-role call can return **`needsActionTotal > 0` with an empty `jobs[]`** (counter and rows diverge; dogfood 2026-08-26 follow-up). Posting inventory uses the same buyer scope → `openings[]` only (`PROMPT-GTM-DESK.md` §A). Seller deliverables: separate call with `role: "seller"` · `needsOnly: true` after the buyer queue is clear.
 
 ---
 
@@ -19,25 +19,25 @@ Do not ask what to do with the text. Pre-flight → **load queue** → **route e
 
 1. **Who am I** — Passport handle + address.  
 2. You only settle **buyer** rows on openings **this Passport funded**. Skip buyer jobs posted by other seats.  
-3. **`t2000_jobs { needsOnly: true }`** — no `role` — needs-action across buyer + seller on this Passport. **Mandatory** — not optional.
+3. **`t2000_jobs { needsOnly: true, role: "buyer" }`** — buyer needs-action on this Passport. **Mandatory** — not optional. (Do **not** omit `role` on settle passes.)
 
 ---
 
 ## Load the queue
 
-1. Call `t2000_jobs` · `needsOnly: true` · no `role`.  
+1. Call `t2000_jobs` · **`needsOnly: true`** · **`role: "buyer"`**.  
 2. Build a work list — process in order:
    1. **Buyer `funded` past deliver deadline** → § Refund (`t2000_job_refund`).
    2. **Buyer `delivered` Open jobs** → settle/reject (money waiting on you).
-   3. Seller rows on jobs you claimed.
-3. For each row, note: `jobId` / opening id, title, maxUsdc, state, seat (buyer = you?).
+3. For each row, note: `jobId` / opening id, title, maxUsdc, state.
 
-If empty → report "queue clear" and stop.
+If empty → report "buyer queue clear". Then optional: `t2000_jobs { needsOnly: true, role: "seller" }` for § Seller-side rows.
 
-**Queue completeness (S.1200d — revised 2026-08-26):**
+**Queue completeness (S.1200d — revised 2026-08-26 follow-up):**
 
-- **`needsActionTotal === 0`** → queue clear (reliable).
-- **`needsActionTotal > 0`** but `jobs[]` is empty or `matching`/`returned` are 0 → **not actionable from this response** — do not trust the card CTA ("…and N more need action") when the JSON lists no jobIds. Console spot-check this seat, or re-call with `role: "buyer"` · `needsOnly: true` and inspect funded rows manually. **Non-zero `needsActionTotal` alone is not queue-clear.**
+- On **`role: "buyer"`** · `needsOnly: true`: **`needsActionTotal === 0`** → buyer queue clear (reliable).
+- **Never** use a no-role call for queue-clear — same moment can show `needsActionTotal: 2` with `jobs: []` while `role: "buyer"` returns the real rows (counter and payload diverge).
+- If a host ever returns **`needsActionTotal > 0`** with empty `jobs[]` even **with** `role: "buyer"` → console spot-check; do not claim queue-clear.
 
 **Resume after tool limit:** if the run stops mid-queue, on the next pass **grade oldest review-window / SLA clock first** — a lapsed window auto-releases to the hunter regardless of quality.
 
@@ -209,9 +209,11 @@ Jobs from `PROMPT-WAVE-ACTIVITY.md`, `PROMPT-50-MICRO-ACTIVITY-JOBS.md`, `PROMPT
 
 ---
 
-## Seller-side rows (same queue)
+## Seller-side rows (after buyer queue clear)
 
-If `needsOnly` shows **seller** work (funded → deliver, review window, etc.) on openings **you claimed** (not ones you funded as buyer):
+Optional second call: `t2000_jobs { needsOnly: true, role: "seller" }`.
+
+If seller work shows up (funded → deliver, review window, etc.) on openings **you claimed** (not ones you funded as buyer):
 
 - **Deliver** with `t2000_job_deliver` when you're the seller and work is ready.  
 - Do **not** settle your own buyer-funded campaign openings you accidentally claimed.
@@ -225,7 +227,7 @@ If `needsOnly` shows **seller** work (funded → deliver, review window, etc.) o
 | activity / micro settled/rejected | job-loop settled/rejected | referral settled/rejected (by price) |
 | metrics settled/rejected (if any) | social settled/rejected (if any) |
 | reviews left (stars) | jobIds settled | jobIds rejected |
-| blockers | queue still needs-action? |
+| blockers | buyer queue clear? (`role: "buyer"` · `needsActionTotal === 0`) |
 ```
 
 On tool fail: continue other rows; list blockers. Do **not** invent jobIds.

--- a/ops/qa/GTM-SETTLE-QA-2026-08-26.md
+++ b/ops/qa/GTM-SETTLE-QA-2026-08-26.md
@@ -49,10 +49,25 @@ Sample: 5 deliveries, 2 sellers — directional only; defects above are solid.
 | # | Sev | Finding | Ops fix | Build deferred |
 |---|-----|---------|---------|----------------|
 | 5 | P0 follow-up | `0x741bab14…` Connect smoke $0.20 — ungraded (tool limit mid-run); oldest clock ~09:36 prior day | **Next run first** — grade before window lapses | — |
-| 6 | P1 | `needsActionTotal: 2` but `jobs[]` empty, matching/returned 0 — card CTA lies | **Fixed:** settle prompt — non-zero counter alone not actionable | audric inbox counter / card CTA |
+| 6 | P1 | `needsActionTotal: 2` but `jobs[]` empty on no-role call | **Fixed:** settle default `role: "buyer"`; queue-clear only on buyer-scoped call | audric: align counter + rows on no-role path |
 | 7 | P1 | Lapsed `funded` register bounties ($3.00 × 3) invisible until deadline; no refund routing in settle prompt | **Fixed:** § Refund before title routing | — |
 | 8 | P2 | Deferred tool-loading blocks `t2000_job_batch_claim` until `tool_search` (#238 hunter report; buyer hit same) | Note in desk pre-flight: load batch claim tool early | Connect / host tool-loading |
 | 9 | P2 | Console POST advertised 200×$0.01 wave; never on board (#334; aligns with cancelled waves ~05:02) | — | console batch post UX / indexer |
 | 10 | P2 | Board pulse farming (#210 triple-claim; #96 guard-poking friction) | **Fixed:** Wave A `maxClaimsPerAgent: 3` | — |
 
 **Verified good:** #202 reject→5★ feedback loop; job-loops #221/#159/#96 proof jobs released seller≠hunter; ~$4.28 net to hunters; escrow $67.47 reported.
+
+---
+
+## Third settle pass — 2026-08-26 (follow-up)
+
+**Seat:** funkii@audric (#16) · refunds 4 + delivered 14
+
+| # | Sev | Finding | Ops fix | Build deferred |
+|---|-----|---------|---------|----------------|
+| 5 | — | `0x741bab14…` | Already settled 4★ prior pass | — |
+| 6 | P1 | Ghost counter = **role-omitted bug** — `needsOnly` alone: `needsActionTotal: 2`, `jobs: []`; `role: "buyer"`: 18 rows same moment | **Fixed:** settle default `role: "buyer"` | audric MCP inbox assembly |
+| 11 | P2 | `t2000_job_board` ×6 "No approval received" with clean `t2000_balance` (#109) — host chrome on board, unlike services docs | — | audric: job_board chrome note + host guidance |
+| 12 | P2 | Identical titles across posting rounds = independent batchIds; board doesn't distinguish new round vs exhausted (#306) | Desk: Wave C top-up priority when low slots | console/board UX: round label or batch metadata |
+
+**Verified good:** #210 separate read after rejects → 5★; #221 1★ escalation on recycled Connect-smoke + in-flight-cap resell; ~$2.28 net; escrow $63.50; buyer `needsActionTotal: 0` verified.


### PR DESCRIPTION
Follow-up pass dogfood: no-role t2000_jobs returns needsActionTotal:2 with empty jobs[]; role:buyer returns real rows. Updates settle + desk + QA.

Made with [Cursor](https://cursor.com)