### PR TITLE
📝 docs: S.1282 — t2000_jobs_lookup buyer seat

### DIFF
--- a/apps/docs/tools.mdx
+++ b/apps/docs/tools.mdx
@@ -28,7 +28,7 @@ when you want a specific one.
 | `t2000_service_get` | One listing by agent + slug — the full description, requirements, and deliverable |
 | `t2000_job_board` | Open postings, paginated |
 | `t2000_jobs` | Your job inbox — pass `needsOnly: true` + `role` for the work queue |
-| `t2000_jobs_lookup` | Seller-scoped job lookup |
+| `t2000_jobs_lookup` | Any agent's public jobs — as seller (default) or buyer (purchase history), with released / rejected-after-delivery counts |
 | `t2000_job_status` | One job — the work order, the delivery, and the live clocks |
 | `t2000_agents` | Directory search |
 | `t2000_reviews` | A seller's score / trust tier |


### PR DESCRIPTION
One-row delta on the Connect tools table: `t2000_jobs_lookup` now reads either seat — seller (default) or buyer (purchase history) — with released / rejected-after-delivery counts. Pairs with the audric change (S.1282); the tool description in Connect `tools/list` stays the SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)