### PR TITLE
✨ feat(sdk,cli): refund-many compose + t2 job release/refund --ids / --all-* (S.1310)

### DIFF
--- a/apps/docs/cli-reference.mdx
+++ b/apps/docs/cli-reference.mdx
@@ -62,6 +62,8 @@ permissionless), jobs cap at 100 USDC, every verb sponsored. Flows:
 | `t2 job release <jobId>` | buyer — or anyone once the review window lapses | Funds → seller, after a delivery. Refused on a no-delivery job unless `--pay-without-delivery` (deliberate goodwill, no recovery). |
 | `t2 job reject <jobId>` | buyer, in the review window | Funds split per the ratio agreed at create. |
 | `t2 job refund <jobId>` | anyone, after the deadline with no delivery | Funds → buyer. |
+| `t2 job release --ids 0xA,0xB` · `--all-delivered` | buyer | Settle several delivered jobs in ONE transaction (all settle or none, up to 10; `--all-delivered` takes the first 10 and says how many remain). |
+| `t2 job refund --ids 0xA,0xB` · `--all-lapsed` | buyer (or anyone) | Refund several lapsed jobs in ONE transaction (all refund or none, up to 10). |
 | `t2 job decline <jobId>` | seller, before delivering | Pass on a funded job — buyer refunded in full, fee-free. |
 | `t2 job review <jobId> --stars <1-5> [--text "…"]` | buyer or seller, after release or reject | Receipt-bound rating on a job that had a delivery. Buyer stars write **on-chain** (re-run to edit); `--text` stays off-chain — [reviews](/how-to/reviews-and-reputation). |
 

--- a/packages/cli/src/commands/job.test.ts
+++ b/packages/cli/src/commands/job.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  BULK_JOB_MAX,
   bucketSellerJob,
+  bulkModeError,
+  eligibleBulkIds,
+  parseIdList,
+  pickBulkJobIds,
   deliverPreflightError,
   fetchSellerJobs,
   type IndexedJob,
@@ -510,5 +515,56 @@ describe('hydrateJobsFromChain seat-neutral alias (S.1016)', () => {
   it('is the same function the seller inbox uses', async () => {
     const { hydrateSellerJobsFromChain } = await import('./job.js');
     expect(hydrateJobsFromChain).toBe(hydrateSellerJobsFromChain);
+  });
+});
+
+// S.1310 — bulk settle / refund helpers: one mode at a time, cap 10 with
+// an honest remainder, eligibility = buyer delivered (settle) / funded
+// past the deadline (refund).
+describe('bulk settle / refund helpers (S.1310)', () => {
+  const row = (jobId: string, state: IndexedJob['state'], deliverByMs: number): IndexedJob => ({
+    jobId,
+    buyer: '0xb',
+    seller: '0xs',
+    amountUsdc: 1,
+    state,
+    deliverByMs,
+    reviewWindowMs: 0,
+    deliveryHash: null,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+  });
+
+  it('parseIdList trims, drops blanks, dedupes case-insensitively', () => {
+    expect(parseIdList(' 0xA, 0xb ,,0xa ')).toEqual(['0xA', '0xb']);
+    expect(parseIdList('')).toEqual([]);
+  });
+
+  it('bulkModeError: exactly one of positional / --ids / --all-*', () => {
+    expect(bulkModeError({ allFlag: '--all-delivered' })).toMatch(/Pass a jobId, --ids/);
+    expect(bulkModeError({ positional: '0xA', allFlag: '--all-delivered' })).toBeNull();
+    expect(bulkModeError({ ids: '0xA', allFlag: '--all-delivered' })).toBeNull();
+    expect(bulkModeError({ all: true, allFlag: '--all-lapsed' })).toBeNull();
+    expect(bulkModeError({ positional: '0xA', ids: '0xB', allFlag: '--all-delivered' })).toMatch(/not a mix/);
+    expect(bulkModeError({ ids: '0xB', all: true, allFlag: '--all-lapsed' })).toMatch(/--ids \/ --all-lapsed/);
+  });
+
+  it('pickBulkJobIds caps at 10 and reports the remainder', () => {
+    const ids = Array.from({ length: 13 }, (_, i) => `0x${i}`);
+    expect(pickBulkJobIds(ids)).toEqual({ jobIds: ids.slice(0, BULK_JOB_MAX), remaining: 3 });
+    expect(pickBulkJobIds(['0x1'])).toEqual({ jobIds: ['0x1'], remaining: 0 });
+  });
+
+  it('eligibleBulkIds: delivered for release; funded past deadline for refund; inbox order', () => {
+    const now = 1_000_000;
+    const jobs = [
+      row('0x1', 'delivered', 0),
+      row('0x2', 'funded', now - 1),
+      row('0x3', 'funded', now + 1),
+      row('0x4', 'released', 0),
+      row('0x5', 'delivered', 0),
+    ];
+    expect(eligibleBulkIds(jobs, 'release', now)).toEqual(['0x1', '0x5']);
+    expect(eligibleBulkIds(jobs, 'refund', now)).toEqual(['0x2']);
   });
 });

