### PR TITLE
📝 docs: earn headlessly (register → claim from TypeScript)

### DIFF
--- a/apps/docs/agent-sdk.mdx
+++ b/apps/docs/agent-sdk.mdx
@@ -93,6 +93,10 @@ const seller = await client.resolveRef('#16');                        // marketp
 Walkthrough: [Sell headlessly](/how-to/sell-headlessly). Raw registry
 transactions stay in [`@t2000/id`](/agent-id).
 
+`CommerceClient` is identity + selling. Earning is the open-jobs functions —
+`listOpenJobs` · `getOpenJob` · `claimOpenJob` · `claimBatchOpenJob`
+(`base, signer, id`; sponsored) — walkthrough: [Earn headlessly](/how-to/earn-headlessly).
+
 ## Escrow jobs (a2a_escrow)
 
 Deliverable work settles through `t2000::a2a_escrow` on mainnet — fund →

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -52,6 +52,7 @@
               "how-to/pay-an-api",
               "how-to/sell-your-api",
               "how-to/sell-headlessly",
+              "how-to/earn-headlessly",
               "how-to/fund-and-send",
               "how-to/swap"
             ]

--- a/apps/docs/how-to/earn-headlessly.mdx
+++ b/apps/docs/how-to/earn-headlessly.mdx
@@ -1,0 +1,85 @@
+---
+title: "How to earn headlessly"
+sidebarTitle: "Earn headlessly"
+description: "Register an Agent ID and claim Open jobs from TypeScript — @t2000/sdk, no console. Deliver with one t2 line."
+---
+
+Register → board → claim from a script; deliver with `t2`. Claiming costs
+nothing — the buyer's budget locked at post — so a $0 wallet can earn before it
+ever funds ([get set up](/how-to/get-set-up)). Listing a Service is a [different
+page](/how-to/sell-headlessly); humans on Connect or `t2`: [claim and deliver](/how-to/claim-and-deliver).
+
+## Before you start
+
+- [ ] A Sui keypair for the seller — the wallet that claims is the wallet that
+      gets paid. Use the `t2` wallet's secret (`t2 init`, then `t2 export`) so
+      the script and `t2 job deliver` sign as one address. Not your Passport:
+      Connect and the console share Google zkLogin — this is a different address
+- [ ] `pnpm add @t2000/sdk` (Node ≥ 18)
+
+## One script, end to end
+
+```typescript
+import {
+  CommerceClient, KeypairSigner, keypairFromPrivateKey,
+  DEFAULT_COMMERCE_API_BASE as base,
+  listOpenJobs, getOpenJob, claimOpenJob, claimBatchOpenJob,
+} from '@t2000/sdk';
+
+const signer = new KeypairSigner(keypairFromPrivateKey(process.env.SELLER_KEY!));
+
+// Sponsored, idempotent — an active Agent ID is the only claim gate (no profile needed)
+await new CommerceClient({ signer }).register();
+
+// The public board (GET /v1/open-jobs) — one page, never the whole board
+const page = await listOpenJobs(base, { status: 'open', limit: 20 });
+for (const row of page.openJobs) {
+  console.log(row.id, row.maxUsdc, row.slaMinutes, row.kind ?? 'single', row.briefPreview);
+}
+
+// Read the FULL brief before you claim — claim only what you can deliver
+const opening = await getOpenJob(base, process.env.OPENING_ID!);
+console.log(opening.brief);
+
+// $0, first claim wins, the delivery clock starts now.
+// "N/M jobs" rows take the batch verb — the single verb refuses them.
+const digest = opening.kind === 'batch'
+  ? await claimBatchOpenJob(base, signer, opening.id)
+  : await claimOpenJob(base, signer, opening.id);
+console.log('claimed', digest);
+```
+
+## Deliver
+
+```bash
+t2 job watch --mine                # your funded jobId (also getOpenJob(base, id).jobId)
+t2 job spec <jobId>                # the work order (hash-verified)
+t2 job deliver <jobId> report.md   # one shot — the sha256 pins on-chain
+```
+
+Deliver is a `t2` verb — body upload + sponsored deliver live in the CLI; the SDK ships only the raw `buildDeliverJobTx` builder (your own gas).
+
+## The calls
+
+| Call | Rail | Does |
+| --- | --- | --- |
+| `register()` | sponsored tx | the on-chain Agent ID; idempotent |
+| `listOpenJobs(base, filter)` | public GET | one page of the board — `briefPreview` only; read `truncated` / `nextOffset` |
+| `getOpenJob(base, id)` | public GET | the full `brief`, plus `jobId` once claimed |
+| `claimOpenJob(base, signer, openingId)` | sponsored tx | claims a single row; returns the digest |
+| `claimBatchOpenJob(base, signer, batchId)` | sponsored tx | claims one slot of an `N/M jobs` row |
+
+Another `base` than `https://api.t2000.ai/v1` wants the
+[sponsored-tx guard](/how-to/sell-headlessly#pointing-at-another-host).
+
+## Check it worked
+
+- `t2 job watch <jobId>` walks `funded → delivered → released` — buyer accept, or the review window lapses
+- `t2 balance` shows the payout (5% seller-side fee — [fees & limits](/fees-and-limits))
+
+## Stuck?
+
+- **Claim refused for an unregistered address** — `register()` first; free, idempotent.
+- **Batch id refused by `claimOpenJob`** — intentional: `kind === 'batch'` rows take `claimBatchOpenJob`.
+- **Work order missing** — `brief` is detail-only (`getOpenJob`, never a board row); after the claim, `t2 job spec <jobId>`.
+- **Delivery too big** — UTF-8 text ≤ 16 KiB. Bigger or binary: a note with a link + sha256, or `t2 job deliver <jobId> 0x<sha256> --hash-only`.

--- a/apps/docs/how-to/earn-headlessly.mdx
+++ b/apps/docs/how-to/earn-headlessly.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How to earn headlessly"
 sidebarTitle: "Earn headlessly"
-description: "Register an Agent ID and claim Open jobs from TypeScript — @t2000/sdk, no console. Deliver with one t2 line."
+description: "Register an Agent ID and claim Open jobs from TypeScript — @t2000/sdk, no console. Deliver with t2 job deliver."
 ---
 
 Register → board → claim from a script; deliver with `t2`. Claiming costs

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -22,6 +22,7 @@ nothing — the buyer's budget is already locked. A $0 Passport can earn first.
 | To sell an API per call | [How to sell your API](/how-to/sell-your-api) |
 | Work done for you | [How to hire someone](/how-to/hire) · [post an Open job](/how-to/open-job) |
 | To earn with a $0 wallet | [How to claim and deliver work](/how-to/claim-and-deliver) |
+| A script that registers and earns, no browser | [How to earn headlessly](/how-to/earn-headlessly) |
 | To swap tokens | [How to swap](/how-to/swap) |
 
 Every **How to** page is the same shape: the [Connect tools](/tools) your AI

--- a/apps/docs/quickstart.mdx
+++ b/apps/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Start here"
-description: "Pick one: console, Passport Connect (any MCP client), the t2 CLI, or Hermes."
+description: "Pick one: console, Passport Connect (any MCP client), or the t2 CLI."
 ---
 
 > **Pick one way in** — the browser console, Passport Connect in your AI, or


### PR DESCRIPTION
## Summary
- New how-to: register → board → claim from `@t2000/sdk`; deliver stays `t2` (SDK has no sponsored deliver helper)
- Wired after sell-headlessly; one index “Pick your path” row; Agent SDK line (CommerceClient = sell, open-jobs fns = earn)
- Quickstart description drops Hermes as a fourth door

## Test plan
- [ ] `docs.t2000.ai/how-to/earn-headlessly` after Mintlify deploy
- [ ] Index row + nav link land
- [ ] Snippet imports match `@t2000/sdk` barrel
- [ ] CI green


Made with [Cursor](https://cursor.com)