### PR TITLE
✨ feat(sdk,cli): job images — reference + proof envelopes (S.1299)

### DIFF
--- a/apps/docs/how-to/claim-and-deliver.mdx
+++ b/apps/docs/how-to/claim-and-deliver.mdx
@@ -38,8 +38,15 @@ t2 job board                    # the work, budgets, SLAs — no wallet needed
 t2 job claim <openingId>        # first claim wins; the funded Job starts now
 t2 job spec <jobId>             # the work order (hash-verified)
 t2 job deliver <jobId> report.md
+t2 job deliver <jobId> report.md --image https://…/proof-1.jpg   # + proof images (≤6, first = cover)
 t2 job watch --mine             # your inbox + the next verb per job
 ```
+
+**Proof images.** A delivery (chat `body` + optional `images`, or
+`--image` on the CLI) can carry up to six HTTPS images. With images the
+body uploads as the `t2-acp-delivery@1` envelope, so they are part of the
+bytes behind `delivery_hash`; without images the body pins raw, exactly as
+before. A buyer sees them beside the delivery text.
 
 ## Check it worked
 

--- a/apps/docs/how-to/hire.mdx
+++ b/apps/docs/how-to/hire.mdx
@@ -36,7 +36,13 @@ t2 services "market brief"                      # find a listing
 t2 job hire --agent 0xSELLER --service <slug> \
   --requirements '{"topic":"DEEP"}'             # its price + terms; fill every listed key
 t2 job hire 1 0xSELLER --spec brief.md --deadline 24h   # or any agent, your own terms
+t2 job hire 1 0xSELLER --spec brief.md --image https://…/ref.jpg   # + reference images (≤6, first = cover)
 ```
+
+**Images.** A custom brief (chat `spec` + optional `images`, or `--spec` +
+`--image`) can carry up to six HTTPS reference images. They ride inside the
+spec envelope, so they are part of the bytes behind the job's on-chain
+`spec_hash` — the seller reads them with the brief.
 
 Then track and settle:
 

--- a/apps/docs/how-to/open-job.mdx
+++ b/apps/docs/how-to/open-job.mdx
@@ -12,7 +12,7 @@ in full, fee-free. **The USDC escrows when you post**, and the brief is public.
 
 | Step | Tool | Key args / returns | Spend gate? |
 | --- | --- | --- | --- |
-| 1. Post | `t2000_job_open` | `title`, `brief`, `maxUsdc`, `slaHours` (delivery window — **min 1**, default 24; fast jobs go 1 · 4 · 12), optional `trustRequirement` → the `openingId` | **yes** — the budget escrows now |
+| 1. Post | `t2000_job_open` | `title`, `brief`, `maxUsdc`, `slaHours` (delivery window — **min 1**, default 24; fast jobs go 1 · 4 · 12), optional `trustRequirement`, optional `images` (up to 6 HTTPS URLs — reference images pinned with the brief; the first is the cover) → the `openingId` | **yes** — the budget escrows now |
 | 2. Watch for a claim | `t2000_jobs` | your postings ride along as `openings[]`; a claim becomes a funded job in the inbox | no |
 | 3. When it delivers | `t2000_job_status` → `t2000_job_settle` / `t2000_job_reject` | the delivery + clocks; settle releases the escrow already locked | releases escrow — no new debit |
 | Changed your mind | `t2000_job_cancel` | `openingId` — unclaimed → full refund, fee-free, any time | no |
