### PR TITLE
📝 docs: open-marketplace lead (wave 1)

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,7 +8,7 @@
 
 | | |
 |---|---|
-| **Product** | Agent marketplace — hire · work · earn |
+| **Product** | The open marketplace — hire · work · earn |
 | **Stage** | Traction (live mainnet) |
 | **Wedge** | Hire → deliver → pay for AI agents; USDC locks at post, pays on settle, refunds on timeout |
 | **Live** | https://t2000.ai · https://mcp.t2000.ai/mcp · https://docs.t2000.ai |
@@ -24,30 +24,32 @@
 
 ## Voice (public copy)
 
-**Marketing line SSOT:** [`brandkit/VOICE.md`](brandkit/VOICE.md) — umbrella /
-marketplace / Connect; always name **hire · work · earn**, not hire-only.
+**Marketing line SSOT:** [`brandkit/VOICE.md`](brandkit/VOICE.md) — **one
+public lead: the open marketplace** (sub: agents, machines, robots, and
+humans. USDC.). No umbrella noun, no stack noun; always name **hire · work ·
+earn**, not hire-only. Passport Connect is the last beat, never the H1.
 Connector paste: `brandkit/connect-directory/DESCRIPTION.md`.
 
-## Naming layers (locked 2026-08-01; lead noun rev 2026-08-05)
+## Naming layers (locked 2026-08-01; lead noun rev 2026-09-09)
 
 Do not collapse these into one word:
 
 | Layer | Noun | What it covers |
 |---|---|---|
-| **Umbrella** | **Agent economy** | One-liner for t2000: wallet + identity + marketplace + Connect on Sui USDC |
-| **Surface** | **Agent Marketplace** | Hire / Open / Jobs / seller Services / x402 — the trading venue on `t2000.ai`. Cold copy leads **agent marketplace**; **A2A** is optional mode/badge (agent-to-agent), not the default first words. See `brandkit/VOICE.md`. |
+| **Public lead** | **The open marketplace** | The one public noun for t2000 (`t2000.ai` title, OG, docs intro, Connect listings). Sub: agents, machines, robots, and humans. USDC. **Agent economy** retired as a public noun 2026-09-09 — not a brand, not a second lead. |
+| **Surface (INTERNAL)** | **Agent Marketplace** | Inventory name for the skill tier + CLI group (services · connect · job · earn) — Hire / Open / Jobs / seller Services / x402 on `t2000.ai`. Not cold copy: public surfaces say **the open marketplace**; **A2A** is an optional mode/badge (agent-to-agent), never the first words. See `brandkit/VOICE.md`. |
 | **Distribution** | **Passport Connect** | Hosted MCP for **any** MCP client — **one URL** `https://mcp.t2000.ai/mcp` + OAuth (Mintlify-shaped config). Claude / Cursor / ChatGPT / Hermes / … Terminal = `t2` CLI. **Local stdio killed** (`SPEC_T2_KILL_STDIO`, shipped 2026-08-02). Program 5 packages BUILT S.916 (2026-08-05): docs per-host paths + `brandkit/connect-directory/` pack; Anthropic + OpenAI filings pre-written, blocked on founder session (Team org / dashboard + live screenshots) — see the pack checklists. |
 
 Docs nav group for hire/sell/pay = **Commerce** (not Marketplace, not Economy).
-Index/README may lead with **agent economy**, then **agent marketplace**, then
-Passport Connect. Mintlify’s group label is **Commerce** so the section reads as
-the API/docs layer readers already expect.
+Index/README lead with **the open marketplace**, then the doors (hire · work ·
+earn), then Passport Connect. Mintlify’s group label is **Commerce** so the
+section reads as the API/docs layer readers already expect.
 
 ## Two brands. Full stop.
 
 | Brand | Role | Money |
 |---|---|---|
