### PR TITLE
📝 docs: voice rev 3 — one lede

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -24,10 +24,11 @@
 
 ## Voice (public copy)
 
-**Marketing line SSOT:** [`brandkit/VOICE.md`](brandkit/VOICE.md) — **one
-public lead: the open marketplace** (sub: agents, machines, robots, and
-humans. USDC.). No umbrella noun, no stack noun; always name **hire · work ·
-earn**, not hire-only. Passport Connect is the last beat, never the H1.
+**Marketing line SSOT:** [`brandkit/VOICE.md`](brandkit/VOICE.md) (rev 3,
+2026-09-09) — **one public noun: the open marketplace**, one cold lede:
+*A global market for agents, robots, and humans. Hire, work, earn in USDC.* No umbrella noun, no stack noun, no second who-line; "t2000 is the
+open marketplace" is title/eyebrow only, never a lede. Always name **hire ·
+work · earn**, not hire-only. Passport Connect is the last beat, never the H1.
 Connector paste: `brandkit/connect-directory/DESCRIPTION.md`.
 
 ## Naming layers (locked 2026-08-01; lead noun rev 2026-09-09)
@@ -36,7 +37,7 @@ Do not collapse these into one word:
 
 | Layer | Noun | What it covers |
 |---|---|---|
-| **Public lead** | **The open marketplace** | The one public noun for t2000 (`t2000.ai` title, OG, docs intro, Connect listings). Sub: agents, machines, robots, and humans. USDC. **Agent economy** retired as a public noun 2026-09-09 — not a brand, not a second lead. |
+| **Public lead** | **The open marketplace** | The one public noun for t2000 (`t2000.ai` title, OG, docs intro, Connect listings). Lede: *A global market for agents, robots, and humans. Hire, work, earn in USDC.* **Agent economy** retired as a public noun 2026-09-09 — not a brand, not a second lead. |
 | **Surface (INTERNAL)** | **Agent Marketplace** | Inventory name for the skill tier + CLI group (services · connect · job · earn) — Hire / Open / Jobs / seller Services / x402 on `t2000.ai`. Not cold copy: public surfaces say **the open marketplace**; **A2A** is an optional mode/badge (agent-to-agent), never the first words. See `brandkit/VOICE.md`. |
 | **Distribution** | **Passport Connect** | Hosted MCP for **any** MCP client — **one URL** `https://mcp.t2000.ai/mcp` + OAuth (Mintlify-shaped config). Claude / Cursor / ChatGPT / Hermes / … Terminal = `t2` CLI. **Local stdio killed** (`SPEC_T2_KILL_STDIO`, shipped 2026-08-02). Program 5 packages BUILT S.916 (2026-08-05): docs per-host paths + `brandkit/connect-directory/` pack; Anthropic + OpenAI filings pre-written, blocked on founder session (Team org / dashboard + live screenshots) — see the pack checklists. |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">The open marketplace.</h3>
 
 <p align="center">
-  Agents, machines, robots, and humans. USDC.
+  A global market for agents, robots, and humans. Hire, work, earn in USDC.
 </p>
 
 <p align="center">

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -1,12 +1,11 @@
 ---
 title: "Introduction"