--- a/packages/cli/src/commands/job.ts
+++ b/packages/cli/src/commands/job.ts
@@ -582,10 +582,88 @@ export function deliverPreflightError(state: Job['state'], deliverByMs: number, 
   return null;
 }
 
+// ── S.1310 — bulk settle / refund: N jobs, ONE PTB (all-or-nothing) ───────
+// `t2 job release --ids 0xA,0xB` / `--all-delivered` and
+// `t2 job refund --ids …` / `--all-lapsed` ride the SAME sponsored rail as
+// the single verbs through the `release-many` / `refund-many` prepare
+// actions (the API re-reads every job on-chain and builds one PTB). The
+// product cap is 10 per transaction; `--all-*` takes the first 10 (inbox
+// order) and says how many remain. Pure helpers below are unit-pinned.
+
+/** Product cap on jobs per bulk transaction (mirrors the API's cap). */
+export const BULK_JOB_MAX = 10;
+
+/** `--ids 0xA,0xB` → trimmed, deduped (case-insensitive) list. */
+export function parseIdList(csv: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of csv.split(',')) {
+    const id = raw.trim();
+    if (!id) continue;
+    const key = id.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(id);
+  }
+  return out;
+}
+
+/** Exactly ONE of positional id · --ids · --all-* — never a mix. */
+export function bulkModeError(opts: {
+  positional?: string;
+  ids?: string;
+  all?: boolean;
+  allFlag: string;
+}): string | null {
+  const modes = [
+    opts.positional ? '<jobId>' : null,
+    opts.ids !== undefined ? '--ids' : null,
+    opts.all ? opts.allFlag : null,
+  ].filter(Boolean);
+  if (modes.length === 0) {
+    return `Pass a jobId, --ids 0xA,0xB, or ${opts.allFlag}.`;
+  }
+  if (modes.length > 1) {
+    return `Pass only one of ${modes.join(' / ')} — not a mix.`;
+  }
+  return null;
+}
+
+/** Cap a bulk selection: the first `cap` ids (input / inbox order) plus how
+ *  many were left behind — the caller says "run again for the rest". */
+export function pickBulkJobIds(
+  ids: string[],
+  cap: number = BULK_JOB_MAX,
+): { jobIds: string[]; remaining: number } {
+  return { jobIds: ids.slice(0, cap), remaining: Math.max(0, ids.length - cap) };
+}
+
+/** Buyer rows a bulk verb may take: delivered (settle) / funded past the
+ *  deadline (refund). Inbox order preserved. */
+export function eligibleBulkIds(
+  jobs: IndexedJob[],
+  verb: 'release' | 'refund',
+  nowMs: number,
+): string[] {
+  return jobs
+    .filter((j) =>
+      verb === 'release' ? j.state === 'delivered' : j.state === 'funded' && nowMs > j.deliverByMs,
+    )
+    .map((j) => j.jobId);
+}
+
 async function sponsoredJobVerb(opts: {
   base: string;
   keyPath?: string;
-  action: 'create' | 'decline' | 'deliver' | 'release' | 'reject' | 'refund';
+  action:
+    | 'create'
+    | 'decline'
+    | 'deliver'
+    | 'release'
+    | 'release-many'
+    | 'reject'
+    | 'refund'
+    | 'refund-many';
   params: Record<string, unknown>;
   /** USDC leaving THIS wallet, for the spending gate. Only `create` moves
    *  buyer money out; the seller-side verbs settle escrow that is already
@@ -1057,13 +1135,54 @@ Ending a job (all states covered):
   // decline would be wrong.
   group
     .command('release')
-    .argument('<jobId>', 'The Job object id (0x…)')
-    .description('Accept delivery — funds go to the seller (buyer; or anyone once the review window lapses). On a FUNDED job with no delivery this pays the full escrow to the seller, terminally — refused unless --pay-without-delivery.')
+    .argument('[jobId]', 'The Job object id (0x…) — or use --ids / --all-delivered')
+    .description('Accept delivery — funds go to the seller (buyer; or anyone once the review window lapses). On a FUNDED job with no delivery this pays the full escrow to the seller, terminally — refused unless --pay-without-delivery. Settle several at once: --ids 0xA,0xB or --all-delivered (one transaction, all settle or none, up to 10).')
+    .option('--ids <list>', 'Settle several DELIVERED jobs in ONE transaction (comma-separated jobIds, up to 10; all settle or none)')
+    .option('--all-delivered', 'Settle every delivered job you bought — first 10 in ONE transaction; run again for the rest')
     .option('--pay-without-delivery', 'DELIBERATE goodwill: release the full escrow on a funded job with NO delivery (off-band delivery only — the seller keeps everything, no refund path)')
     .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
     .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
-    .action(async (jobId: string, opts: { payWithoutDelivery?: boolean; key?: string; api?: string }) => {
+    .action(async (jobId: string | undefined, opts: { ids?: string; allDelivered?: boolean; payWithoutDelivery?: boolean; key?: string; api?: string }) => {
       try {
+        const modeErr = bulkModeError({ positional: jobId, ids: opts.ids, all: opts.allDelivered, allFlag: '--all-delivered' });
+        if (modeErr) throw new Error(modeErr);
+        // S.1310 — bulk: ONE PTB through the release-many prepare action.
+        if (opts.ids !== undefined || opts.allDelivered) {
+          if (opts.payWithoutDelivery) {
+            throw new Error('--pay-without-delivery is single-job only — bulk release settles DELIVERED work.');
+          }
+          const base = opts.api ?? DEFAULT_API_BASE;
+          let candidates: string[];
+          if (opts.allDelivered) {
+            const me = (await withAgent({ keyPath: opts.key })).address();
+            candidates = eligibleBulkIds(await fetchBuyerJobs(base, me), 'release', Date.now());
+            if (candidates.length === 0) {
+              printInfo('Nothing to settle — no delivered jobs on your buyer seat.');
+              return;
+            }
+          } else {
+            candidates = parseIdList(opts.ids ?? '');
+            if (candidates.length === 0) throw new Error('--ids needs at least one jobId.');
+          }
+          const { jobIds, remaining } = pickBulkJobIds(candidates);
+          const { digest } = await sponsoredJobVerb({
+            base,
+            keyPath: opts.key,
+            action: 'release-many',
+            params: { jobIds },
+          });
+          if (isJsonMode()) {
+            printJson({ action: 'release-many', jobIds, digest, remaining });
+            return;
+          }
+          printBlank();
+          printSuccess(`Settled ${jobIds.length} job${jobIds.length === 1 ? '' : 's'} in one transaction — funds released to the sellers.`);
+          if (digest) printKeyValue('Tx', digest);
+          if (remaining > 0) printInfo(`${remaining} more delivered — run again for the rest.`);
+          printBlank();
+          return;
+        }
+        if (!jobId) throw new Error('Pass a jobId.');
         // Preflight (same style as deliver, S.1003): read the chain before
         // signing. Unreadable job → proceed; the prepare API runs the same
         // gate server-side (S.1015 root fix) and the chain stays authority.
@@ -1119,11 +1238,6 @@ Ending a job (all states covered):
       'Delivery rejected — funds split per the terms agreed at create.',
     ],
     [
-      'refund',
-      'Reclaim funds after the deadline passed with no delivery (anyone may crank this)',
-      'Escrow refunded to the buyer.',
-    ],
-    [
       'decline',
       "Pass on an undelivered job you were hired for — the buyer's escrow returns in full, fee-free (seller, before delivery)",
       "Declined — the buyer's escrow went back in full, fee-free, and your claim seat is free again. (An Open-claimed posting does not resurrect; the buyer re-posts.)",
@@ -1156,6 +1270,71 @@ Ending a job (all states covered):
         }
       });
   }
+
+  // S.1310 — refund stands alone so it can take --ids / --all-lapsed.
+  group
+    .command('refund')
+    .argument('[jobId]', 'The Job object id (0x…) — or use --ids / --all-lapsed')
+    .description('Reclaim funds after the deadline passed with no delivery (anyone may crank this). Refund several at once: --ids 0xA,0xB or --all-lapsed (one transaction, all refund or none, up to 10).')
+    .option('--ids <list>', 'Refund several lapsed jobs in ONE transaction (comma-separated jobIds, up to 10; all refund or none)')
+    .option('--all-lapsed', 'Refund every funded job you bought whose deadline passed undelivered — first 10 in ONE transaction; run again for the rest')
+    .option('--key <path>', 'Custom wallet path (default ~/.t2000/wallet.key)')
+    .option('--api <url>', `API base URL (default ${DEFAULT_API_BASE})`)
+    .action(async (jobId: string | undefined, opts: { ids?: string; allLapsed?: boolean; key?: string; api?: string }) => {
+      try {
+        const modeErr = bulkModeError({ positional: jobId, ids: opts.ids, all: opts.allLapsed, allFlag: '--all-lapsed' });
+        if (modeErr) throw new Error(modeErr);
+        const base = opts.api ?? DEFAULT_API_BASE;
+        if (opts.ids !== undefined || opts.allLapsed) {
+          let candidates: string[];
+          if (opts.allLapsed) {
+            const me = (await withAgent({ keyPath: opts.key })).address();
+            candidates = eligibleBulkIds(await fetchBuyerJobs(base, me), 'refund', Date.now());
+            if (candidates.length === 0) {
+              printInfo('Nothing to refund — no funded jobs past their deadline on your buyer seat.');
+              return;
+            }
+          } else {
+            candidates = parseIdList(opts.ids ?? '');
+            if (candidates.length === 0) throw new Error('--ids needs at least one jobId.');
+          }
+          const { jobIds, remaining } = pickBulkJobIds(candidates);
+          const { digest } = await sponsoredJobVerb({
+            base,
+            keyPath: opts.key,
+            action: 'refund-many',
+            params: { jobIds },
+          });
+          if (isJsonMode()) {
+            printJson({ action: 'refund-many', jobIds, digest, remaining });
+            return;
+          }
+          printBlank();
+          printSuccess(`Refunded ${jobIds.length} job${jobIds.length === 1 ? '' : 's'} in one transaction — escrow back to the buyer, fee-free.`);
+          if (digest) printKeyValue('Tx', digest);
+          if (remaining > 0) printInfo(`${remaining} more lapsed — run again for the rest.`);
+          printBlank();
+          return;
+        }
+        if (!jobId) throw new Error('Pass a jobId.');
+        const { digest } = await sponsoredJobVerb({
+          base,
+          keyPath: opts.key,
+          action: 'refund',
+          params: { jobId },
+        });
+        if (isJsonMode()) {
+          printJson({ jobId, action: 'refund', digest });
+          return;
+        }
+        printBlank();
+        printSuccess('Escrow refunded to the buyer.');
+        if (digest) printKeyValue('Tx', digest);
+        printBlank();
+      } catch (error) {
+        handleError(error);
+      }
+    });
 
   group
     .command('review')

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -122,6 +122,8 @@ export {
   buildReleaseJobTx,
   addReleaseJobToTx,
   buildReleaseJobsTx,
+  addRefundJobToTx,
+  buildRefundJobsTx,
   MAX_RELEASES_PER_TX,
   buildRejectJobTx,
   buildRefundJobTx,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -153,6 +153,8 @@ export {
   buildReleaseJobTx,
   addReleaseJobToTx,
   buildReleaseJobsTx,
+  addRefundJobToTx,
+  buildRefundJobsTx,
   MAX_RELEASES_PER_TX,
   buildRejectJobTx,
   buildRefundJobTx,

--- a/packages/sdk/src/wallet/job.test.ts
+++ b/packages/sdk/src/wallet/job.test.ts
@@ -15,6 +15,8 @@ import {
   buildReleaseJobTx,
   addReleaseJobToTx,
   buildReleaseJobsTx,
+  addRefundJobToTx,
+  buildRefundJobsTx,
   MAX_RELEASES_PER_TX,
   getJob,
   getJobBatchOrigin,
@@ -602,7 +604,7 @@ describe('buildReleaseJobsTx (S.1302 settle selected)', () => {
   });
 
   it('empty selection throws; a duplicate jobId throws (case-insensitive)', () => {
-    expect(() => buildReleaseJobsTx([])).toThrow(/at least one job/);
+    expect(() => buildReleaseJobsTx([])).toThrow(/Settle selected: pick at least one job/);
     expect(() =>
       buildReleaseJobsTx([
         { jobId: JOB_A, sellerScoreId: SCORE_A },
@@ -622,5 +624,76 @@ describe('buildReleaseJobsTx (S.1302 settle selected)', () => {
       sellerScoreId: SCORE_ID,
     }));
     expect(() => buildReleaseJobsTx(over)).toThrow(/ceiling/);
+  });
+});
+
+// S.1310 — "Refund all lapsed": the exact mirror of settle-selected on the
+// refund doors (refund_v2 / batch_refund), same composer.
+describe('buildRefundJobsTx (S.1310 refund all lapsed)', () => {
+  const JOB_A = `0x${'1'.repeat(64)}`;
+  const JOB_B = `0x${'2'.repeat(64)}`;
+  const SCORE_A = `0x${'3'.repeat(64)}`;
+  const SCORE_B = `0x${'4'.repeat(64)}`;
+  const BATCH = `0x${'9'.repeat(64)}`;
+  type Call = {
+    MoveCall: { package: string; module: string; function: string; arguments: unknown[] };
+  };
+  const moveCalls = (tx: Transaction): Call[] =>
+    tx
+      .getData()
+      .commands.filter((c) => 'MoveCall' in (c as Record<string, unknown>)) as Call[];
+
+  it('buildRefundJobTx is unchanged: one call, same door, via addRefundJobToTx', () => {
+    const single = moveCalls(buildRefundJobTx(JOB_A, { sellerScoreId: SCORE_A }));
+    const added = moveCalls(addRefundJobToTx(new Transaction(), JOB_A, { sellerScoreId: SCORE_A }));
+    expect(single).toHaveLength(1);
+    expect(single[0].MoveCall.function).toBe('refund_v2');
+    expect(JSON.stringify(single)).toBe(JSON.stringify(added));
+  });
+
+  it('mix: wave-origin + plain → batch_refund then refund_v2, input order', () => {
+    const calls = moveCalls(
+      buildRefundJobsTx([
+        { jobId: JOB_A, sellerScoreId: SCORE_A, batchId: BATCH },
+        { jobId: JOB_B, sellerScoreId: SCORE_B },
+      ]),
+    );
+    expect(calls.map((c) => `${c.MoveCall.module}::${c.MoveCall.function}`)).toEqual([
+      'batch::batch_refund',
+      'reputation::refund_v2',
+    ]);
+    for (const c of calls) expect(c.MoveCall.package).toBe(A2A_ESCROW_LATEST_PACKAGE_ID);
+  });
+
+  it('same seller twice shares ONE score input; same wave twice shares ONE batch input', () => {
+    const sameSeller = buildRefundJobsTx([
+      { jobId: JOB_A, sellerScoreId: SCORE_A },
+      { jobId: JOB_B, sellerScoreId: SCORE_A },
+    ]);
+    expect(sameSeller.getData().inputs).toHaveLength(5);
+    const sameWave = buildRefundJobsTx([
+      { jobId: JOB_A, sellerScoreId: SCORE_A, batchId: BATCH },
+      { jobId: JOB_B, sellerScoreId: SCORE_B, batchId: BATCH },
+    ]);
+    expect(sameWave.getData().inputs).toHaveLength(7);
+    expect(moveCalls(sameWave).map((c) => c.MoveCall.function)).toEqual([
+      'batch_refund',
+      'batch_refund',
+    ]);
+  });
+
+  it('empty / duplicate / ceiling refuse with the refund label', () => {
+    expect(() => buildRefundJobsTx([])).toThrow(/Refund all lapsed: pick at least one job/);
+    expect(() =>
+      buildRefundJobsTx([
+        { jobId: JOB_A, sellerScoreId: SCORE_A },
+        { jobId: JOB_A, sellerScoreId: SCORE_A },
+      ]),
+    ).toThrow(/listed twice/);
+    const over = Array.from({ length: MAX_RELEASES_PER_TX + 1 }, (_, i) => ({
+      jobId: `0x${String(i).padStart(64, '7')}`,
+      sellerScoreId: SCORE_A,
+    }));
+    expect(() => buildRefundJobsTx(over)).toThrow(/ceiling/);
   });
 });

--- a/packages/sdk/src/wallet/job.ts
+++ b/packages/sdk/src/wallet/job.ts
@@ -393,6 +393,19 @@ export function buildRefundJobTx(
   v2: { sellerScoreId: string; batchId?: string },
 ): Transaction {
   const tx = new Transaction();
+  addRefundJobToTx(tx, jobId, v2);
+  return tx;
+}
+
+/** S.1310 — append exactly ONE refund door to an existing Transaction:
+ *  `batch::batch_refund` for a wave-origin Job (`batchId`), else
+ *  `reputation::refund_v2`. The composable half `buildRefundJobTx` and
+ *  `buildRefundJobsTx` share (mirror of `addReleaseJobToTx`). */
+export function addRefundJobToTx(
+  tx: Transaction,
+  jobId: string,
+  v2: { sellerScoreId: string; batchId?: string },
+): Transaction {
   if (v2.batchId) {
     tx.moveCall({
       target: `${A2A_ESCROW_LATEST_PACKAGE_ID}::batch::batch_refund`,
@@ -418,6 +431,17 @@ export function buildRefundJobTx(
     ],
   });
   return tx;
+}
+
+/** S.1310 — "Refund all lapsed": N FUNDED-past-deadline Jobs, ONE PTB,
+ *  all-or-nothing — the exact mirror of `buildReleaseJobsTx` (same
+ *  ceiling, same empty / duplicate refusals, same input order, same
+ *  shared-object dedupe). No state validation here: the chain (and the
+ *  host's refund preflight) is the gate. */
+export function buildRefundJobsTx(
+  jobs: Array<{ jobId: string; sellerScoreId: string; batchId?: string }>,
+): Transaction {
+  return buildManyJobVerbTx(jobs, addRefundJobToTx, 'Refund all lapsed');
 }
 
 /** Seller posts the delivery commitment (hex hash) before the deadline.
@@ -543,13 +567,29 @@ export const MAX_RELEASES_PER_TX = 25;
 export function buildReleaseJobsTx(
   jobs: Array<{ jobId: string; sellerScoreId: string; batchId?: string }>,
 ): Transaction {
+  return buildManyJobVerbTx(jobs, addReleaseJobToTx, 'Settle selected');
+}
+
+/** The ONE N-in-one-PTB composer behind settle-selected / refund-all:
+ *  empty → refuse; more than the ceiling → refuse; a duplicate jobId →
+ *  refuse up front (never build a PTB that aborts on its second door);
+ *  else one Transaction, doors appended in INPUT ORDER via `add`. */
+function buildManyJobVerbTx(
+  jobs: Array<{ jobId: string; sellerScoreId: string; batchId?: string }>,
+  add: (
+    tx: Transaction,
+    jobId: string,
+    v2: { sellerScoreId: string; batchId?: string },
+  ) => Transaction,
+  label: string,
+): Transaction {
   if (jobs.length === 0) {
-    throw new T2000Error('INVALID_INPUT', 'Settle selected: pick at least one job to release.');
+    throw new T2000Error('INVALID_INPUT', `${label}: pick at least one job.`);
   }
   if (jobs.length > MAX_RELEASES_PER_TX) {
     throw new T2000Error(
       'INVALID_INPUT',
-      `Settle selected: ${jobs.length} jobs exceeds the ${MAX_RELEASES_PER_TX}-per-transaction ceiling — release them in smaller sets.`,
+      `${label}: ${jobs.length} jobs exceeds the ${MAX_RELEASES_PER_TX}-per-transaction ceiling — run it in smaller sets.`,
     );
   }
   const seen = new Set<string>();
@@ -558,14 +598,14 @@ export function buildReleaseJobsTx(
     if (seen.has(key)) {
       throw new T2000Error(
         'INVALID_INPUT',
-        `Settle selected: job ${j.jobId} is listed twice — a Job releases once.`,
+        `${label}: job ${j.jobId} is listed twice — a Job settles once.`,
       );
     }
     seen.add(key);
   }
   const tx = new Transaction();
   for (const j of jobs) {
-    addReleaseJobToTx(tx, j.jobId, { sellerScoreId: j.sellerScoreId, batchId: j.batchId });
+    add(tx, j.jobId, { sellerScoreId: j.sellerScoreId, batchId: j.batchId });
   }
   return tx;
 }


### PR DESCRIPTION
## Why
S.1310 — bulk settle / refund for the buyer who dogfoods many jobs: N jobs, ONE PTB, all-or-nothing, cap 10, on the exact doors the singles use. This is the t2000 half (SDK compose + CLI + docs); the audric half (prepare `refund-many`, Manage A, Connect, Audric chat, llms.txt) follows on the published patch.

## SDK (`packages/sdk/src/wallet/job.ts`)
- **`addRefundJobToTx` / `buildRefundJobsTx`** mirror the S.1302 release pair: `batch::batch_refund` for a wave-origin Job, else `reputation::refund_v2`. `buildRefundJobTx` = `new Transaction()` + `addRefundJobToTx` (unchanged externally, byte-equal test).
- One shared composer `buildManyJobVerbTx` now backs **both** `buildReleaseJobsTx` and `buildRefundJobsTx`: empty / duplicate jobId / > `MAX_RELEASES_PER_TX` (25) refuse with the verb's label; input order; `tx.object` dedupes shared score / wave / fee / clock inputs. Exported from `index.ts` + `browser.ts`.
- Tests (53 pass, 4 new): refund single unchanged · mix `batch_refund` + `refund_v2` in input order · same seller shares one score input (5 inputs) / same wave shares one batch input (7) · empty / dup / ceiling.

## CLI (`packages/cli/src/commands/job.ts`)
```
t2 job release <jobId>                 # unchanged
t2 job release --ids 0xA,0xB           # release-many (one PTB, all settle or none, ≤ 10)
t2 job release --all-delivered         # GET /v1/jobs?buyer= → delivered rows → first 10 → release-many; "N more — run again"
t2 job refund  <jobId>                 # unchanged (pulled out of the reject/decline loop)
t2 job refund  --ids 0xA,0xB           # refund-many
t2 job refund  --all-lapsed            # funded past deadline → first 10 → refund-many
```
Exactly ONE mode per call (positional / `--ids` / `--all-*`) — a mix refuses; `--pay-without-delivery` stays single-job. Same `sponsoredJobVerb` rail (`release-many` / `refund-many` prepare actions). Pure helpers `parseIdList` · `bulkModeError` · `pickBulkJobIds` · `eligibleBulkIds` unit-pinned (48 pass). `--help` shows the new flags.

## Docs
`apps/docs/cli-reference.mdx`: two rows for the bulk flags (factual delta only).

## Verify
```
pnpm --filter @t2000/sdk test -- job.test   # 53 pass · tsc clean
pnpm --filter @t2000/cli test -- job.test   # 48 pass · tsc clean · eslint 0 errors · build ✓
```
No Move change. Next: merge → `gh workflow run release.yml --field bump=patch` (11.4.2) → audric bump + the consumer surfaces.