@@ -66,6 +66,8 @@ can't farm a posting's jobs.
 ```bash
 t2 job open --title "Logo sketch" --brief brief.md --max 1 --sla 24h
 t2 job open --title "Board pulse" --brief brief.md --max 0.25 --sla 4h --trust established
+t2 job open --title "Bins out" --brief brief.md --max 0.5 \
+  --image https://…/gate.jpg --image https://…/bins.jpg   # reference images (≤6, first = cover)
 t2 job batch-open --title "Board check" --brief brief.md --max 0.08 --slots 50
 t2 job cancel <openingId>          # unclaimed single → full refund, fee-free
 t2 job batch-cancel <batchId>      # unclaimed batch remainder → refund

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -45,6 +45,7 @@ import {
   printKeyValue,
   printSuccess,
 } from '../output.js';
+import { collectImage, IMAGE_FLAG_HELP, resolveImageFlags } from './job-images.js';
 
 const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 
@@ -64,12 +65,14 @@ export function registerBatchVerbs(group: Command) {
       '--trust <requirement>',
       'Who may claim: open (default) · established · top · veteran; claiming stays instant and $0 (S.1209)',
     )
+    .option('--image <url>', `${IMAGE_FLAG_HELP} — reference images for every job in the posting`, collectImage, [] as string[])
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(
       async (opts: {
         title: string;
         brief: string;
+        image?: string[];
         max: string;
         slots: string;
         maxClaimsPerAgent: string;
@@ -95,6 +98,7 @@ export function registerBatchVerbs(group: Command) {
           }
           const trustRequirement = resolveTrustFlag(opts.trust);
           const brief = await resolveBrief(opts.brief);
+          const images = resolveImageFlags(opts.image);
           // The WHOLE posting escrows at post — the spend gate sees the total.
           const totalUsdc = maxUsdc * slots;
           assertSpendAllowed(totalUsdc);
@@ -114,6 +118,7 @@ export function registerBatchVerbs(group: Command) {
             openHours: parseDuration(opts.openFor) / 3_600_000,
             trustRequirement,
             maxClaimsPerAgent: maxClaims,
+            ...(images.length > 0 ? { images } : {}),
           });
           recordSpendIfLanded(totalUsdc, digest);
           const batchId = await resolveCreatedObjectId(

--- a/packages/cli/src/commands/job-images.ts
+++ b/packages/cli/src/commands/job-images.ts
@@ -1,0 +1,22 @@
+// S.1299 — `--image <url>` (repeatable) on the job verbs: reference images
+// on open / batch-open / hire (inside the spec envelope → spec_hash) and
+// proof images on deliver (inside the delivery envelope → delivery_hash).
+// The SDK owns the rules (HTTPS, max 6, first = cover); this only collects
+// the flag and turns the SDK's refusal into CLI wording.
+import { MAX_JOB_IMAGES, validateJobImages } from '@t2000/sdk';
+
+/** Commander accumulator for a repeatable `--image <url>`. */
+export function collectImage(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+export const IMAGE_FLAG_HELP = `Image URL (HTTPS; repeat up to ${MAX_JOB_IMAGES} — the first is the cover)`;
+
+/** Validate the collected list or throw a CLI-flavored error. */
+export function resolveImageFlags(values: readonly string[] | undefined): string[] {
+  const v = validateJobImages(values ?? []);
+  if (!v.valid) {
+    throw new Error(`--image: ${v.error}`);
+  }
+  return v.images;
+}

--- a/packages/cli/src/commands/job.test.ts
+++ b/packages/cli/src/commands/job.test.ts
@@ -221,6 +221,16 @@ describe('resolveHireSpecUpload (S.978 — CLI writes the t2-acp-custom@1 envelo
     expect(typeof body.brief).toBe('string'); // not a nested envelope string
   });
 
+  it('S.1299: --image URLs ride INSIDE the envelope (part of the pinned spec); refused on a bare hash', async () => {
+    const { fn } = mockPutSpec();
+    const images = ['https://res.cloudinary.com/t/a.jpg', 'https://res.cloudinary.com/t/b.jpg'];
+    await resolveHireSpecUpload(BASE, 'Brief with pictures.', undefined, images);
+    const body = uploadedBody(fn);
+    expect(body.images).toEqual(images);
+    expect(body.type).toBe('t2-acp-custom@1');
+    await expect(resolveHireSpecUpload(BASE, HASH64, undefined, images)).rejects.toThrow(/--image/);
+  });
+
   it('bare 0x… sha256 stays hash-only — no upload, no wrap', async () => {
     const { fn } = mockPutSpec();
     const result = await resolveHireSpecUpload(BASE, HASH64, undefined);

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -46,6 +46,8 @@ import {
   customHireEnvelope,
   isCustomHireEnvelope,
   type Job,
+  deliveryEnvelope,
+  parseSpecImages,
 } from '@t2000/sdk';
 import { runSponsoredTx } from '../lib/agent-register.js';
 import { registerBatchVerbs } from './batch.js';
@@ -70,6 +72,7 @@ import {
   printSuccess,
   printWarning,
 } from '../output.js';
+import { collectImage, IMAGE_FLAG_HELP, resolveImageFlags } from './job-images.js';
 
 const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 const DEFAULT_REVIEW_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -200,6 +203,31 @@ export async function resolveSpecUpload(
   return { hash: `0x${await putAndVerifySpec(base, loaded.text)}`, uploaded: true };
 }
 
+/** Delivery upload (S.1299): the body uploads RAW unless proof images
+ *  ride along — then it uploads as the SDK's `t2-acp-delivery@1` envelope
+ *  so the bytes behind delivery_hash carry the images. A bare 0x… sha stays
+ *  hash-only (no images possible). */
+export async function resolveDeliveryUpload(
+  base: string,
+  input: string,
+  images: readonly string[] = [],
+): Promise<{ hash: string; uploaded: boolean }> {
+  const loaded = await loadSpecText(input);
+  if (loaded.kind === 'hash') {
+    if (images.length > 0) {
+      throw new Error('--image needs an uploaded delivery body — a bare 0x… hash pins without one.');
+    }
+    return { hash: loaded.hash, uploaded: false };
+  }
+  const body = deliveryEnvelope(loaded.text, Date.now(), { images });
+  if (Buffer.byteLength(body, 'utf8') > SPEC_STORE_MAX_BYTES) {
+    throw new Error(
+      'The delivery plus its image list exceeds the 16 KiB store cap — shorten the text or the URLs.',
+    );
+  }
+  return { hash: `0x${await putAndVerifySpec(base, body)}`, uploaded: true };
+}
+
 /** Direct-hire spec upload (S.978): text briefs wrap in the SDK's
  *  `t2-acp-custom@1` envelope — the same write shape as console + Connect —
  *  so manage / the public page / the feed title the job without derive
@@ -209,14 +237,22 @@ export async function resolveHireSpecUpload(
   base: string,
   input: string,
   title: string | undefined,
+  /** S.1299 — reference images (validated HTTPS list; first = cover). */
+  images: readonly string[] = [],
 ): Promise<{ hash: string; uploaded: boolean }> {
   const loaded = await loadSpecText(input);
   if (loaded.kind === 'hash') {
+    if (images.length > 0) {
+      throw new Error('--image needs a text brief: a bare 0x… spec hash pins without an envelope, so there is nowhere to put the images.');
+    }
     return { hash: loaded.hash, uploaded: false };
+  }
+  if (isCustomHireEnvelope(loaded.text) && images.length > 0) {
+    throw new Error('--image goes with a plain brief — this input is already a spec envelope; add the images inside it instead.');
   }
   const body = isCustomHireEnvelope(loaded.text)
     ? loaded.text
-    : customHireEnvelope(loaded.text, title, Date.now());
+    : customHireEnvelope(loaded.text, title, Date.now(), { images });
   if (Buffer.byteLength(body, 'utf8') > SPEC_STORE_MAX_BYTES) {
     throw new Error(
       'The brief plus its envelope exceeds the 16 KiB job-spec store cap — ' +
@@ -644,6 +680,7 @@ Ending a job (all states covered):
     .description('Hire — fund an escrow job in one transaction (buyer): a listing (--agent + --service) or your own terms (amount + seller + --spec)')
     .option('--spec <file-or-text>', 'Job spec — a file path or inline text (UPLOADED as the public t2-acp-custom@1 title+brief envelope so the seller and the store can read it; sha256 pinned on-chain), or a bare 0x… sha256 (hash-only: pins without uploading, no envelope — the body stays off-platform)')
     .option('--title <text>', 'Public job title (≤80 chars). Custom/direct hire only; derived from the brief\'s first line if omitted')
+    .option('--image <url>', `${IMAGE_FLAG_HELP} — reference images, pinned with the brief (custom/direct hire only)`, collectImage, [] as string[])
     .option(
       '--agent <address|#id|@handle>',
       "Hire a listing: the seller's agent address, #id, or @handle",
@@ -668,6 +705,7 @@ Ending a job (all states covered):
           deadline: string;
           review: string;
           split: string;
+          image?: string[];
           key?: string;
           api?: string;
         },
@@ -774,6 +812,7 @@ Ending a job (all states covered):
               base,
               opts.spec,
               opts.title,
+              resolveImageFlags(opts.image),
             ));
             deliverByMs = Date.now() + parseDuration(opts.deadline);
             reviewWindowMs = opts.review
@@ -929,9 +968,10 @@ Ending a job (all states covered):
     .argument('<proof>', 'Delivery body — a file path or text (UPLOADED so the buyer can read it; sha256 pinned on-chain), or a bare 0x… sha256')
     .description('Post your delivery before the deadline (seller) — ONE SHOT: the sha256 pins on-chain permanently and cannot be replaced. Fix mistakes via buyer reject (inside the review window) or out-of-band — never a second deliver. Decline is only possible BEFORE delivery.')
     .option('--hash-only', "Pin <proof> as a precomputed 0x… sha256 WITHOUT uploading a body — the hashed-spec / large-artifact path (the buyer can't read it on-platform; hand the artifact over out-of-band)")
+    .option('--image <url>', `${IMAGE_FLAG_HELP} — proof images, pinned with the delivery text`, collectImage, [] as string[])
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(async (jobId: string, proof: string, opts: { hashOnly?: boolean; key?: string; api?: string }) => {
+    .action(async (jobId: string, proof: string, opts: { hashOnly?: boolean; image?: string[]; key?: string; api?: string }) => {
       try {
         const base = opts.api ?? DEFAULT_API_BASE;
         // Preflight BEFORE any upload (S.1003): a redeliver / terminal /
@@ -948,14 +988,18 @@ Ending a job (all states covered):
         }
         let deliveryHash: string;
         let uploaded = false;
+        const images = resolveImageFlags(opts.image);
         if (opts.hashOnly) {
+          if (images.length > 0) {
+            throw new Error('--image needs an uploaded delivery body — --hash-only pins without one, so there is nowhere to put the images.');
+          }
           const hash = proof.trim().toLowerCase();
           if (!SHA256_HEX_RE.test(hash)) {
             throw new Error('--hash-only expects a 0x… 64-char sha256 (e.g. from `shasum -a 256`).');
           }
           deliveryHash = hash;
         } else {
-          ({ hash: deliveryHash, uploaded } = await resolveSpecUpload(base, proof));
+          ({ hash: deliveryHash, uploaded } = await resolveDeliveryUpload(base, proof, images));
         }
         if (!isJsonMode()) {
           // Point of no return — copy only, NEVER a stdin prompt: this
@@ -969,13 +1013,14 @@ Ending a job (all states covered):
           params: { jobId, deliveryHash },
         });
         if (isJsonMode()) {
-          printJson({ jobId, deliveryHash, uploaded, digest, onceOnly: true });
+          printJson({ jobId, deliveryHash, uploaded, digest, onceOnly: true, ...(images.length > 0 ? { images } : {}) });
           return;
         }
         printBlank();
         printSuccess('Delivery posted — the buyer\'s review window is now open.');
         printInfo('This delivery cannot be amended — further `t2 job deliver` calls on this job will fail.');
         printKeyValue('Delivery hash', deliveryHash);
+        if (images.length > 0) printKeyValue('Proof images', `${images.length} (first is the cover)`);
         if (digest) printKeyValue('Tx', digest);
         if (uploaded) {
           printInfo('Body uploaded — the buyer reads it content-addressed (tamper-evident against the on-chain hash).');
@@ -1225,12 +1270,17 @@ Ending a job (all states covered):
           } catch {
             // free-text spec — return as string
           }
-          printJson({ jobId, specHash: job.specHash, spec: parsed });
+          printJson({ jobId, specHash: job.specHash, spec: parsed, images: parseSpecImages(content) });
           return;
         }
         printBlank();
         printKeyValue('Job', jobId);
         printKeyValue('Spec hash', `${job.specHash} ${pc.green('(content verified)')}`);
+        const specImages = parseSpecImages(content);
+        if (specImages.length > 0) {
+          printKeyValue('Reference images', `${specImages.length} (first is the cover) — part of the pinned spec`);
+          for (const url of specImages) printLine(pc.dim(`  ${url}`));
+        }
         printBlank();
         printLine(content);
         printBlank();

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -54,6 +54,7 @@ import {
   printLine,
   printSuccess,
 } from '../output.js';
+import { collectImage, IMAGE_FLAG_HELP, resolveImageFlags } from './job-images.js';
 
 const DEFAULT_API_BASE = process.env.T2000_API_URL ?? 'https://api.t2000.ai/v1';
 const MAX_BRIEF_BYTES = 16 * 1024;
@@ -136,6 +137,7 @@ export function registerOpenVerbs(group: Command) {
       '--trust <requirement>',
       `Who may claim: open (default — any active Agent ID) · established (reviews from ${PROVEN_MIN_REVIEWS}+ distinct buyers) · top (adds a 4.0★ average) · veteran (power-user floor); claiming stays instant and $0 under every gate (S.1209)`,
     )
+    .option('--image <url>', `${IMAGE_FLAG_HELP} — reference images, pinned with the brief`, collectImage, [] as string[])
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
     .action(
@@ -146,6 +148,7 @@ export function registerOpenVerbs(group: Command) {
         sla: string;
         openFor: string;
         trust?: string;
+        image?: string[];
         key?: string;
         api?: string;
       }) => {
@@ -157,6 +160,7 @@ export function registerOpenVerbs(group: Command) {
           }
           const brief = await resolveBrief(opts.brief);
           const trustRequirement = resolveTrustFlag(opts.trust);
+          const images = resolveImageFlags(opts.image);
           // The budget escrows ON-CHAIN at post — a real outflow from the
           // buyer's wallet, so it belongs under the same cap as a hire.
           // (Claiming is free and is never recorded as spend.)
@@ -175,17 +179,21 @@ export function registerOpenVerbs(group: Command) {
             slaMinutes,
             openHours: parseDuration(opts.openFor) / 3_600_000,
             trustRequirement,
+            ...(images.length > 0 ? { images } : {}),
           });
           recordSpendIfLanded(maxUsdc, digest);
           const openingId = await resolveCreated(digest, '::opening::Opening<');
           if (isJsonMode()) {
-            printJson({ digest, openingId });
+            printJson({ digest, openingId, ...(images.length > 0 ? { images } : {}) });
             return;
           }
           printBlank();
           printSuccess(
             `Posted — $${maxUsdc.toFixed(2)} USDC escrowed on-chain in the opening.`,
           );
+          if (images.length > 0) {
+            printInfo(`${images.length} reference image${images.length === 1 ? '' : 's'} pinned with the brief (first is the cover).`);
+          }
           if (trustRequirement !== 'open') {
             printInfo(
               `${trustRequirementLabel(minSellerLevelForTrustRequirement(trustRequirement))} — sellers below that effective tier cannot claim.`,

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -219,6 +219,25 @@ export {
   detectWrongChainAddressShape,
   wrongChainAddressMessage,
 } from './utils/suins.js';
+// S.1299 — job images: the envelope builders/parsers are pure (no node
+// crypto) so the browser build ships them for the console + Audric chat.
+export {
+  customHireEnvelope,
+  DELIVERY_ENVELOPE_TYPE,
+  deliveryEnvelope,
+  isCustomHireEnvelope,
+  MAX_JOB_IMAGES,
+  normalizeJobImages,
+  openPostEnvelope,
+  parseDeliveryContent,
+  parseSpecImages,
+  validateJobImages,
+} from './job-spec-envelope.js';
+export type {
+  DeliveryContent,
+  JobImagesValidation,
+  SpecEnvelopeOptions,
+} from './job-spec-envelope.js';
 
 // Spending limits are Node-only (`@t2000/sdk/limits` uses node:fs) — NOT
 // exported here. The browser (Audric) write path skips client-side limits;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -260,7 +260,20 @@ export type {
 } from './commerce.js';
 export {
   customHireEnvelope,
+  DELIVERY_ENVELOPE_TYPE,
+  deliveryEnvelope,
   isCustomHireEnvelope,
+  MAX_JOB_IMAGES,
+  normalizeJobImages,
+  openPostEnvelope,
+  parseDeliveryContent,
+  parseSpecImages,
+  validateJobImages,
+} from './job-spec-envelope.js';
+export type {
+  DeliveryContent,
+  JobImagesValidation,
+  SpecEnvelopeOptions,
 } from './job-spec-envelope.js';
 export {
   cancelOpenJob,

--- a/packages/sdk/src/job-spec-envelope.test.ts
+++ b/packages/sdk/src/job-spec-envelope.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
 import {
   customHireEnvelope,
+  deliveryEnvelope,
   isCustomHireEnvelope,
+  MAX_JOB_IMAGES,
+  normalizeJobImages,
+  openPostEnvelope,
+  parseDeliveryContent,
+  parseSpecImages,
+  validateJobImages,
 } from './job-spec-envelope.js';
 
 // S.978 — the ONE write shape for buyer custom jobs. These pins mirror the
@@ -66,5 +74,82 @@ describe('isCustomHireEnvelope', () => {
     expect(isCustomHireEnvelope(customHireEnvelope('a real brief', undefined, 1))).toBe(
       true,
     );
+  });
+});
+
+// ── S.1299 — job images ────────────────────────────────────────────────────
+
+const sha = (s: string) => createHash('sha256').update(s, 'utf8').digest('hex');
+const IMG = ['https://res.cloudinary.com/t/a.jpg', 'https://res.cloudinary.com/t/b.jpg'];
+
+describe('validateJobImages', () => {
+  it('empty / absent is valid and empty; blanks drop; duplicates collapse (first = cover)', () => {
+    expect(validateJobImages(undefined)).toEqual({ valid: true, images: [] });
+    expect(validateJobImages([])).toEqual({ valid: true, images: [] });
+    expect(validateJobImages([' ', IMG[0], IMG[0], IMG[1]])).toEqual({
+      valid: true,
+      images: [IMG[0], IMG[1]],
+    });
+  });
+  it('HTTPS only; junk and non-lists refuse; more than 6 refuses', () => {
+    expect(validateJobImages(['http://x.test/a.jpg']).valid).toBe(false);
+    expect(validateJobImages(['not a url']).valid).toBe(false);
+    expect(validateJobImages('https://x.test/a.jpg').valid).toBe(false);
+    expect(validateJobImages([1]).valid).toBe(false);
+    const seven = Array.from({ length: MAX_JOB_IMAGES + 1 }, (_, i) => `https://x.test/${i}.jpg`);
+    const r = validateJobImages(seven);
+    expect(r.valid).toBe(false);
+    expect(r.valid ? '' : r.error).toMatch(/Up to 6/);
+    expect(() => normalizeJobImages(seven)).toThrow(/Up to 6/);
+  });
+});
+
+describe('customHireEnvelope / openPostEnvelope with images', () => {
+  it('no images → byte-identical to the pre-S.1299 envelope (no images key)', () => {
+    const a = customHireEnvelope('brief', 'T', 1);
+    const b = customHireEnvelope('brief', 'T', 1, { images: [] });
+    expect(a).toBe(b);
+    expect(JSON.parse(a)).not.toHaveProperty('images');
+  });
+  it('images ride inside the envelope — the hash CHANGES when they change', () => {
+    const none = customHireEnvelope('brief', 'T', 1);
+    const one = customHireEnvelope('brief', 'T', 1, { images: [IMG[0]] });
+    const two = customHireEnvelope('brief', 'T', 1, { images: IMG });
+    expect(JSON.parse(one).images).toEqual([IMG[0]]);
+    expect(sha(none)).not.toBe(sha(one));
+    expect(sha(one)).not.toBe(sha(two));
+    expect(parseSpecImages(two)).toEqual(IMG);
+    expect(parseSpecImages(none)).toEqual([]);
+    expect(parseSpecImages('raw brief text')).toEqual([]);
+  });
+  it('refuses more than 6 or non-HTTPS at write time', () => {
+    expect(() => customHireEnvelope('b', 'T', 1, { images: ['http://x.test/a.jpg'] })).toThrow(/HTTPS/);
+  });
+  it('openPostEnvelope = the same shape with the post title', () => {
+    const e = JSON.parse(openPostEnvelope('Bins out', 'Two bins…', 5, { images: [IMG[0]] }));
+    expect(e).toMatchObject({ type: 't2-acp-custom@1', title: 'Bins out', brief: 'Two bins…', images: [IMG[0]] });
+    expect(isCustomHireEnvelope(openPostEnvelope('Bins out', 'Two bins…', 5))).toBe(true);
+  });
+});
+
+describe('deliveryEnvelope / parseDeliveryContent', () => {
+  it('no proof images → the RAW body, byte-identical to every past delivery', () => {
+    expect(deliveryEnvelope('done.md contents', 1)).toBe('done.md contents');
+    expect(parseDeliveryContent('done.md contents')).toEqual({
+      body: 'done.md contents',
+      images: [],
+      enveloped: false,
+    });
+  });
+  it('proof images → t2-acp-delivery@1; the hash changes; round-trips', () => {
+    const raw = 'Both bins in place.';
+    const env = deliveryEnvelope(raw, 7, { images: IMG });
+    expect(JSON.parse(env)).toMatchObject({ type: 't2-acp-delivery@1', body: raw, images: IMG, createdAtMs: 7 });
+    expect(sha(env)).not.toBe(sha(raw));
+    expect(parseDeliveryContent(env)).toEqual({ body: raw, images: IMG, enveloped: true });
+  });
+  it('a JSON delivery that is not the envelope stays raw text', () => {
+    const other = JSON.stringify({ hello: 'world' });
+    expect(parseDeliveryContent(other)).toEqual({ body: other, images: [], enveloped: false });
   });
 });

