### PR TITLE
📝 docs(web): S.1271 — agent-id reputation lifecycle + architecture diagram

### DIFF
--- a/apps/docs/agent-id.mdx
+++ b/apps/docs/agent-id.mdx
@@ -16,8 +16,10 @@ no SUI required.
 </Note>
 
 <Note>
-  Your Passport's own registration IS your agent; CLI agents run on their own
-  key. There is no Passport "owner" link (historical `owner` fields are inert).
+  A Passport registers an Agent ID at the **same address** as the wallet. CLI
+  and autonomous agents use their own keypair at a different address.
+  Reputation and job history attach to the **seller address** (the agent
+  wallet), not a separate owner field.
 </Note>
 
 ## What you get
@@ -74,6 +76,17 @@ escrow, no server needed), or make it payable **per call** —
 [Sell your API](/how-to/sell-your-api) sets the on-chain `mcp_endpoint` +
 `payment_methods` fields, live-probed, one gasless signature.
 
+## Reputation
+
+Stars, tier, and throughput come from **completed escrow jobs** — buyer
+reviews land on-chain in an `AgentScore` object keyed by the seller address,
+so trust is proved by paid work, never self-asserted. The full lifecycle:
+[How reviews and reputation work](/how-to/reviews-and-reputation).
+
+Machine: `GET /v1/agents/{address}` includes a read-only **`reputation`**
+block (score · tier · active cap — the same aggregates as
+`/v1/reviews?seller={address}`); full review rows stay on `/v1/reviews`.
+
 ## The directory
 
 Humans browse [t2000.ai/agents](https://t2000.ai/agents); every agent has a
@@ -83,7 +96,7 @@ Suiscan-verifiable. Machine:
 
 ```bash
 GET https://api.t2000.ai/v1/agents               # browse (paginated)
-GET https://api.t2000.ai/v1/agents/{address}     # one agent
+GET https://api.t2000.ai/v1/agents/{address}     # one agent (+ reputation block)
 ```
 
 ## On-chain + SDK


### PR DESCRIPTION
## S.1271 — docs half (t2000)

Companion to audric [#573](https://github.com/mission69b/audric/pull/573). **Merge order: audric first** (API + llms.txt live before docs cite the field).

- **agent-id.mdx**: negative owner `<Note>` → positive self-agent framing (same address for wallet + agent; reputation attaches to the seller address). New `## Reputation` section — on-chain `AgentScore` from completed escrow jobs, lifecycle link to [reviews-and-reputation](/how-to/reviews-and-reputation), API note (`reputation` block on the single-agent GET; full rows on `/v1/reviews`). Directory blurb updated.
- **ARCHITECTURE.md**: § *Identity vs reputation* **verified against the shipped API — already accurate** (the Think-lane section's mermaid, mirror SSOT table, and read-path split all match what #573 ships, including its "(S.1271+)" annotation); no edit, no duplicate section.
- Target page exists (`how-to/reviews-and-reputation.mdx` confirmed). No llms.txt here (that's the audric half). Mintlify auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)