-description: "The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC."
+description: "A global market for agents, robots, and humans. Hire, work, earn in USDC."
 ---
 
 > **Machine visitor?** Condensed docs: [`docs.t2000.ai/llms.txt`](https://docs.t2000.ai/llms.txt).
 
-**t2000 is the open marketplace.** Agents, machines, robots, and humans.
-USDC. Hire, work, earn — one identity and one wallet.
+**The open marketplace.** A global market for agents, robots, and humans. Hire, work, earn in USDC. One identity and one wallet.
 
 Registering an [Agent ID](/agent-id) is free, and claiming an Open job costs
 nothing — the buyer's budget is already locked. A $0 Passport can earn first.

--- a/brandkit/MARKETING-ONEPAGER.md
+++ b/brandkit/MARKETING-ONEPAGER.md
@@ -6,7 +6,7 @@
 
 ## 30-second pitch
 
-**t2000 is the open marketplace.** Agents, machines, robots, and humans. USDC. **Hire, work, earn** — the budget locks in the job (or pays per call), with receipts.
+**t2000 — the open marketplace.** A global market for agents, robots, and humans. Hire, work, earn in USDC. The budget locks in the job (or pays per call), with receipts.
 
 **Audric** is **AI you can put to work** — put it on the t2000 marketplace (hire, claim, deliver, settle in USDC). Private chat and Private Inference are extra. Same Passport. USDC when it counts.
 
@@ -37,11 +37,10 @@ Lead cold marketing with **the open marketplace**. **A2A** is an optional mode b
 
 ### Lines
 
-- **Title:** t2000 — the open marketplace.  
-- **Lede:** t2000 is the open marketplace.  
-- **Sub:** Agents, machines, robots, and humans. USDC.  
+- **Title / SEO title:** t2000 — the open marketplace.  
+- **Lede (SEO description · OG support · docs · Connect short · email · README sub):** A global market for agents, robots, and humans. Hire, work, earn in USDC.  
+- **Eyebrow:** `OPEN MARKETPLACE` · **Home H1:** GET WORK DONE  
 - **Doors (when you need verbs):** Hire, work, earn.  
-- **SEO:** The open marketplace. Agents, machines, robots, and humans. Hire, work, earn in USDC.  
 - **Connect tagline:**  
   t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a service, claim open jobs.
 

--- a/brandkit/VOICE.md
+++ b/brandkit/VOICE.md
@@ -1,16 +1,34 @@
 # t2000 voice — product copy SSOT
 
-> **Use this pack for any public string.** 2026-09-09 (rev — t2000 lead:
-> **the open marketplace**; Audric lead unchanged: **AI you can put to work**).
-> Technical product map: `PRODUCT.md`. Marketing one-pager: `brandkit/MARKETING-ONEPAGER.md`.
-> Do not invent capabilities, fees, or custody.
+> **Use this pack for any public string.** 2026-09-09 (rev 3 — one path).
+> Noun = **open marketplace**. Fold = **GET WORK DONE**. Support = the
+> sentence below. Audric unchanged: **AI you can put to work**. Store
+> stays **dark**. Technical product map: `PRODUCT.md`. Marketing one-pager:
+> `brandkit/MARKETING-ONEPAGER.md`. Do not invent capabilities, fees, or
+> custody.
 
 ---
 
-## One lead (no umbrella, no stack noun)
+## Noun vs fold
 
-**t2000 is the open marketplace.**  
-Sub: agents, machines, robots, and humans. USDC.
+**Public noun:** the open marketplace.  
+Eyebrow: `OPEN MARKETPLACE`. Not “agent marketplace.” Not a sentence.
+
+**Fold (home hero):** GET WORK DONE. The wordmark already says t2000 —
+do not use “t2000 is the open marketplace” as the H1.
+
+```
+OPEN MARKETPLACE
+GET WORK DONE
+A global market for agents, robots, and humans. Hire, work, earn in USDC.
+
+Post work · Earn with your AI
+Escrow first · Claim is free · ~5% at settle
+```
+
+That support sentence is the **only** cold lede under the noun. Do not
+run a second who-line. Do not say “open” again in the support (eyebrow
+already has it). Do not use “t2000 is the open marketplace” as a lede.
 
 That’s the only public noun. No “agent economy.” No “open economy.” No
 “agentic.” No stack brand (identity / wallet / escrow / Connect are how it
@@ -19,8 +37,9 @@ works — they don’t get a name on the billboard).
 **Passport Connect** is how the market shows up in your AI. Last beat, never
 the H1.
 
-**Lead with the open marketplace · hire · work · earn** — not A2A, not leash
-tech, not “agent marketplace,” not “on Sui.”
+**Lead with GET WORK DONE · open marketplace · hire · work · earn** — not
+A2A, not leash tech, not “agent marketplace,” not “on Sui,” not
+“t2000 is the open marketplace” as the headline.
 
 **A2A** = optional second beat (agent-to-agent mode / technical badge), never
 the cold first words.
@@ -36,7 +55,7 @@ headline.
 
 | Form | When |
 |---|---|
-| **the open marketplace** / **open marketplace** | Default lead (body, titles, Connect listings, eyebrow, OG) |
+| **the open marketplace** / **open marketplace** | Noun: eyebrow, body, titles, Connect, OG. Not the home H1. |
 | **the marketplace** | Second mention on the same surface |
 | **A2A** / **A2A Marketplace** | Once per viewport max as mode badge; docs protocol / CLI |
 | ~~agent marketplace~~ as the lead | Retired 2026-09-09 — undersells humans + the global/USDC story |
@@ -49,7 +68,7 @@ headline.
 
 ## Who it’s for
 
-**Sub (locked):** agents, machines, robots, and humans. USDC.
+**Fold / lede:** A global market for agents, robots, and humans. Hire, work, earn in USDC.
 
 Robots are the tent, not a live door. Don’t add a robot product, a Why row,
 or a Hire-a-robot CTA until that door exists. The four cares still say
@@ -83,14 +102,19 @@ released, process strip, hire rail). Never “0% fees.”
 
 ## Canonical lines
 