--- a/packages/sdk/src/job-spec-envelope.ts
+++ b/packages/sdk/src/job-spec-envelope.ts
@@ -1,15 +1,88 @@
 // Buyer custom-hire spec envelope (S.978) — the ONE write shape for
 // buyer-authored jobs across every surface: console hire-custom-prepare,
-// Connect t2000_job_hire (S.977) and `t2 job hire` all upload
-// `t2-acp-custom@1` {type, title, brief, createdAtMs}. Raw-text READ
-// fallbacks stay forever for history; nothing should EMIT raw anymore.
+// Connect t2000_job_hire (S.977), `t2 job hire`, and (S.1299) the open /
+// batch-open posts the API composes — all upload `t2-acp-custom@1`
+// {type, title, brief, createdAtMs, images?}. Raw-text READ fallbacks stay
+// forever for history; nothing should EMIT raw anymore.
 // Behavior is byte-stable with the S.977 mcp builder it canonicalizes
 // (audric apps/mcp/lib/hire-order.ts imports this once the version bumps).
 //
-// Deliveries are NOT wrapped — this envelope is for hire specs only.
+// S.1299 — job images. Two kinds, never conflated:
+//   REFERENCE images ride INSIDE the spec envelope (buyer: open / hire /
+//   batch-open / repost) → they are part of the bytes behind spec_hash.
+//   PROOF images ride INSIDE the delivery payload (seller: deliver) →
+//   `t2-acp-delivery@1` → part of the bytes behind delivery_hash.
+// Same rules for both: max 6, first = cover, HTTPS only. The `images` key
+// is written ONLY when there are images, so every existing call site stays
+// byte-identical (a job with no images hashes exactly as before).
 
 const TITLE_PREFIX_RE = /^title\s*:\s*(.+)$/i;
 const ENVELOPE_TITLE_MAX = 80;
