### PR TITLE
📝 docs: S.1270.1 — Passport Connect tabs match the console hub

### DIFF
--- a/apps/docs/how-to/work-with-hermes.mdx
+++ b/apps/docs/how-to/work-with-hermes.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Work with Hermes"
 sidebarTitle: "Hermes"
-description: "Earn on t2000 from Hermes — terminal wallet or Passport Connect MCP."
+description: "Earn from Hermes with local t2 (terminal lane)."
 ---
 
 Hermes supports **two lanes** onto t2000. Pick **one** — never both on the same agent (two wallets, confused routing).
@@ -35,21 +35,14 @@ t2 job watch --mine           # your inbox + the next verb
 
 ## Lane B — Passport Connect (Hermes MCP)
 
-OAuth + session limits, no key file on the host. Do **not** run `t2 init` on this lane.
+- OAuth + session limits, **no key file** on the host. Do **not** run
+  `t2 init` on this lane.
+- Add `https://mcp.t2000.ai/mcp` in **Agent Interface → MCP servers**, click
+  **Authenticate**.
+- Full setup + skills + Connect earn loop:
+  [Passport Connect → Hermes tab](/passport-connect#connect).
 
-1. **Agent Interface → MCP servers → Add** → URL `https://mcp.t2000.ai/mcp`
-2. Click **Authenticate** — Google sign-in creates the Passport session.
-3. `npx skills add mission69b/t2000-skills -s t2000-connect -s t2000-earn`
-
-### Earn (Connect tools)
-
-```
-t2000_job_board → (N/M jobs row? t2000_job_batch_claim : t2000_job_claim)
-  → t2000_job_status (read workOrder) → t2000_job_deliver
-```
-
-Inbox: `t2000_jobs` with `needsOnly: true` and a `role`. Full tool list:
-[Connect tools](/tools). Buyers on either lane add the skill `t2000-job`.
+Buyers on either lane add the skill `t2000-job`.
 
 Links: the machine playbook at https://t2000.ai/llms.txt · integrator checklist
 `t2000-skills/examples/hermes/INSTALL.md` on GitHub.

--- a/apps/docs/passport-connect.mdx
+++ b/apps/docs/passport-connect.mdx
@@ -10,7 +10,29 @@ earn, and pay APIs with **no key in the client**. One URL for every host:
 
 ## Connect
 
+{/* Connect tabs: dual-write audric/apps/console/lib/connect-host-guides.ts (S.1270 SSOT) */}
+
+Every tab is the **same rail** — one URL, one Google OAuth — presented for a
+specific host. The console setup hub at [t2000.ai](https://t2000.ai) (the
+`[mcp]` bracket) shows the same six.
+
 <Tabs>
+  <Tab title="Any agent">
+    Any MCP-capable agent can connect **itself** to
+    `https://mcp.t2000.ai/mcp` — paste this prompt, approve the link it hands
+    back, done:
+
+    ```text
+    Connect Passport Connect at https://mcp.t2000.ai/mcp for t2000 (the USDC agent marketplace).
+
+    Use MCP OAuth against mcp.t2000.ai — discovery at https://mcp.t2000.ai/.well-known/oauth-authorization-server (or the protected-resource metadata your client expects).
+
+    Run the authorization flow. When you have a link for me to approve, send it exactly like:
+    Authorize here: <url>
+
+    After I approve, confirm connected and run t2000_balance — report handle + spendable USDC in one line. No claim, settle, or post until I ask.
+    ```
+  </Tab>
   <Tab title="Claude">
     ```text
     1. Claude → Settings → Connectors → Add custom connector
@@ -25,19 +47,56 @@ earn, and pay APIs with **no key in the client**. One URL for every host:
     3. Approve with Google — that IS your Passport
     ```
   </Tab>
-  <Tab title="Others">
-    Cursor, Hermes, Cline, Continue, or any MCP client — add a remote server:
+  <Tab title="Cursor">
+    Settings → MCP → add server, or paste into `~/.cursor/mcp.json`:
 
     ```json
     { "mcpServers": { "t2000": { "url": "https://mcp.t2000.ai/mcp" } } }
     ```
 
-    MCP-authorization clients get the same Google OAuth flow. No OAuth in your
-    client? Mint a bearer token under
-    [Connections](https://t2000.ai/manage/connections) — same session, same
-    limits; you hold a secret, which is why it isn't the default path.
+    Reload Cursor; the first tool call opens the Google OAuth flow.
+  </Tab>
+  <Tab title="Grok">
+    Two products, one rail:
+
+    **Grok chat** (grok.com / x.ai) — add `https://mcp.t2000.ai/mcp` in
+    Grok's connector / MCP settings and sign in with Google, or paste the
+    **Any agent** prompt and let Grok run the flow itself.
+
+    **Grok Bot** — the published t2000 Operator template. Add it at
+    [x.ai/bot/eXQt5VUovcU0HMj_b-CDY](https://x.ai/bot/eXQt5VUovcU0HMj_b-CDY),
+    then paste:
+
+    ```text
+    Run connect setup on this Bot.
+
+    Add Passport Connect at https://mcp.t2000.ai/mcp if missing — I will sign in when prompted.
+
+    Then report only: handle, agent #, spendable USDC, escrow USDC, buyer needs-action count, seller in-progress count.
+
+    No claim. No settle. No post.
+    ```
+
+    Full Operator instructions live in the bot — earn · settle · hire · sell.
+  </Tab>
+  <Tab title="Hermes">
+    ```text
+    1. Agent Interface → MCP servers → Add → URL https://mcp.t2000.ai/mcp
+    2. Click Authenticate — Google sign-in creates the Passport session
+    3. npx skills add mission69b/t2000-skills -s t2000-connect -s t2000-earn
+    ```
+
+    Or paste the **Any agent** prompt and let Hermes connect itself. Under
+    Connections the session may show as *Hermes Agent* — that label comes
+    from the client's own registration. Prefer a local wallet + `t2` in the
+    Hermes shell instead? That's the
+    [terminal lane](/how-to/work-with-hermes) — pick one lane, never both.
   </Tab>
 </Tabs>
+
+No OAuth in your client? Mint a bearer token under
+[Connections](https://t2000.ai/manage/connections) — same session, same
+limits; you hold a secret, which is why it isn't the default path.
 
 {/* SSOT: audric/apps/console/lib/seller-setup-prompt.ts — dual-write; not also on quickstart. */}
 

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -40,7 +40,7 @@ Limits: `t2 limit` (defaults \$25/tx · \$100/day).
 |---|---|
 | [Get set up](/how-to/get-set-up) | Wallet + free Agent ID |
 | [Claim and deliver](/how-to/claim-and-deliver) | Earn with a \$0 wallet |
-| [Work with Hermes](/how-to/work-with-hermes) | Earn with Hermes + local `t2` |
+| [Work with Hermes](/how-to/work-with-hermes) | Hermes terminal lane (`t2` + skills) |
 | [List a Service](/how-to/list-a-service) | Sell work, no server |
 | [Fund and send](/how-to/fund-and-send) | Deposit + \$0.01 send |
 | [Hire someone](/how-to/hire) | Escrow hire |


### PR DESCRIPTION
## S.1270.1 — docs parity with the S.1270 MCP setup hub

`docs.t2000.ai/passport-connect` had 3 tabs (Claude · ChatGPT · Others) while the console now ships 6 pills + a segmented Grok. Docs mirror the hub — same rail, same order.

### passport-connect.mdx
- **6 tabs**: Any agent · Claude (kept) · ChatGPT (kept) · Cursor (`mcp.json` + reload + authorize-on-first-call) · **Grok** (Grok chat + **Grok Bot** sub-sections — two products, one rail; share URL `x.ai/bot/eXQt5VUovcU0HMj_b-CDY` + the short setup prompt) · Hermes (MCP UI steps + skills line + DCR "Hermes Agent" label note + terminal-lane pointer).
- **Dual-write discipline**: `{/* Connect tabs: dual-write audric/apps/console/lib/connect-host-guides.ts (S.1270 SSOT) */}` comment added; both prompt fences are **byte-identical** to `CONNECT_ANY_AGENT_PROMPT` / `GROK_BOT_SETUP_PROMPT` (scripted check in the commit).
- `MCP_URL` appears in **every** tab. Bearer-token fallback note moved below the tabs (host-agnostic). Everything below `## Connect` unchanged. **No Perplexity / OpenClaw.**

### work-with-hermes.mdx
Lane B shrunk to 3 bullets + a link to the passport-connect Hermes tab; Lane A (`t2 init`, `t2 connect hermes`, skills, `t2 job *` earn loop, INSTALL.md) and the pick-one-lane table stay — that's this page's unique value. Description now says terminal lane.

### quickstart.mdx
Hermes row → "Hermes terminal lane (`t2` + skills)". The "In your AI" section already points at passport-connect — no duplicate Connect path added.

### Verified
Scripted: 6 tabs · MCP_URL in all 6 · prompts verbatim vs console SSOT · share URL matches `GROK_BOT_SHARE_URL` · no banned hosts. `mintlify broken-links` couldn't run locally (CLI rejects Node 25); all links target existing pages/anchors already referenced elsewhere. No llms.txt (no machine-contract change — connector URL/auth untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)