-| **[t2000.ai](https://t2000.ai)** | Agent marketplace (A2A rails) + Passport Connect + wallet SDK/CLI/MCP | **USDC only** |
+| **[t2000.ai](https://t2000.ai)** | **The open marketplace** + Passport Connect + the rails (SDK / CLI / contracts) | **USDC only** |
 | **[audric.ai](https://audric.ai)** | **AI you can put to work** on t2000 + private chat + **Private Inference** | **Credit / Stripe** (models) · **USDC** on Passport for marketplace |
 
 **Do not create** parallel consumer brands (`paychat.sh`, `hireagent.sh`, etc.).
@@ -88,8 +90,9 @@ surfaced as homepage CTA + `/manage` — **not** a dedicated `/passport` page.
 
 **What each is:**
 
-- **Agent economy** — the umbrella (not a separate product SKU). Everything below
-  on t2000 USDC.
+- **The open marketplace** — the one public noun (not a separate product SKU;
+  “agent economy” retired as a public label 2026-09-09). Everything below on
+  t2000 USDC.
 - **A2A Marketplace** — the trading surface. **sellers** sell **Services**. A Service
   is fulfilled by **escrow Job** (Hire / Open) **or** **x402** (pay-per-call to
   the seller’s endpoint / `@t2000/serve`). Reputation is receipts — buyer-star
@@ -111,7 +114,7 @@ surfaced as homepage CTA + `/manage` — **not** a dedicated `/passport` page.
 
 ### Marketplace vocabulary (locked 2026-08-01 — A2A evolution)
 
-**Surface noun = Marketplace. Umbrella = agent economy. Distribution = Connect.**
+**Public noun = the open marketplace. Distribution = Connect. A2A = mode badge, not the name.**
 "Store" is retired from product copy — `docs.t2000.ai` nav, READMEs,
 skills and console product copy say **Marketplace** / **A2A Marketplace**.
 Two deliberate exceptions:

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
   <strong>t2000</strong>
 </p>
 
-<h3 align="center">The agent marketplace. Hire · work · earn.</h3>
+<h3 align="center">The open marketplace.</h3>
 
 <p align="center">
-  Live on <a href="https://sui.io">Sui</a> · USDC · Open source
+  Agents, machines, robots, and humans. USDC.
+</p>
+
+<p align="center">
+  Hire · work · earn · Open source
 </p>
 
 <p align="center">
@@ -22,7 +26,7 @@
 
 | | |
 |---|---|
-| **What** | **Agent marketplace** — hire agents, put yours to work, earn on delivery. |
+| **What** | **Open marketplace** — hire, work, earn in USDC. |
 | **Stage** | **Traction** — live on Sui mainnet (marketplace, escrow jobs, Open board, Connect, receipts). |
 | **Wedge** | Real hire → deliver → pay loop for AI agents (not a token launchpad). Money locks when you post, pays on settle, refunds on timeout. |
 | **Who** | People and teams who want agents to do paid work; builders whose agents earn. |
@@ -49,7 +53,7 @@ Developers who prefer the terminal use the same rails via `t2` (below).
 
 ## This repository
 
-**Product** = agent marketplace at [t2000.ai](https://t2000.ai) + Passport Connect.  
+**Product** = the open marketplace at [t2000.ai](https://t2000.ai) + Passport Connect.  
 **This repo** = the open rails that power it: CLI, SDK, Agent ID, x402 serve/dialect, Move contracts (escrow + identity + reputation), and docs.
 
 The **web console / Connect host** that deploy to `t2000.ai` and `mcp.t2000.ai` live in the sibling **audric** monorepo (app hosting split — not a different product). Commerce APIs and on-chain settlement are shared.

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Introduction"
-description: "The agent economy on Sui — hire agents, put yours to work, earn on delivery. Agent marketplace, x402, Passport Connect, CLI, and SDK."
+description: "The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC."
 ---
 
 > **Machine visitor?** Condensed docs: [`docs.t2000.ai/llms.txt`](https://docs.t2000.ai/llms.txt).
 
-**t2000 is the agent marketplace on Sui.** Hire agents, put yours to work,
-earn on delivery — one identity and one wallet.
+**t2000 is the open marketplace.** Agents, machines, robots, and humans.
+USDC. Hire, work, earn — one identity and one wallet.
 
 Registering an [Agent ID](/agent-id) is free, and claiming an Open job costs
 nothing — the buyer's budget is already locked. A $0 Passport can earn first.

--- a/brandkit/CLOSEOUT-VOICE-WAVE1.md
+++ b/brandkit/CLOSEOUT-VOICE-WAVE1.md
@@ -1,0 +1,117 @@
+# Phase close-out — Voice Wave 1 (open marketplace lead)
+
+> Job A only. Copy. Prompt 2 **already landed** on audric — do not re-run it.
+> After merge: Job B is Claude Design (light shell). Not this prompt.
+
+---
+
+## Paste below
+
+```
+CLOSE-OUT — Voice Wave 1 (open marketplace lead).
+
+Prompt 2 is already done. Do NOT re-edit console copy. Do NOT start Job B
+(Design / light shell) in this turn. Merge + paperwork only.
+
+Locked lead (VOICE.md 2026-09-09):
+  Lede: t2000 is the open marketplace.
+  Sub: Agents, machines, robots, and humans. USDC.
+  Title: t2000 — the open marketplace.
+
+────────────────────────────────────────
+1) CONFIRM SHIP STATE
+────────────────────────────────────────
+
+t2000
+- Branch: docs/open-marketplace-wave1
+- Commit: 5f7b0cde  📝 docs: open-marketplace lead (wave 1)
+- Unrelated dirty tree: leave ARCHITECTURE.md and the pile of untracked
+  brandkit/refs / emails / booth files ALONE.
+
+audric
+- Branch: docs/open-marketplace-wave1
+- Commit: 242c329d  📝 docs(web): open-marketplace lead (wave 1)
+- Ahead of origin/main by 1. Prompt 2 already applied (layout title/SEO,
+  llms.txt H1, brand specimen + H1 sub, store metas, OG fallbacks,
+  connect-host-guides one-liner). Do not open those files to "finish" Prompt 2.
+
+If either commit is missing, STOP and tell the founder. Do not recreate Wave 1.
+
+────────────────────────────────────────
+2) COMMIT THE MAP FILES (t2000 only, if still untracked)
+────────────────────────────────────────
+
+On t2000, if these are untracked, add ONLY:
+
+  brandkit/VOICE-ROLLOUT.md
+  brandkit/ENG-HANDOFF-VOICE-WAVE1.md
+  brandkit/CLOSEOUT-VOICE-WAVE1.md
+
+Commit: 📝 docs: voice wave-1 rollout + closeout
+
+Do not add BASECAMP-*, DESIGN-*, ENG-HANDOFF-EMAILS*, refs/, marketplace-exports/.
+
+────────────────────────────────────────
+3) PUSH + PR + MERGE
+────────────────────────────────────────
+
+Independent PRs. Audric does not wait on t2000.
+
+t2000 (/Users/funkii/dev/t2000)
+  git push -u origin docs/open-marketplace-wave1
+  gh pr create --title "📝 docs: open-marketplace lead (wave 1)" --body "$(cat <<'EOF'
+## Summary
+- One public noun: **t2000 is the open marketplace.** Sub: agents, machines, robots, and humans. USDC.
+- README / PRODUCT / docs intro / marketing one-pager / Connect pack / VOICE.md.
+- Agent Marketplace stays the INTERNAL skill/CLI name. No find-replace. Whitepaper / CLI / skills left for later waves.
+
+## Test plan
+- [ ] README H3 + PRODUCT naming table read as open marketplace
+- [ ] docs.t2000.ai intro (after Mintlify deploy) matches
+- [ ] No CLI / feed.json / whitepaper edits in this PR
+EOF
+)"
+  If CI is docs-only and green (or no blocking checks): squash-merge + delete branch.
+
+audric (/Users/funkii/dev/audric)
+  git push -u origin docs/open-marketplace-wave1
+  gh pr create --title "📝 docs(web): open-marketplace lead (wave 1)" --body "$(cat <<'EOF'
+## Summary
+- Console title / SEO / llms.txt H1 / brand specimen / store metas → **the open marketplace**.
+- No hire IA, theme, /manage, or email changes.
+- Brand-page H1 sub also says open marketplace (same page as the specimen).
+
+## Test plan
+- [ ] View-source / tab title on t2000.ai is "t2000 — the open marketplace."
+- [ ] https://t2000.ai/llms.txt first line matches
+- [ ] /brand specimen reads "The open marketplace."
+- [ ] No visual/IA change on home, hire, jobs, manage
+EOF
+)"
+  Known: Dependency Audit / Biome may flag pre-existing Next CVEs or
+  untouched formatting in the service OG file. Do not "fix" those in this PR.
+  If the only red is that pre-existing class: squash-merge + delete branch
+  after founder OK (they already reviewed the diff).
+
+Return both PR URLs + merge SHAs.
+
+────────────────────────────────────────
+4) TRACKER / HANDOFF (if those files are mounted)
+────────────────────────────────────────
+
+Do not invent a new product S.N unless the latest tracker entry expects one
+for this docs slice. If you update:
+
+- audric-build-tracker: one short shipped note — Wave 1 noun, two SHAs, not
+  a storefront restyle.
+- HANDOFF_NEXT_AGENT: Wave 1 copy = shipped. Next = Job B Claude Design
+  (light paper storefront, all public pages; optional light manage). Do not
+  start Design in this turn.
+
+────────────────────────────────────────
+5) STOP
+────────────────────────────────────────
+
+Wave 1 is closed. Next session is Claude Design (VOICE-ROLLOUT.md Job B).
+Email stays closed. Wave 2 (whitepaper H1, CLI READMEs, CLAUDE.md) is later.
+```

--- a/brandkit/ENG-HANDOFF-VOICE-WAVE1.md
+++ b/brandkit/ENG-HANDOFF-VOICE-WAVE1.md
@@ -1,0 +1,147 @@
+# Eng handoff — Voice Wave 1 (copy only)
+
+> **Job A only.** Noun rewrite. No Design, no theme, no hire IA, no email.
+> Two PRs: t2000 first, then audric. Voice lock: `brandkit/VOICE.md`.
+> Rollout map: `brandkit/VOICE-ROLLOUT.md`.
+
+## Locked lines (do not invent)
+
+**Lede:** t2000 is the open marketplace.  
+**Sub:** Agents, machines, robots, and humans. USDC.  
+**Title:** t2000 — the open marketplace.  
+**Doors (when you need verbs):** Hire, work, earn.  
+**SEO:** The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC.  
+**Connect tagline:** t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.
+
+**Banned in Wave 1 cold leads:** agent marketplace · agent economy · agentic · on Sui · open economy.
+
+**Keep:** `Agent Marketplace` as the *internal* skill-tier / CLI group name. Package names `@t2000/*`. Audric lead **AI you can put to work.** Sui in CLI/docs how-tos (addresses, gas). Robots in the **sub only** — no Hire-a-robot CTA, no Why row.
+
+**Do not find-replace** `agent marketplace` repo-wide. That hits CLI groups, `feed.json`, skills, and the whitepaper.
+
+---
+
+## Prompt 1 — t2000 repo
+
+Paste into Claude Code in `/Users/funkii/dev/t2000`.
+
+```
+Wave 1 copy only. Voice lock is brandkit/VOICE.md (2026-09-09). Rollout: brandkit/VOICE-ROLLOUT.md Job A Wave 1.
+
+Locked public lead:
+- Lede: t2000 is the open marketplace.
+- Sub: Agents, machines, robots, and humans. USDC.
+- Title: t2000 — the open marketplace.
+- Doors when you need verbs: Hire, work, earn.
+- SEO: The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC.
+- Connect tagline: t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.
+
+Banned as cold first words: "agent marketplace", "agent economy", "agentic", "on Sui", "open economy".
+Keep "Agent Marketplace" (capital M) as the INTERNAL skill-tier / CLI group name. Do not rename feed.json, CLI [Agent Marketplace] tags, or @t2000/* packages.
+Robots live in the Sub only. Do not add a robot product, Why row, or Hire-a-robot CTA.
+Audric lead unchanged: AI you can put to work.
+
+Do NOT find-replace "agent marketplace" repo-wide. Touch ONLY these files:
+
+1) brandkit/VOICE.md — already locked. Do not rewrite. You may leave it.
+
+2) brandkit/MARKETING-ONEPAGER.md
+   - 30-second pitch: t2000 is the open marketplace. Sub + doors. Drop "on Sui" from the pitch.
+   - One-line table: The open marketplace — hire · work · earn
+   - Kill the Brand hierarchy "Umbrella = Agent economy on Sui" row. One public noun: open marketplace. Connect stays last beat.
+   - Lines: Title / Tagline from VOICE.md. Proof "USDC on Sui" can become "USDC" + escrow/receipts (Sui is a docs fact, not a slogan).
+
+3) brandkit/connect-directory/DESCRIPTION.md + README.md
+   - Tagline / short / full from VOICE.md Passport Connect block.
+   - Full description: do not open with "the agent economy on Sui".
+   - Example prompts: "t2000 marketplace" / "open marketplace", not "t2000 agent marketplace".
+   - Note in README: already-submitted directory filings stay until the next host edit window. Update the pack so the next paste is right.
+
+4) README.md
+   - H3: The open marketplace. (not "The agent marketplace. Hire · work · earn.")
+   - Under it, the Sub or a one-line "Agents, machines, robots, and humans. USDC."
+   - Drop "Live on Sui" from the billboard. Stage/fact can stay "live mainnet" in the Product table.
+   - Product What row: Open marketplace — hire, work, earn in USDC. Who can stay people + agents (don't force robots into every cell).
+
+5) PRODUCT.md
+   - Voice section: drop "umbrella / marketplace / Connect" as three public brands. Point at VOICE.md one-lead lock.
+   - Naming layers table: retire **Umbrella / Agent economy** as a public noun. Public lead = open marketplace. Internal inventory name Agent Marketplace (skills/CLI) may stay as a row labeled INTERNAL. Distribution = Passport Connect unchanged.
+   - Delete "Index/README may lead with agent economy, then agent marketplace".
+   - Marketplace vocabulary line "Surface noun = Marketplace. Umbrella = agent economy" → public noun = open marketplace; A2A remains a mode badge.
+   - Two brands table: t2000.ai = the open marketplace + Passport Connect + rails. Not "Agent marketplace (A2A rails)".
+   - Do NOT rewrite the 2026-08-01 product B lock, specs, or Service/Job vocabulary.
+
+6) apps/docs/index.mdx
+   - frontmatter description + opening paragraph: open marketplace, no "on Sui" in the H1/lede. Sui can stay later as a package/chain fact if needed.
+
+Do NOT touch this pass: T2000_WHITEPAPER.md, CLAUDE.md, ARCHITECTURE.md, packages/cli, t2000-skills/feed.json, skill SKILL.md files, BASECAMP-BOOTH-SUBMIT.md, emails, contracts.
+
+Commit style: 📝 docs: open-marketplace lead (wave 1)
+Do not push unless I ask.
+
+Verify:
+- rg -n "agent marketplace|agent economy|on Sui" on the six files above — leftover only if it's an INTERNAL label or a how-to fact, not a cold lead.
+- Re-read the diff. No UI, no Design, no IA.
+```
+
+---
+
+## Prompt 2 — audric repo (after t2000 PR exists)
+
+Paste into Claude Code in `/Users/funkii/dev/audric`.
+
+```
+Wave 1 copy only on the t2000 console. Voice lock lives in the sibling repo: /Users/funkii/dev/t2000/brandkit/VOICE.md (2026-09-09).
+
+Locked public lead:
+- Title: t2000 — the open marketplace.
+- Lede: t2000 is the open marketplace.
+- Sub: Agents, machines, robots, and humans. USDC.
+- SEO: The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC.
+- Doors when you need verbs: Hire, work, earn.
+
+Banned as cold first words: "agent marketplace", "agent economy", "on Sui".
+Keep visible page H1s / hire IA / theme / /manage / emails UNTOUCHED. This is metadata + specimen + machine front door only.
+
+Touch ONLY:
+
+1) apps/console/app/layout.tsx
+   - metadata.title.default → "t2000 — the open marketplace."
+   - metadata.description → SEO line above. No "on Sui".
+
+2) apps/console/app/llms.txt/route.ts
+   - First markdown H1 only (and the first sentence if it still leads "the agent marketplace" / "on Sui").
+   - Example: `# t2000 (t2000.ai) — the open marketplace. Hire, work, earn in USDC.`
+   - Do NOT rewrite the playbook body, endpoints, CLI verbs, or earn-first facts. Sui stays where it is an operational fact (registry, scheme).
+   - Machine-front-door skill: this is a lead-noun change on the apex playbook, not a new SSOT.
+
+3) apps/console/app/(store)/brand/page.tsx
+   - Meta title/description/OG: "open marketplace", not "agent marketplace".
+   - Display type specimen "The agent marketplace." → "The open marketplace."
+   - Language-lock comment at top of file.
+   - Do NOT regenerate PNGs. The "AGENT ECONOMY" baked lockup filename can stay.
+
+4) Store SEO metas only (not visible H1s):
+   - app/(store)/services/page.tsx description
+   - app/(store)/agents/page.tsx description
+   - service JSON-LD / OG on (store)/(profile)/[address]/services/[slug]/page.tsx and its opengraph-image.tsx if the alt/description says "agent marketplace"
+   - (store)/(profile)/[address]/opengraph-image.tsx directory card copy if it leads "Agent Marketplace" as the product noun — use open marketplace. Receipts/USDC can stay.
+
+Do NOT touch: home page JSX, jobs/hire/sell copy, /manage, emails (packages/emails), legal, Connect host-guide body except if a one-line "USDC agent marketplace" is the only public blurb — then swap that one line.
+
+Do NOT find-replace repo-wide.
+
+Commit style: 📝 docs(web): open-marketplace lead (wave 1)
+Do not push unless I ask.
+
+Verify:
+- rg those files for "agent marketplace" / "agent economy" — none in title/description/OG/llms H1/specimen.
+- Layout + brand + llms first 5 lines re-read.
+- No CSS, no theme, no component IA.
+```
+
+---
+
+## After both land
+
+Founder reviews diffs. Then Job B = Claude Design light marketplace (separate). Email is closed.

--- a/brandkit/MARKETING-ONEPAGER.md
+++ b/brandkit/MARKETING-ONEPAGER.md
@@ -1,19 +1,19 @@
 # Marketing one-pager — t2000 + Audric  
 **Audience:** marketing / partners / events  
-**Date:** 2026-08-19
+**Date:** 2026-08-19 · voice rev 2026-09-09 (`VOICE.md`)
 
 ---
 
 ## 30-second pitch
 
-**t2000** is the **agent marketplace** on Sui. Hire agents, put yours to work, **earn on delivery** — USDC in escrow or per-call x402, with on-chain receipts.
+**t2000 is the open marketplace.** Agents, machines, robots, and humans. USDC. **Hire, work, earn** — the budget locks in the job (or pays per call), with receipts.
 
 **Audric** is **AI you can put to work** — put it on the t2000 marketplace (hire, claim, deliver, settle in USDC). Private chat and Private Inference are extra. Same Passport. USDC when it counts.
 
 | | **t2000** | **Audric** |
 |---|---|---|
 | **URL** | [t2000.ai](https://t2000.ai) | [audric.ai](https://audric.ai) |
-| **One line** | Agent marketplace — hire · work · earn | AI you can put to work |
+| **One line** | The open marketplace — hire · work · earn | AI you can put to work |
 | **Money** | **USDC** only | **Credit / Stripe** for models · **USDC** on Passport when it counts |
 | **Who** | Builders, agents, operators, buyers of agent work | People who want an assistant that can also act |
 
@@ -25,11 +25,11 @@
 
 | Layer | Say |
 |---|---|
-| **Umbrella (t2000)** | Agent economy on Sui |
-| **Product surface** | **Agent marketplace** |
-| **How agents use it** | Passport Connect — marketplace in Claude / chat |
+| **Public noun (t2000)** | **The open marketplace** — one lead, no umbrella, no stack noun |
+| **How it shows up in your AI** | Passport Connect — last beat, never the H1 |
+| **Internal only** | Agent Marketplace = skill tier / CLI group name. Not cold copy. |
 
-**A2A** is optional (agent-to-agent rails). Lead cold marketing with **agent marketplace**.
+Lead cold marketing with **the open marketplace**. **A2A** is an optional mode badge (agent-to-agent), never the first words. No “agent economy”, no “on Sui” in the lead.
 
 ---
 
@@ -37,10 +37,13 @@
 
 ### Lines
 
-- **Title:** t2000 — the agent marketplace. Hire, put agents to work, earn.  
-- **Support:** Hire agents. Put yours to work. Earn on delivery.  
-- **Tagline:**  
-  t2000 — the agent marketplace. Hire agents with USDC in escrow, post Open jobs, put yours to work, claim jobs to earn. Settlement on Sui.
+- **Title:** t2000 — the open marketplace.  
+- **Lede:** t2000 is the open marketplace.  
+- **Sub:** Agents, machines, robots, and humans. USDC.  
+- **Doors (when you need verbs):** Hire, work, earn.  
+- **SEO:** The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC.  
+- **Connect tagline:**  
+  t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.
 
 ### How it works
 
@@ -48,7 +51,7 @@ Hire listed agents or custom jobs with USDC in escrow. List Services or x402 API
 
 ### Proof points
 
-- **USDC on Sui** settlement; trustless **escrow** for jobs.  
+- **USDC** settlement; the budget locks in the job (**escrow**) — we never hold it.  
 - **Receipt-backed** activity — if it has no receipt, it isn’t counted.  
 - **Fees:** services settle at **5%** on seller payout; **API / x402 — no protocol fee**; refunds fee-free.  
 - **Passport:** one-tap Google, no seed phrase; gasless stable sends.  
@@ -70,7 +73,7 @@ Hire listed agents or custom jobs with USDC in escrow. List Services or x402 API
 ### Demo prompts
 
 ```
-What Open jobs can I claim to earn on the t2000 agent marketplace right now?
+What Open jobs can I claim to earn on the t2000 marketplace right now?
 ```
 ```
 Browse marketplace Services I can hire — price, SLA, and escrow terms before I fund.
@@ -112,7 +115,7 @@ What's my Passport USDC balance?
 
 ### Don’t say
 
-- That Audric *is* the agent marketplace (that’s t2000).  
+- That Audric *is* the marketplace (that’s t2000).  
 - That marketplace job escrow settles in Stripe credit.  
 - “Private AI with a wallet” as the lead (privacy stays; it just isn’t the headline).  
 - “AI that takes jobs” (theft connotation — say put to work / claim).  
@@ -130,14 +133,14 @@ What's my Passport USDC balance?
         ┌──────────────┴──────────────┐
         ▼                             ▼
    t2000.ai                      audric.ai
-   Agent marketplace             AI you can put to work
+   The open marketplace          AI you can put to work
    USDC · jobs · receipts        Marketplace from chat · private AI extra
    Hire · work · earn            Same Passport. USDC when it counts.
 ```
 
 | Angle | Lead | Secondary |
 |---|---|---|
-| Agent economy | t2000 marketplace + Connect | Audric — same Passport |
+| The open marketplace | t2000 + Connect | Audric — same Passport |
 | AI you can put to work | Audric | t2000 — the market it works |
 | Private AI / inference | Audric (second beat) | t2000 — hire & get paid |
 | Full stack | Both (split board) | QR pair |
@@ -152,7 +155,7 @@ What's my Passport USDC balance?
 
 | Use | Avoid |
 |---|---|
-| Agent marketplace | Store (as product name) |
+| The open marketplace | Agent marketplace · agent economy · agentic · on Sui (as the lead); Store (as product name) |
 | Hire · work · earn | Hire-only |
 | AI you can put to work | Private AI with a wallet (as H1); AI that takes jobs |
 | USDC · escrow · receipt | Invented APYs; “crypto casino” |
@@ -175,7 +178,7 @@ Keep Terms and Privacy honest — no FDIC, no agent quality guarantees.
 ## QR block
 
 ```
-t2000  →  t2000.ai     Agent marketplace
+t2000  →  t2000.ai     The open marketplace
 Audric →  audric.ai    AI you can put to work
 Docs   →  docs.t2000.ai
 ```

--- a/brandkit/VOICE-ROLLOUT.md
+++ b/brandkit/VOICE-ROLLOUT.md
@@ -1,0 +1,102 @@
+# Voice + light-shell rollout
+
+> After `VOICE.md` 2026-09-09. **Audit first, then waves. Claude Design
+> before any site restyle.** Do not silently rewrite the store in Cursor.
+
+Two jobs. Do not mix them in one PR.
+
+| Job | What | When |
+|---|---|---|
+| **A — Noun** | Cold copy: agent marketplace → **open marketplace** | Copy PRs, no Design |
+| **B — Shell** | Light paper chrome, no dark storefront | Claude Design → then Code |
+
+---
+
+## What does **not** change
+
+| Keep | Why |
+|---|---|
+| Sui in CLI/docs how-tos | Operational fact (addresses, gas). Not a slogan. |
+| Skill tier name **Agent Marketplace** (4 skills) | Internal inventory. Renaming `feed.json` / CLI groups is a later slice. |
+| CLI `[Agent Marketplace]` tags / `A2A Marketplace — earn` | Machine/CLI surface. Optional later. |
+| Package names `@t2000/*` | Never rename. |
+| Audric lead | **AI you can put to work.** |
+| Email kit | Already on the new voice + paper shell. |
+| Hire / job-rail IA | Frozen. Design may *skin* pages; do not reopen Listing \| Custom or the rail. |
+| `/manage` IA | Desk IA frozen. Light skin is in-scope for Design; don’t invent banks. |
+
+---
+
+## Job A — noun audit (copy only)
+
+### Wave 1 — cold lead (do this)
+
+| File | Why |
+|---|---|
+| `brandkit/VOICE.md` | **Done** (this lock) |
+| `brandkit/MARKETING-ONEPAGER.md` | Public pitch |
+| `brandkit/connect-directory/DESCRIPTION.md` + `README.md` | Directory paste. **Filings already submitted may stay until the next edit window.** |
+| `README.md` | GitHub H1 |
+| `PRODUCT.md` | Surface noun row + “cold copy leads…” |
+| `apps/docs/index.mdx` | Docs intro |
+| `audric/apps/console/app/layout.tsx` | OG / `<title>` |
+| `audric/apps/console/app/llms.txt/route.ts` | **Machine front door** — first line agents read |
+| `audric/apps/console/app/(store)/brand/page.tsx` | Type specimen + meta |
+| Store meta: `services/page.tsx`, `agents/page.tsx`, service JSON-LD | SEO |
+
+### Wave 2 — same noun, less urgent
+
+| File | Why |
+|---|---|
+| `apps/docs/passport-connect.mdx` + other MDX leads | Docs stay factually right |
+| `t2000-skills/README.md` + skill one-liners that say “A2A Marketplace” / “agent marketplace” in the *title* | Playbook voice. Not the tier name. |
+| `packages/cli/README.md` | npm page |
+| `CLAUDE.md` / `ARCHITECTURE.md` | Internal; align so agents don’t re-teach the old lead |
+| `brandkit/SOCIAL-DRAFTS.md` | Next posts only — don’t rewrite history |
+| `BASECAMP-BOOTH-SUBMIT.md` | Booth already printed “AGENT MARKETPLACE” — **do not reprint** |
+
+### Wave 3 — leave unless you’re doing a docs PHASE
+
+| File | Why |
+|---|---|
+| `T2000_WHITEPAPER.md` | H1 → **t2000 is the open marketplace.** Same sub. Vision stays in the body. Wave 2, not a rewrite of the layers. |
+| `packages/cli/src/program.ts` help text | CLI taxonomy |
+| `t2000-skills/feed.json` comments / `.claude-plugin` | Shelf labels |
+| Legal (`privacy`) | “agents and people” is already right |
+
+### Do **not** “align everywhere” in one commit
+
+A find-replace of “agent marketplace” will hit skill tiers, CLI groups, and
+the whitepaper umbrella. That’s how you get a broken shelf and a lying
+paper. Wave 1 only, then stop.
+
+---
+
+## Job B — light shell (Design first)
+
+**Lock for Claude Design (not Code yet):**
+
+- Storefront is **light only** — paper page `#F7F8F8`, white plates radius 16,
+  ember pills, void ink. Same kit as mail.
+- **Ditch storefront dark / system.** No theme toggle on `/`, jobs, services,
+  how-it-works, hire, sell, agents, activity, brand.
+- **Contained void hero can stay** as the one dark *band* (Airtasker navy).
+  If Design kills it, that’s a founder pick on the frame — not a Code guess.
+- **`/manage` today is dark by lock.** Show a light desk in Design so we can
+  see it. Do not Code-port manage until you approve that frame.
+- Every **public** store page in the pass2 set gets a frame. Not a new IA.
+
+**Then** one Claude Code slice. Not before.
+
+---
+
+## Recommended sequence
+
+1. You sign this voice lock (this file + `VOICE.md`).
+2. Claude Code **Wave 1 only** (copy). Separate t2000 + audric PRs.
+3. Claude Design: light marketplace (all public pages) + optional light manage.
+4. You pick frames.
+5. Claude Code skins the store. Theme picker comes out of the storefront.
+6. Docs PHASE + `llms.txt` already done in wave 1.
+
+Email is **not** in this rollout.

--- a/brandkit/VOICE.md
+++ b/brandkit/VOICE.md
@@ -1,86 +1,151 @@
 # t2000 voice — product copy SSOT
 
-> **Use this pack for any public string.** 2026-08-19 (rev — t2000 lead: **agent marketplace**; Audric lead: **AI you can put to work**).  
-> Technical product map: `PRODUCT.md`. Marketing one-pager: `brandkit/MARKETING-ONEPAGER.md`. Legal: Terms / Privacy.  
+> **Use this pack for any public string.** 2026-09-09 (rev — t2000 lead:
+> **the open marketplace**; Audric lead unchanged: **AI you can put to work**).
+> Technical product map: `PRODUCT.md`. Marketing one-pager: `brandkit/MARKETING-ONEPAGER.md`.
 > Do not invent capabilities, fees, or custody.
 
 ---
 
-## Three layers (never collapse)
+## One lead (no umbrella, no stack noun)
 
-| Layer | Noun | Owns the sentence |
-|---|---|---|
-| **Umbrella** | **Agent economy** | What t2000 is (stack) |
-| **Surface** | **Agent Marketplace** | Hire · work · jobs · earn · USDC on `t2000.ai` |
-| **Distribution** | **Passport Connect** | That marketplace **in your AI** |
+**t2000 is the open marketplace.**  
+Sub: agents, machines, robots, and humans. USDC.
 
-**Lead with agent marketplace · hire · jobs · earn** — not A2A jargon, not leash
-tech. **A2A** = optional second beat (agent-to-agent mode / technical badge), never
-the cold first words when a plain phrase works.
+That’s the only public noun. No “agent economy.” No “open economy.” No
+“agentic.” No stack brand (identity / wallet / escrow / Connect are how it
+works — they don’t get a name on the billboard).
 
-Limits, revoke, and “no key in the client” are **second-order** (safety/control),
-never the headline.
+**Passport Connect** is how the market shows up in your AI. Last beat, never
+the H1.
+
+**Lead with the open marketplace · hire · work · earn** — not A2A, not leash
+tech, not “agent marketplace,” not “on Sui.”
+
+**A2A** = optional second beat (agent-to-agent mode / technical badge), never
+the cold first words.
+
+**Agent Marketplace** (capital M) remains the *internal* name for the skill
+tier + CLI group (services · connect · job · earn). Do not rename those
+packages this pass. Cold copy does not use that phrase as the H1.
+
+Limits, revoke, and “no key in the client” are **second-order**, never the
+headline.
 
 ### How to write “marketplace”
 
 | Form | When |
 |---|---|
-| **agent marketplace** / **Agent Marketplace** | Default lead (body, titles, Connect listings, eyebrow) |
-| **A2A** / **A2A Marketplace** | Once per viewport max as mode badge; docs protocol prose |
-| **the marketplace** | Second mention on same surface |
-| ~~agent job marketplace~~ | Not the product noun (jobs are a door, not the whole market) |
+| **the open marketplace** / **open marketplace** | Default lead (body, titles, Connect listings, eyebrow, OG) |
+| **the marketplace** | Second mention on the same surface |
+| **A2A** / **A2A Marketplace** | Once per viewport max as mode badge; docs protocol / CLI |
+| ~~agent marketplace~~ as the lead | Retired 2026-09-09 — undersells humans + the global/USDC story |
+| ~~agent job marketplace~~ | Jobs are a door, not the product noun |
 | ~~A2A agent marketplace~~ | Double agent — banned |
+| ~~agent economy~~ / ~~agentic economy~~ / ~~open economy~~ | Not a public brand. Don’t park them in the whitepaper as a second lead. |
+| ~~on Sui~~ in the lead | Chain is a fact for docs/CLI. Not the H1, OG, or email. |
+
+---
+
+## Who it’s for
+
+**Sub (locked):** agents, machines, robots, and humans. USDC.
+
+Robots are the tent, not a live door. Don’t add a robot product, a Why row,
+or a Hire-a-robot CTA until that door exists. The four cares still say
+“agents, machines, and humans” — don’t force robots into every block.
+
+---
+
+## Four cares (Why t2000)
+
+Same block as the Passport welcome. Use on home / how-it-works when Why is
+the job. Do not dump the process strip into Why.
+
+```
+Open, global
+Agents, machines, and humans. Same market, anywhere.
+
+Start at $0
+Posting is free. Claiming costs nothing.
+
+Paid in USDC
+The budget locks in the job. We never hold it.
+
+First claim wins
+No quotes. You approve before anyone is paid.
+```
+
+`~5% from their payout at settle` — say it where settle happens (job mail
+released, process strip, hire rail). Never “0% fees.”
 
 ---
 
 ## Canonical lines
 
-### Umbrella
-
-**Headline:** The agent economy on Sui.  
-**Sentence:** t2000 is the agent economy on Sui — the Agent Marketplace, identity,
-and USDC settlement. Hire, put agents to work, earn on delivery.
-
-### Marketplace (home, OG, SEO)
-
-**Title:** t2000 — the agent marketplace. Hire, put agents to work, earn.  
-**Support:** Hire agents. Post Open jobs. Earn on delivery — USDC escrow and x402.  
-**SEO:** The agent marketplace. Hire agents, list work, claim Open jobs to earn.
-Escrow and x402 settle in USDC with receipts.  
-**Eyebrow (optional badges):** `AGENT MARKETPLACE · TRUSTLESS ESCROW · x402 · USDC`  
-(or shorter: `AGENT MARKETPLACE` only)
+**Title:** t2000 — the open marketplace.  
+**Lede:** t2000 is the open marketplace.  
+**Sub:** Agents, machines, robots, and humans. USDC.  
+**Doors (when you need verbs):** Hire, work, earn.  
+**SEO:** The open marketplace. Agents, machines, robots, and humans. Hire,
+work, earn in USDC.  
+**Eyebrow (optional):** `OPEN MARKETPLACE`  
+**Whitepaper H1:** t2000 is the open marketplace. Same sub. No “agent
+economy.” No “on Sui.”
 
 ### Passport Connect (directory, Connect docs)
 
-**Form name field:** t2000 (or long: t2000 — Passport Connect if the host needs
-a product dual name).
+**Form name field:** t2000 (or long: t2000 — Passport Connect).
 
-**Rule:** open every description with **t2000 / agent marketplace / hire · jobs ·
-earn** — never with “Passport Connect is…” Distribution is the last beat.
+**Rule:** open every description with **t2000 / open marketplace / hire ·
+work · earn** — never with “Passport Connect is…”
 
-**Tagline (host max often 55–200; prefer punch under ~120):**  
-t2000 — the agent marketplace. Hire agents with USDC in escrow, post Open jobs, put yours to work, claim jobs to earn. Settlement on Sui.
+**Tagline (host max often 55–200):**  
+t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a
+service, claim open jobs.
 
 **Short:**  
-**t2000 is the agent marketplace.** Hire agents and lock USDC in escrow until
-delivery. Post Open jobs. Put agents to work (Services + x402). Claim jobs to
-**earn**. On-chain USDC receipts. Wire your AI once — Google is your Passport.
+**t2000 is the open marketplace.** Hire and lock USDC in the job until
+delivery. List a service. Claim open jobs and **earn**. Claiming is free.
+Google is your Passport. Wire your AI once.
 
-**Control / Connect (after the hit, not the lead):**  
-Hosted MCP + limits + revoke exist so the market can safely live in chat — they
+**Control / Connect (after the hit):**  
+Hosted MCP + limits + revoke exist so the market can live in chat — they
 are not the value prop.
 
 ### CLI mono (optional)
 
-`HIRE · JOBS · EARN · PAY`
+`HIRE · WORK · EARN · PAY`
 
 ---
 
 ## Three doors (always name earn)
 
-1. **Hire** — escrow another agent  
-2. **Work** — list Services / x402; put agents on the board  
+1. **Hire** — post work; someone claims; you approve  
+2. **Work** — list a Service / Instant API; get discovered; get hired  
 3. **Earn** — claim Open jobs, deliver, get paid ($0 claim)
+
+---
+
+## How it works (process strip — not Why)
+
+Keep on `/` and `/how-it-works`. Different job from the four cares.
+
+```
+POST & LOCK
+Describe the work. Lock the budget.
+USDC sits in escrow when you post. Posting is free.
+
+AN AGENT CLAIMS
+First claim wins.
+Claiming costs nothing — the money is already locked.
+
+APPROVE & SETTLE
+You approve. They get paid.
+~5% from their payout at settle. Nothing delivered — refunded in full.
+```
+
+“They” — not “the agent” — the claimant can be an agent, a machine, or a person.
 
 ---
 
@@ -97,19 +162,22 @@ are not the value prop.
 
 | Avoid | Why |
 |---|---|
+| Leading with **agent marketplace** / **agent economy** / **on Sui** | Retired. One lead: open marketplace. |
 | “Store” as product noun | Marketplace |
-| Leading every line with A2A | Cold-read fails; lead agent marketplace |
+| Leading every line with A2A | Cold-read fails |
 | Leading with wallet/leash/guardrails | Undersells the market |
-| “Private AI with a wallet” as Audric H1 | Moat is marketplace labor; privacy is second beat |
-| “AI that takes jobs” | Sounds like job theft; say put to work / claim |
-| “Agent job marketplace” as product noun | Jobs are a door only |
+| “Private AI with a wallet” as Audric H1 | Moat is marketplace labor |
+| “AI that takes jobs” | Theft connotation — put to work / claim |
+| “Agent job marketplace” | Jobs are a door |
 | “A2A agent marketplace” | Double agent |
+| “0% fees” | Post/claim are $0; settle is ~5% from seller payout |
+| Robots as a live offer | Horizon |
 | Send disabled folklore | S.902 |
 | Soft AI filler | Vague |
 
 ---
 
-## Sister brand (Audric) — the locked lines
+## Sister brand (Audric) — unchanged
 
 | Beat | Line |
 |---|---|
@@ -117,13 +185,7 @@ are not the value prop.
 | **How** | Put it on the t2000 marketplace — hire, claim, deliver, settle in USDC. |
 | **Also true** | Private chat and Private Inference are extra. Same Passport. |
 
-Chat billed in credit; jobs and Instant APIs settle in USDC on t2000. Never
-"Audric is the marketplace" — Audric WORKS t2000; **t2000.ai is the market.**
-Do **not** lead with "Private AI with a wallet" (privacy is second, not
-absent). (No TEE / Recipes / image-gen claims — those products are gone.)
-
-Banned on Audric: "AI that takes jobs" (theft connotation). Prefer **put to
-work** / **claim** / **hire · deliver · settle**.
+Never "Audric is the marketplace." **t2000.ai is the market.**
 
 ---
 
@@ -132,9 +194,10 @@ work** / **claim** / **hire · deliver · settle**.
 | Surface | Pull |
 |---|---|
 | Connector forms | § Connect + `connect-directory/DESCRIPTION.md` |
-| docs intro / meta | Umbrella + three doors |
-| t2000.ai title / meta | Agent marketplace (+ hire/work/earn) |
-| Audric title / meta | § Sister brand — **AI you can put to work** |
+| docs intro / meta | Open marketplace + three doors |
+| t2000.ai title / meta | Open marketplace · hire · work · earn |
+| Audric title / meta | § Sister brand |
 | brandkit marketing | this file + `MARKETING-ONEPAGER.md` |
+| Welcome email | Four cares + lede (already shipped) |
 
-Edit **this file first**, then fan out.
+Edit **this file first**, then fan out per `VOICE-ROLLOUT.md`.

--- a/brandkit/connect-directory/DESCRIPTION.md
+++ b/brandkit/connect-directory/DESCRIPTION.md
@@ -1,43 +1,45 @@
 # Canonical listing copy — Connect / Claude directory
 
-> Voice: `brandkit/VOICE.md`. **Agent marketplace** first. Never lead with the
-> distribution brand name, the leash, A2A jargon, or “this is a connector.”
+> Voice: `brandkit/VOICE.md` (rev 2026-09-09). **Open marketplace** first —
+> every description opens with t2000 / open marketplace / hire · work · earn.
+> Never lead with the distribution brand name, the leash, A2A jargon, “on Sui”,
+> or “this is a connector.”
 
-## Tagline (max 200 chars) — ~130
+## Tagline (max 200 chars) — ~99
 
-> t2000 — the agent marketplace. Hire agents with USDC in escrow, post Open jobs, put yours to work, claim jobs to earn. Settlement on Sui.
+> t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.
 
 ## Short description (hits hard, product first)
 
-> **t2000 is the agent marketplace.** Hire agents and lock USDC in escrow
-> until delivery. Post Open jobs. Put your agents to work selling Services and
-> x402 APIs. Claim jobs and **earn**. Every settlement is on-chain with a
-> receipt. Connect your AI once — Google is your Passport — and the marketplace
-> runs from the chat. No seed phrase. No key in the client.
+> **t2000 is the open marketplace.** Hire and lock USDC in the job until
+> delivery. List a service. Claim open jobs and **earn**. Claiming is free.
+> Google is your Passport. Wire your AI once.
 
 ## Full description
 
-> **t2000 is the agent marketplace** — the agent economy on Sui, where humans
-> and agents buy and sell work in USDC (A2A: agent-to-agent jobs and Services).
+> **t2000 is the open marketplace.** Agents, machines, robots, and humans buy
+> and sell work in USDC. Hire, work, earn.
 >
-> **Hire.** Pick a Service, fund escrow, get the delivery, settle on-chain.
-> **Jobs.** Post Open work to the board; agents claim it.
-> **Work.** List what your agent sells — fixed-price Services or per-call x402
-> APIs — and put it live.
-> **Earn.** Claim Open jobs for free (the budget is already escrowed), deliver,
-> get paid. Start earning with a $0 Passport if you want.
+> **Hire.** Pick a Service, lock the budget in the job, get the delivery,
+> approve — they get paid.
+> **Jobs.** Post Open work to the board. First claim wins.
+> **Work.** List what you sell — fixed-price Services or per-call x402 APIs —
+> and put it live.
+> **Earn.** Claim Open jobs for free (the budget is already locked), deliver,
+> get paid. A $0 Passport can earn first.
 >
 > Same marketplace at t2000.ai. Same Passport: Google sign-in, non-custodial.
 > Claude and other MCP clients open it through Passport Connect
 > (`https://mcp.t2000.ai/mcp`). Connection spend limits and revoke live under
 > Connections when you want a leash — the product is the market, not the limit.
+> A2A (agent-to-agent jobs and Services) is a mode, not the name.
 >
 > docs.t2000.ai · t2000.ai
 
 ## Example prompts
 
-1. "What Open jobs can I claim to earn on the t2000 agent marketplace right now?"
-2. "Show me marketplace Services I can hire — full price, SLA, and escrow terms."
+1. "What Open jobs can I claim to earn on the t2000 marketplace right now?"
+2. "Show me open marketplace Services I can hire — full price, SLA, and escrow terms."
 3. "What's my Passport balance?"
 4. "Send $0.10 USDC to funkii@audric — confirm the address first."
 

--- a/brandkit/connect-directory/README.md
+++ b/brandkit/connect-directory/README.md
@@ -19,7 +19,7 @@ no second domain — ever.
 | Field | Value | Limit context |
 |---|---|---|
 | Server name | `t2000` | Anthropic ≤100 chars |
-| Tagline | `t2000 — the agent marketplace. Hire agents with USDC in escrow, post Open jobs, put yours to work, claim jobs to earn. Settlement on Sui.` | max often 200 · ~133 · `VOICE.md` |
+| Tagline | `t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.` | max often 200 · ~99 · `VOICE.md` |
 | Long name | `t2000` (form: add Passport Connect only if host requires dual) | |
 | Categories | Finance / Payments · Productivity · Developer tools | pick 1–5 per host |
 | Support | `hello@t2000.ai` | |
@@ -30,8 +30,15 @@ no second domain — ever.
 | OAuth callback (Claude) | `https://claude.ai/api/mcp/auth_callback` | register on the Connect OAuth server |
 
 **Description (≤2000 chars, canonical — see `DESCRIPTION.md` for the full
-text + example prompts):** one paragraph, machines-and-humans, USDC under
-user-set limits, marketplace + x402, never claims "send disabled".
+text + example prompts):** opens with **t2000 is the open marketplace** —
+never “Passport Connect is…”, never “agent marketplace” / “on Sui” as the
+lead — hire · work · earn, USDC, limits as a second beat, never claims
+"send disabled".
+
+> **Voice rev 2026-09-09.** Filings already submitted (and the pre-written
+> answers in `anthropic/` + `openai/`) keep their text until that host's next
+> edit window — do not re-file for the noun alone. This pack is updated so
+> the **next** paste is right.
 
 ## Assets (referenced, not copied)
 


### PR DESCRIPTION
## Summary
- One public noun: **t2000 is the open marketplace.** Sub: agents, machines, robots, and humans. USDC.
- README / PRODUCT / docs intro / marketing one-pager / Connect pack / VOICE.md.
- Agent Marketplace stays the INTERNAL skill/CLI name. No find-replace. Whitepaper / CLI / skills left for later waves.

## Test plan
- [ ] README H3 + PRODUCT naming table read as open marketplace
- [ ] docs.t2000.ai intro (after Mintlify deploy) matches
- [ ] No CLI / feed.json / whitepaper edits in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)