+
+/** Max images per job (reference) and per delivery (proof). */
+export const MAX_JOB_IMAGES = 6;
+
+export type JobImagesValidation =
+  | { valid: true; images: string[] }
+  | { valid: false; error: string };
+
+/** Validate a candidate image list: a list of HTTPS URLs, at most
+ *  MAX_JOB_IMAGES, blanks dropped, duplicates collapsed (first wins —
+ *  it is the cover). `undefined` / `null` / `[]` are valid and empty. */
+export function validateJobImages(input: unknown): JobImagesValidation {
+  if (input === undefined || input === null) {
+    return { valid: true, images: [] };
+  }
+  if (!Array.isArray(input)) {
+    return { valid: false, error: 'images must be a list of HTTPS URLs.' };
+  }
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== 'string') {
+      return { valid: false, error: 'images must be a list of HTTPS URLs.' };
+    }
+    const url = raw.trim();
+    if (!url) {
+      continue;
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return { valid: false, error: `Not a URL: ${url}` };
+    }
+    if (parsed.protocol !== 'https:') {
+      return { valid: false, error: `Images must be HTTPS URLs: ${url}` };
+    }
+    if (url.length > 2048) {
+      return { valid: false, error: 'Image URLs must be under 2048 characters.' };
+    }
+    if (!out.includes(url)) {
+      out.push(url);
+    }
+  }
+  if (out.length > MAX_JOB_IMAGES) {
+    return {
+      valid: false,
+      error: `Up to ${MAX_JOB_IMAGES} images per job (the first is the cover).`,
+    };
+  }
+  return { valid: true, images: out };
+}
+
+/** validateJobImages that throws — for write paths. */
+export function normalizeJobImages(input: unknown): string[] {
+  const v = validateJobImages(input);
+  if (!v.valid) {
+    throw new Error(v.error);
+  }
+  return v.images;
+}
+
+export type SpecEnvelopeOptions = {
+  /** S.1299 — reference images (≤6 HTTPS; first = cover). Validated. */
+  images?: readonly string[] | null;
+};
 
 /** Title rules: an explicit title wins; otherwise the brief's first
  *  non-empty line (a leading "Title: …" prefix is stripped for the title
@@ -19,6 +92,7 @@ export function customHireEnvelope(
   brief: string,
   title: string | undefined,
   now: number,
+  opts: SpecEnvelopeOptions = {},
 ): string {
   const body = brief.trim();
   let t = title?.trim() ?? '';
@@ -30,12 +104,27 @@ export function customHireEnvelope(
   if (t.length > ENVELOPE_TITLE_MAX) {
     t = `${t.slice(0, ENVELOPE_TITLE_MAX - 1).trimEnd()}…`;
   }
+  const images = normalizeJobImages(opts.images);
   return JSON.stringify({
     type: 't2-acp-custom@1',
     title: t || 'Custom job',
     brief: body,
     createdAtMs: now,
+    // Written only when present — byte-stable for every image-less job.
+    ...(images.length > 0 ? { images } : {}),
   });
+}
+
+/** The open-board / batch-open twin (S.1299): SAME envelope, title
+ *  required (the board names the row). The API composes this at post so
+ *  the bytes behind the opening's spec_hash carry the images. */
+export function openPostEnvelope(
+  title: string,
+  brief: string,
+  now: number,
+  opts: SpecEnvelopeOptions = {},
+): string {
+  return customHireEnvelope(brief, title.trim() || undefined, now, opts);
 }
 
 /** Idempotency guard: text that already IS a custom envelope (current or
@@ -52,4 +141,74 @@ export function isCustomHireEnvelope(text: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** READ the reference images off any spec content — fail-soft: raw text,
+ *  listing specs, legacy envelopes, or junk all read as no images. Only
+ *  HTTPS strings count, capped at MAX_JOB_IMAGES. */
+export function parseSpecImages(content: string): string[] {
+  try {
+    const parsed = JSON.parse(content) as { images?: unknown };
+    const v = validateJobImages(
+      Array.isArray(parsed.images) ? parsed.images.slice(0, MAX_JOB_IMAGES) : undefined,
+    );
+    return v.valid ? v.images : [];
+  } catch {
+    return [];
+  }
+}
+
+// ── Delivery payload (S.1299 — proof images) ─────────────────────────────
+
+export const DELIVERY_ENVELOPE_TYPE = 't2-acp-delivery@1';
+
+/** Wrap a delivery body for the spec store. With NO proof images the body
+ *  uploads RAW — byte-identical to every delivery ever pinned. With images
+ *  it becomes the `t2-acp-delivery@1` envelope {type, body, images,
+ *  createdAtMs}, so the bytes behind delivery_hash carry the proof. */
+export function deliveryEnvelope(
+  body: string,
+  now: number,
+  opts: SpecEnvelopeOptions = {},
+): string {
+  const images = normalizeJobImages(opts.images);
+  if (images.length === 0) {
+    return body;
+  }
+  return JSON.stringify({
+    type: DELIVERY_ENVELOPE_TYPE,
+    body,
+    images,
+    createdAtMs: now,
+  });
+}
+
+export type DeliveryContent = {
+  /** The delivery text the buyer reads (the whole content when raw). */
+  body: string;
+  /** Proof images (≤6 HTTPS; first = cover) — empty on raw deliveries. */
+  images: string[];
+  /** Whether the content was a `t2-acp-delivery@1` envelope. */
+  enveloped: boolean;
+};
+
+/** READ a delivery: envelope → body + images; anything else is the raw
+ *  body with no images (every pre-S.1299 delivery, and hash-only misses). */
+export function parseDeliveryContent(content: string): DeliveryContent {
+  try {
+    const parsed = JSON.parse(content) as {
+      type?: unknown;
+      body?: unknown;
+      images?: unknown;
+    };
+    if (parsed.type === DELIVERY_ENVELOPE_TYPE && typeof parsed.body === 'string') {
+      const v = validateJobImages(
+        Array.isArray(parsed.images) ? parsed.images.slice(0, MAX_JOB_IMAGES) : undefined,
+      );
+      return { body: parsed.body, images: v.valid ? v.images : [], enveloped: true };
+    }
+  } catch {
+    // raw text
+  }
+  return { body: content, images: [], enveloped: false };
 }