-**Title:** t2000 — the open marketplace.  
-**Lede:** t2000 is the open marketplace.  
-**Sub:** Agents, machines, robots, and humans. USDC.  
-**Doors (when you need verbs):** Hire, work, earn.  
-**SEO:** The open marketplace. Agents, machines, robots, and humans. Hire,
-work, earn in USDC.  
-**Eyebrow (optional):** `OPEN MARKETPLACE`  
-**Whitepaper H1:** t2000 is the open marketplace. Same sub. No “agent
+**Title / SEO title:** t2000 — the open marketplace.  
+**SEO / meta description / OG support / docs lede / Connect short / email lede / README sub:**  
+A global market for agents, robots, and humans. Hire, work, earn in USDC.  
+**Home H1:** GET WORK DONE  
+**Home CTAs:** Post work · Earn with your AI  
+**Home proof:** Escrow first · Claim is free · ~5% at settle  
+**Doors:** Hire, work, earn.  
+**Eyebrow:** `OPEN MARKETPLACE`  
+**~~t2000 is the open marketplace.~~** Retired as a lede. Title/eyebrow
+only.  
+**~~Post work. You approve before anyone is paid.~~** Why row / process
+only — not the fold.  
+**Whitepaper H1:** The open marketplace. Vision in the body. No “agent
 economy.” No “on Sui.”
 
 ### Passport Connect (directory, Connect docs)
@@ -105,9 +129,9 @@ t2000 — the open marketplace. Hire, work, earn in USDC. Post work, list a
 service, claim open jobs.
 
 **Short:**  
-**t2000 is the open marketplace.** Hire and lock USDC in the job until
-delivery. List a service. Claim open jobs and **earn**. Claiming is free.
-Google is your Passport. Wire your AI once.
+t2000 — the open marketplace. A global market for agents, robots, and
+humans. Hire, work, earn in USDC. Google is your Passport. Wire your AI
+once.
 
 **Control / Connect (after the hit):**  
 Hosted MCP + limits + revoke exist so the market can live in chat — they
@@ -162,7 +186,8 @@ You approve. They get paid.
 
 | Avoid | Why |
 |---|---|
