### PR TITLE
📝 docs: purge Passport card top-up — receive-only funding (S.1297)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,8 +208,8 @@ The machine customer's account: a local keypair, USDC rails, guardrails.
 - **Gas:** USDC/USDsui sends, x402 pays, and Agent ID ops are **gasless**
   (foundation sponsor + SIP-58 address balances). Cetus swaps and SUI sends
   self-fund (~0.05 SUI on hand).
-- **Funding:** send USDC on Sui to the wallet (`t2 fund` prints address + QR),
-  or card → USDC via the Stripe onramp at `t2000.ai/manage/topup`.
+- **Funding:** send USDC on Sui to the wallet (`t2 fund` prints address + QR).
+  Receive-only — the card onramp (`/manage/topup`) was deleted 2026-09-10.
 - **Chain access:** gRPC only (`SuiGrpcClient`; JSON-RPC is retired and banned
   in new code). History reads the GraphQL `transactions` schema. Token
   metadata comes from the SDK's `token-registry.ts` — never hardcode decimals.

--- a/apps/docs/console.mdx
+++ b/apps/docs/console.mdx
@@ -30,9 +30,8 @@ is created or loaded. Same Passport as [Audric](https://audric.ai).
 - **Set spend limits** — per-job / daily / ask-above caps for
   [Passport Connect](/passport-connect) sessions live at
   [/manage/connections](https://t2000.ai/manage/connections), with revoke.
-- **Fund with a card** — buy USDC at
-  [/manage/topup](https://t2000.ai/manage/topup) (Stripe; funds land in your
-  own Passport), or deposit on-chain.
+- **Fund it** — send USDC on Sui to your Passport address (Wallet shows
+  the address + QR). No card door.
 - **Watch it happen** — [Activity](https://t2000.ai/activity) shows jobs,
   listings, and paid calls.
 

--- a/packages/cli/src/commands/fund.ts
+++ b/packages/cli/src/commands/fund.ts
@@ -25,10 +25,10 @@ export interface ReceiveOptions {
 // `receive` stays as a hidden back-compat alias so existing scripts/docs keep
 // working. The value-promise (what a top-up buys) is folded into the output.
 const VALUE_PROMISE = '$5 USDC ≈ ~250 paid API calls (at the $0.02 floor).';
-// Card path (SPEC_ONRAMP): the console tops up the human's Passport with a
-// card; funding an agent from there is one gasless send (My agents → Fund).
-const CARD_HINT =
-  'No USDC yet? Buy some with a card: https://t2000.ai/manage/topup (then My agents → Fund, or send to the address above).';
+// Funding SSOT (S.1297): send USDC on Sui to the address. The console card
+// onramp (/manage/topup) was deleted 2026-09-10 — receive-only.
+const FUND_HINT =
+  'No USDC yet? Send USDC on Sui to the address above from any wallet or exchange.';
 
 export function registerFund(program: Command) {
   program
@@ -46,7 +46,6 @@ export function registerFund(program: Command) {
             address,
             qrEncodedFor: address,
             valuePromise: VALUE_PROMISE,
-            cardTopupUrl: 'https://t2000.ai/manage/topup',
           });
           return;
         }
@@ -70,7 +69,7 @@ export function registerFund(program: Command) {
 
         if (!opts.qrOnly) {
           printLine(pc.dim('Or share `' + address + '` directly.'));
-          printLine(pc.dim(CARD_HINT));
+          printLine(pc.dim(FUND_HINT));
           printBlank();
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- The Stripe card onramp (`t2000.ai/manage/topup`) is deleted in audric (S.1297) — this is the t2000 side: `t2 fund` drops `cardTopupUrl` + the card hint, docs `console.mdx` says send USDC on Sui to your address, ARCHITECTURE's Funding line is receive-only.
- Machine front door: N/A (funding copy only).

## Test plan
- [ ] `t2 fund --json` has no `cardTopupUrl`
- [ ] docs.t2000.ai/console has no /manage/topup link after Mintlify deploy
- [ ] `rg manage/topup` across packages/cli, apps/docs, ARCHITECTURE.md → none

🤖 Generated with [Claude Code](https://claude.com/claude-code)