--- a/packages/sdk/src/open-jobs.ts
+++ b/packages/sdk/src/open-jobs.ts
@@ -16,6 +16,7 @@
 // Browser-safe: fetch + base64 only; no fs, no node:crypto.
 
 import { fromBase64 } from '@mysten/sui/utils';
+import { normalizeJobImages } from './job-spec-envelope.js';
 import type { TransactionSigner } from './signer.js';
 import { runSponsoredTxGuard } from './sponsored-guard.js';
 import {
@@ -92,6 +93,10 @@ export interface OpenJobRow {
   slotsRemaining?: number;
   /** S.1193 — slots one agent may claim of this wave (batch rows only). */
   maxClaimsPerAgent?: number;
+  /** S.1299 — reference images the buyer posted with the job (≤6 HTTPS
+   *  URLs; `[0]` is the cover). Absent / empty = none — never render a
+   *  gallery for an empty list. */
+  images?: string[];
   createdAtMs: number;
   updatedAtMs: number;
 }
@@ -270,11 +275,16 @@ export function postOpenJob(
     /** S.1209 — the ONE trust knob: who may claim (default "open").
      *  Maps to the on-chain tier floor; `claim_policy` is always 0. */
     trustRequirement?: TrustRequirement;
+    /** S.1299 — reference images (≤6 HTTPS URLs; first = cover). They ride
+     *  inside the spec envelope the API composes → part of spec_hash. */
+    images?: readonly string[];
   },
 ): Promise<string> {
-  const { trustRequirement = 'open', ...rest } = input;
+  const { trustRequirement = 'open', images, ...rest } = input;
+  const imageList = normalizeJobImages(images);
   return sponsoredOpeningVerb(base, signer, 'open-create', {
     ...rest,
+    ...(imageList.length > 0 ? { images: imageList } : {}),
     // Mapped client-side so the rail contract stays value-stable — the
     // server re-asserts the same mapping and always writes claimPolicy 0.
     trustRequirement,
@@ -362,14 +372,18 @@ export function postBatchOpenJob(
     openHours?: number;
     /** S.1209 — the ONE trust knob (default "open"); claim_policy always 0. */
     trustRequirement?: TrustRequirement;
+    /** S.1299 — reference images for every job in the wave (≤6 HTTPS). */
+    images?: readonly string[];
     /** Slots one agent may claim of this wave (default 1 — NOT the tier
      *  cap; the effective per-posting limit is min(this, tier cap)). */
     maxClaimsPerAgent?: number;
   },
 ): Promise<string> {
-  const { trustRequirement = 'open', ...rest } = input;
+  const { trustRequirement = 'open', images, ...rest } = input;
+  const imageList = normalizeJobImages(images);
   return sponsoredOpeningVerb(base, signer, 'batch-open-create', {
     ...rest,
+    ...(imageList.length > 0 ? { images: imageList } : {}),
     trustRequirement,
     minSellerLevel: minSellerLevelForTrustRequirement(trustRequirement),
     claimPolicy: 0,


### PR DESCRIPTION
## Summary
S.1299 t2000 side — job images on the rails. Two kinds:
- **Reference images** (buyer: open / hire / batch-open / repost) ride **inside the spec envelope** → part of `spec_hash`.
- **Proof images** (seller: deliver) ride **inside the delivery payload** → part of `delivery_hash`.

Locks: max 6 · cover = `[0]` · HTTPS only · `images` key written only when non-empty (every existing hash is byte-stable) · delivery stays raw text unless images are present (then `t2-acp-delivery@1`).

## SDK (`@t2000/sdk`)
- `validateJobImages` / `normalizeJobImages` / `MAX_JOB_IMAGES`
- `customHireEnvelope(brief, title, now, { images })`, `openPostEnvelope(...)`, `parseSpecImages`
- `deliveryEnvelope`, `parseDeliveryContent`, `DELIVERY_ENVELOPE_TYPE`
- `postOpenJob` / `postBatchOpenJob` take `images`; `OpenJobRow.images`
- `./browser` entry exports the envelope helpers (audric imports the shape — never copies it)

## CLI (`@t2000/cli`)
`--image <url>` (repeatable) on `job open` · `job batch-open` · `job hire` (custom brief only; refused on a bare hash) · `job deliver` (refused with `--hash-only`). `job spec` prints reference images.

## Docs
`how-to/open-job` · `how-to/hire` · `how-to/claim-and-deliver` — `--image` / `images` facts.

## Verify
- sdk: tsc clean · 674 tests (envelope suite covers hash-changes-with-images, byte-stable-without, delivery wrap/unwrap)
- cli: tsc clean · 336 tests (new: `--image` rides inside the envelope, refused on a bare hash)
- lint: 0 errors both packages (warnings pre-existing, untouched files)

## Downstream
audric's S.1299 PR imports these exports — needs a **minor** release of `@t2000/sdk` (new surface) before it can typecheck in CI. Not merging here unless asked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)