-| Leading with **agent marketplace** / **agent economy** / **on Sui** | Retired. One lead: open marketplace. |
+| Leading with **agent marketplace** / **agent economy** / **on Sui** | Retired. Noun = open marketplace. Fold = GET WORK DONE. |
+| **t2000 is the open marketplace** as the H1 | The mark already says t2000. Use GET WORK DONE. |
 | “Store” as product noun | Marketplace |
 | Leading every line with A2A | Cold-read fails |
 | Leading with wallet/leash/guardrails | Undersells the market |
@@ -194,8 +219,9 @@ Never "Audric is the marketplace." **t2000.ai is the market.**
 | Surface | Pull |
 |---|---|
 | Connector forms | § Connect + `connect-directory/DESCRIPTION.md` |
+| Home fold | GET WORK DONE + this file’s hero stack |
 | docs intro / meta | Open marketplace + three doors |
-| t2000.ai title / meta | Open marketplace · hire · work · earn |
+| t2000.ai title / meta | t2000 — the open marketplace (SEO). Fold is GET WORK DONE. |
 | Audric title / meta | § Sister brand |
 | brandkit marketing | this file + `MARKETING-ONEPAGER.md` |
 | Welcome email | Four cares + lede (already shipped) |

--- a/brandkit/connect-directory/DESCRIPTION.md
+++ b/brandkit/connect-directory/DESCRIPTION.md
@@ -1,6 +1,6 @@
 # Canonical listing copy — Connect / Claude directory
 
-> Voice: `brandkit/VOICE.md` (rev 2026-09-09). **Open marketplace** first —
+> Voice: `brandkit/VOICE.md` (rev 3, 2026-09-09). **Open marketplace** first —
 > every description opens with t2000 / open marketplace / hire · work · earn.
 > Never lead with the distribution brand name, the leash, A2A jargon, “on Sui”,
 > or “this is a connector.”
@@ -11,14 +11,12 @@
 
 ## Short description (hits hard, product first)
 
-> **t2000 is the open marketplace.** Hire and lock USDC in the job until
-> delivery. List a service. Claim open jobs and **earn**. Claiming is free.
-> Google is your Passport. Wire your AI once.
+> **t2000 — the open marketplace.** A global market for agents, robots, and humans. Hire, work, earn in USDC. Google is your Passport. Wire
+> your AI once.
 
 ## Full description
 
-> **t2000 is the open marketplace.** Agents, machines, robots, and humans buy
-> and sell work in USDC. Hire, work, earn.
+> **t2000 — the open marketplace.** A global market for agents, robots, and humans. Hire, work, earn in USDC.
 >
 > **Hire.** Pick a Service, lock the budget in the job, get the delivery,
 > approve — they get paid.

--- a/brandkit/connect-directory/README.md
+++ b/brandkit/connect-directory/README.md
@@ -30,7 +30,7 @@ no second domain — ever.
 | OAuth callback (Claude) | `https://claude.ai/api/mcp/auth_callback` | register on the Connect OAuth server |
 
 **Description (≤2000 chars, canonical — see `DESCRIPTION.md` for the full
-text + example prompts):** opens with **t2000 is the open marketplace** —
+text + example prompts):** opens with **t2000 — the open marketplace** then the one lede —
 never “Passport Connect is…”, never “agent marketplace” / “on Sui” as the
 lead — hire · work · earn, USDC, limits as a second beat, never claims
 "send disabled".


### PR DESCRIPTION
## Summary
- One lede everywhere: **A global market for agents, robots, and humans. Hire, work, earn in USDC.**
- Title / eyebrow stay **the open marketplace**. "t2000 is the open marketplace" retired as a lede; the two-line sub is gone.
- README sub · PRODUCT voice + public-lead cells · marketing one-pager · Connect pack short/full · docs intro. Includes VOICE.md rev 3.
- Copy only — no CLI, skills, whitepaper, or design files.

## Test plan
- [ ] README sub + docs.t2000.ai intro read the lede
- [ ] No "t2000 is the open marketplace" as a lede in the six files
- [ ] Connect pack opens noun → lede

🤖 Generated with [Claude Code](https://claude.com/claude-code)